### PR TITLE
[BUG #3] Fix workflow reorder persistence by assigning sortOrder values

### DIFF
--- a/src/components/workflow/WorkflowList.tsx
+++ b/src/components/workflow/WorkflowList.tsx
@@ -505,9 +505,16 @@ const WorkflowList: React.FC = () => {
   };
 
   const handleReorder = async (newOrder: Workflow[]) => {
-    setWorkflows(newOrder);
+    // Assign sortOrder values based on the new array position
+    const workflowsWithUpdatedOrder = newOrder.map((workflow, index) => ({
+      ...workflow,
+      sortOrder: index
+    }));
+
+    setWorkflows(workflowsWithUpdatedOrder);
     try {
-      await saveAllWorkflows(newOrder);
+      await saveAllWorkflows(workflowsWithUpdatedOrder);
+      console.log('✅ Workflow order saved successfully');
     } catch (error) {
       console.error('Failed to save reordered workflows:', error);
       toast.error('Failed to save workflow order');


### PR DESCRIPTION
- Assign sortOrder based on array index in handleReorder function
- Ensure reordered workflows maintain their position after page refresh
- Add success logging for workflow order save operations