### PR TITLE
feat: implement execution previews in workflow nodes and optimize gallery loading

### DIFF
--- a/src/components/canvas/NodeDetailModal.tsx
+++ b/src/components/canvas/NodeDetailModal.tsx
@@ -297,28 +297,6 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
     // Group handling
     const isGroupNode = selectedNode.type === 'GROUP_NODE' && 'groupInfo' in selectedNode && selectedNode.groupInfo;
 
-    // NOTE: GroupInspector handling
-    if (isGroupNode) {
-        return (
-            <>
-                {/* Hidden container to satisfy useScroll hook requirements when in group mode */}
-                <div ref={scrollContainerRef} style={{ display: 'none' }} />
-                <GroupInspector
-                    selectedNode={selectedNode}
-                    isVisible={true}
-                    onClose={onClose}
-                    onNavigateToNode={onNavigateToNode}
-                    onSelectNode={onSelectNode}
-                    onNodeModeChange={onNodeModeChange}
-                    getNodeMode={getNodeMode}
-                    onGroupDelete={onGroupDelete}
-                    onGroupSizeChange={onGroupSizeChange}
-                    onNodeModeChangeBatch={onNodeModeChangeBatch}
-                />
-            </>
-        );
-    }
-
     // --- Logic from NodeParameterEditor ---
 
     // Helper function for file selection (OutputsGallery)
@@ -876,6 +854,27 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
             </div>
         );
     };
+
+    if (isGroupNode) {
+        return (
+            <>
+                {/* Hidden container to satisfy useScroll hook requirements when in group mode */}
+                <div ref={scrollContainerRef} style={{ display: 'none' }} />
+                <GroupInspector
+                    selectedNode={selectedNode}
+                    isVisible={true}
+                    onClose={onClose}
+                    onNavigateToNode={onNavigateToNode}
+                    onSelectNode={onSelectNode}
+                    onNodeModeChange={onNodeModeChange}
+                    getNodeMode={getNodeMode}
+                    onGroupDelete={onGroupDelete}
+                    onGroupSizeChange={onGroupSizeChange}
+                    onNodeModeChangeBatch={onNodeModeChangeBatch}
+                />
+            </>
+        );
+    }
 
     return createPortal(
         <AnimatePresence>

--- a/src/components/canvas/NodeDetailModal.tsx
+++ b/src/components/canvas/NodeDetailModal.tsx
@@ -411,29 +411,84 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
         return null;
     };
 
+    type ImagePreviewData = string | { filename?: string; subfolder?: string; type?: string };
+
     // We need to re-implement these helpers properly to match the file we read
-    const extractImagePreviewFromNode = () => { // Renamed to avoid collision
+    const extractImagePreviewFromNode = (): { value: ImagePreviewData | null; isFromExecution: boolean } => { // Renamed to avoid collision
         if (executionNodePreviewFiles.length > 0) {
-            return executionNodePreviewFiles[executionNodePreviewFiles.length - 1];
+            return {
+                value: executionNodePreviewFiles[executionNodePreviewFiles.length - 1],
+                isFromExecution: true
+            };
         }
 
         const imagePreviewValue = getWidgetValue(nodeId, 'imagepreview', undefined);
-        if (imagePreviewValue?.params) return imagePreviewValue.params;
+        if (imagePreviewValue?.params) {
+            return {
+                value: imagePreviewValue.params,
+                isFromExecution: false
+            };
+        }
 
         const imageWidget = widgets.find((w: any) => w.name === 'imagepreview' || w.type === 'imagepreview');
-        if (imageWidget?.value?.params) return imageWidget.value.params;
+        if (imageWidget?.value?.params) {
+            return {
+                value: imageWidget.value.params,
+                isFromExecution: false
+            };
+        }
         const previewWidget = widgets.find((w: any) => w.name === 'previewImage');
-        if (previewWidget?.value) return previewWidget.value;
+        if (previewWidget?.value) {
+            return {
+                value: previewWidget.value,
+                isFromExecution: false
+            };
+        }
 
-        if (!selectedNode?.widgets_values || typeof selectedNode.widgets_values !== 'object') return null;
+        if (!selectedNode?.widgets_values || typeof selectedNode.widgets_values !== 'object') {
+            return {
+                value: null,
+                isFromExecution: false
+            };
+        }
 
         if (!Array.isArray(selectedNode.widgets_values)) {
             const widgetsValues = selectedNode.widgets_values as Record<string, any>;
-            if (widgetsValues.imagepreview && widgetsValues.imagepreview.params) return widgetsValues.imagepreview.params;
-            if (widgetsValues.previewImage) return widgetsValues.previewImage;
+            if (widgetsValues.imagepreview && widgetsValues.imagepreview.params) {
+                return {
+                    value: widgetsValues.imagepreview.params,
+                    isFromExecution: false
+                };
+            }
+            if (widgetsValues.previewImage) {
+                return {
+                    value: widgetsValues.previewImage,
+                    isFromExecution: false
+                };
+            }
         }
 
-        return null;
+        return {
+            value: null,
+            isFromExecution: false
+        };
+    };
+
+    const getPreviewPath = (preview: ImagePreviewData): string | null => {
+        if (typeof preview === 'string') {
+            const trimmedPath = preview.trim();
+            return trimmedPath.length > 0 ? trimmedPath : null;
+        }
+
+        const filename = typeof preview.filename === 'string' ? preview.filename.trim() : '';
+        const subfolder = typeof preview.subfolder === 'string' ? preview.subfolder.trim() : '';
+
+        // Ignore malformed objects that do not point to a concrete file.
+        if (!filename) {
+            return null;
+        }
+
+        return subfolder ? `${subfolder}/${filename}` : filename;
     };
 
 
@@ -468,7 +523,9 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
             }
         }
     }, [selectedNode, widgets, onAutoRefreshNode]);
-    const imagePreview = useMemo(() => extractImagePreviewFromNode(), [selectedNode, widgets, nodeId, executionNodePreviewFiles]); // Depend on widgets
+    const imagePreviewData = useMemo(() => extractImagePreviewFromNode(), [selectedNode, widgets, nodeId, executionNodePreviewFiles]); // Depend on widgets
+    const imagePreview = imagePreviewData.value;
+    const isImagePreviewFromExecution = imagePreviewData.isFromExecution;
     // Video preview was mostly stubbed in original code, skipping for brevity unless needed.
     const videoPreview = useMemo(() => extractVideoPreview(), [selectedNode, widgets, nodeId]);
 
@@ -1165,17 +1222,13 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                         <InlineImagePreview
                                             imagePreview={imagePreview}
                                             onClick={() => {
-                                                const previewPath = typeof imagePreview === 'string'
-                                                    ? imagePreview
-                                                    : (imagePreview.subfolder
-                                                        ? `${imagePreview.subfolder}/${imagePreview.filename || ''}`
-                                                        : (imagePreview.filename || ''));
-                                                if (typeof previewPath !== 'string' || previewPath.trim().length === 0) {
+                                                const previewPath = getPreviewPath(imagePreview);
+                                                if (!previewPath) {
                                                     return;
                                                 }
                                                 onFilePreview(previewPath.trim());
                                             }}
-                                            isFromExecution={true}
+                                            isFromExecution={isImagePreviewFromExecution}
                                             themeOverride={hasCustomColor ? {
                                                 container: 'bg-transparent shadow-none',
                                                 text: 'text-white/80',

--- a/src/components/canvas/NodeDetailModal.tsx
+++ b/src/components/canvas/NodeDetailModal.tsx
@@ -25,6 +25,10 @@ import { VideoPreviewSection } from '@/components/media/VideoPreviewSection';
 import { InlineImagePreview } from '@/components/media/InlineImagePreview';
 import { PointEditor } from '@/components/controls/widgets/custom_node_widget/PointEditor';
 import { detectParameterTypeForGallery } from '@/shared/utils/GalleryPermissionUtils';
+import { useNodeExecutionPreviewStore, NodeExecutionPreviewFile } from '@/ui/store/nodeExecutionPreviewStore';
+import { useNodeSamplerPreviewStore } from '@/ui/store/nodeSamplerPreviewStore';
+
+const EMPTY_EXECUTION_PREVIEWS: readonly NodeExecutionPreviewFile[] = [];
 
 interface NodeBounds {
     x: number;
@@ -154,6 +158,12 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
 }) => {
     const { t } = useTranslation();
     const nodeId = typeof selectedNode.id === 'string' ? parseInt(selectedNode.id) : selectedNode.id;
+    const executionNodePreviewFiles =
+        useNodeExecutionPreviewStore(state => state.previewsByNode.get(nodeId)) || EMPTY_EXECUTION_PREVIEWS;
+    const samplerPreviewFrame = useNodeSamplerPreviewStore(state => {
+        const frames = state.previewsByNode.get(String(nodeId));
+        return frames && frames.length > 0 ? frames[0] : null;
+    });
     const metadata = nodeMetadata.get(nodeId);
 
     const hasCustomColor = true; // Always true now as we default to dark grey
@@ -425,6 +435,10 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
 
     // We need to re-implement these helpers properly to match the file we read
     const extractImagePreviewFromNode = () => { // Renamed to avoid collision
+        if (executionNodePreviewFiles.length > 0) {
+            return executionNodePreviewFiles[executionNodePreviewFiles.length - 1];
+        }
+
         const imagePreviewValue = getWidgetValue(nodeId, 'imagepreview', undefined);
         if (imagePreviewValue?.params) return imagePreviewValue.params;
 
@@ -476,7 +490,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
             }
         }
     }, [selectedNode, widgets, onAutoRefreshNode]);
-    const imagePreview = useMemo(() => extractImagePreviewFromNode(), [selectedNode, widgets, nodeId]); // Depend on widgets
+    const imagePreview = useMemo(() => extractImagePreviewFromNode(), [selectedNode, widgets, nodeId, executionNodePreviewFiles]); // Depend on widgets
     // Video preview was mostly stubbed in original code, skipping for brevity unless needed.
     const videoPreview = useMemo(() => extractVideoPreview(), [selectedNode, widgets, nodeId]);
 
@@ -1120,7 +1134,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                         {/* Single Scrollable Content Area */}
                         <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
                             {/* Static Top Bumper - Prevents initial jitter */}
-                            <div className="h-[110px] relative pointer-events-none">
+                            <div className="h-[150px] relative pointer-events-none">
                                 {/* Sentinel for IntersectionObserver at exactly 80px scroll depth */}
                                 <div ref={sentinelRef} className="absolute top-[10px] left-0 h-px w-full" />
                             </div>
@@ -1130,12 +1144,35 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                    actually since it's NOT absolute but flex-col, it pushes down naturally. 
                                    We just removed the old identity header from here. */}
 
+                                {/* Live sampler preview from websocket latent frames (node-associated when possible). */}
+                                {samplerPreviewFrame && (
+                                    <div className={`mt-4 mb-6 rounded-2xl overflow-hidden border ${hasCustomColor ? 'bg-black/20 border-white/10' : 'bg-slate-50 dark:bg-slate-900 border-slate-200 dark:border-slate-800'}`}>
+                                        <div className={`px-3 py-2 border-b text-[11px] uppercase tracking-wider font-semibold ${hasCustomColor ? 'border-white/10 text-white/70' : 'border-slate-200 dark:border-slate-800 text-slate-500 dark:text-slate-400'}`}>
+                                            <span>{t('latentPreview.title')}</span>
+                                        </div>
+                                        <div className="p-2">
+                                            <img
+                                                src={samplerPreviewFrame.imageUrl}
+                                                alt={t('latentPreview.title')}
+                                                className="w-full max-h-56 object-contain rounded-xl"
+                                            />
+                                        </div>
+                                    </div>
+                                )}
+
                                 {/* Image Preview */}
                                 {imagePreview && (
-                                    <div className={`mb-8 rounded-2xl overflow-hidden shadow-sm border ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-white border-slate-200 dark:border-slate-800'}`}>
+                                    <div className={`mt-4 mb-8 rounded-2xl overflow-hidden shadow-sm border ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-white border-slate-200 dark:border-slate-800'}`}>
                                         <InlineImagePreview
                                             imagePreview={imagePreview}
-                                            onClick={() => onFilePreview(imagePreview.filename || imagePreview)}
+                                            onClick={() => {
+                                                const previewPath = typeof imagePreview === 'string'
+                                                    ? imagePreview
+                                                    : (imagePreview.subfolder
+                                                        ? `${imagePreview.subfolder}/${imagePreview.filename || ''}`
+                                                        : (imagePreview.filename || ''));
+                                                onFilePreview(previewPath);
+                                            }}
                                             isFromExecution={true}
                                             themeOverride={hasCustomColor ? {
                                                 container: 'bg-transparent shadow-none',

--- a/src/components/canvas/NodeDetailModal.tsx
+++ b/src/components/canvas/NodeDetailModal.tsx
@@ -1171,7 +1171,10 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                     : (imagePreview.subfolder
                                                         ? `${imagePreview.subfolder}/${imagePreview.filename || ''}`
                                                         : (imagePreview.filename || ''));
-                                                onFilePreview(previewPath);
+                                                if (typeof previewPath !== 'string' || previewPath.trim().length === 0) {
+                                                    return;
+                                                }
+                                                onFilePreview(previewPath.trim());
                                             }}
                                             isFromExecution={true}
                                             themeOverride={hasCustomColor ? {

--- a/src/components/media/OutputsGallery.tsx
+++ b/src/components/media/OutputsGallery.tsx
@@ -117,6 +117,12 @@ const LazyImage: React.FC<LazyImageProps> = ({
     return () => observer.disconnect();
   }, [index]);
 
+  useEffect(() => {
+    if (index < 12) {
+      setIsInView(true);
+    }
+  }, [index]);
+
 
   // Find matching image thumbnail for video files using the optimized map
   const findMatchingImageForVideo = (videoFilename: string): IComfyFileInfo | null => {
@@ -1203,7 +1209,10 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
               <div ref={loadMoreTriggerRef} className="flex flex-col items-center justify-center py-8">
                 <Loader2 className="h-6 w-6 text-white/30 animate-spin" />
                 <p className="mt-2 text-xs text-white/40 tracking-wide">
-                  Showing {visibleFiles.length} / {filesForCurrentView.length}
+                  {t('gallery.showingVisible', {
+                    visible: visibleFiles.length,
+                    total: filesForCurrentView.length
+                  })}
                 </p>
               </div>
             )}

--- a/src/components/media/OutputsGallery.tsx
+++ b/src/components/media/OutputsGallery.tsx
@@ -16,6 +16,8 @@ import { isImageFile, isVideoFile } from '@/shared/utils/ComfyFileUtils';
 
 type TabType = 'images' | 'videos';
 type FolderType = 'input' | 'output' | 'temp' | 'all';
+const INITIAL_VISIBLE_FILE_COUNT = 120;
+const VISIBLE_FILE_BATCH_SIZE = 90;
 
 // Utility function to find matching image file for a video
 const findMatchingImageFile = (
@@ -340,6 +342,8 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
   // Move panel state
   const [showMovePanel, setShowMovePanel] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [visibleFileCount, setVisibleFileCount] = useState(INITIAL_VISIBLE_FILE_COUNT);
+  const loadMoreTriggerRef = useRef<HTMLDivElement | null>(null);
 
   const navigate = useNavigate();
   const { url: serverUrl, isConnected, hasExtension, isCheckingExtension, checkExtension } = useConnectionStore();
@@ -563,8 +567,9 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
     const newSelected = new Set(selectedFiles);
 
     if (viewMode === 'folders') {
-      // In folder mode, select only files (not folders) in the CURRENT path
-      const currentPathFilesKeys = folderContent.files.map(f => `${f.filename}-${f.subfolder}-${f.type}`);
+      // In folder mode, select currently rendered files by default.
+      const selectableFiles = visibleOnly ? visibleFiles : folderContent.files;
+      const currentPathFilesKeys = selectableFiles.map(f => `${f.filename}-${f.subfolder}-${f.type}`);
       const allCurrentFilesSelected = currentPathFilesKeys.every(key => selectedFiles.has(key));
 
       if (allCurrentFilesSelected) {
@@ -575,7 +580,7 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
     } else {
       // Flat mode behavior
       if (visibleOnly) {
-        const visibleKeys = currentFiles.map(f => `${f.filename}-${f.subfolder}-${f.type}`);
+        const visibleKeys = visibleFiles.map(f => `${f.filename}-${f.subfolder}-${f.type}`);
         const allVisibleSelected = visibleKeys.every(key => selectedFiles.has(key));
 
         if (allVisibleSelected) {
@@ -787,11 +792,6 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
     return videoLookupMap.has(key);
   }, [videoLookupMap]);
 
-  // Calculate filtered image count (excluding thumbnails)
-  const filteredImageCount = useMemo(() => {
-    return files.images.filter(img => !hasCorrespondingVideo(img)).length;
-  }, [files.images, hasCorrespondingVideo]);
-
   // Apply thumbnail filtering only for images tab
   const currentFiles = useMemo(() => {
     if (activeTab === 'images') {
@@ -805,6 +805,13 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
 
   // Extract current level's folders and files
   const folderContent = useMemo(() => {
+    if (viewMode !== 'folders') {
+      return {
+        folders: [] as Array<{ name: string; count: number; lastFile: IComfyFileInfo; thumbnailFile: IComfyFileInfo; fullPath: string }>,
+        files: [] as IComfyFileInfo[]
+      };
+    }
+
     const currentPath = selectedSubfolder || '/';
     const subfolders = new Map<string, { count: number, lastFile: IComfyFileInfo, thumbnailFile: IComfyFileInfo, fullPath: string }>();
     const filesInCurrentFolder: IComfyFileInfo[] = [];
@@ -873,7 +880,42 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
       folders: sortedFolders,
       files: filesInCurrentFolder
     };
-  }, [currentFiles, selectedSubfolder, imageLookupMap]);
+  }, [currentFiles, selectedSubfolder, imageLookupMap, viewMode]);
+
+  const filesForCurrentView = useMemo(() => {
+    return viewMode === 'folders' ? folderContent.files : currentFiles;
+  }, [viewMode, folderContent.files, currentFiles]);
+
+  const visibleFiles = useMemo(() => {
+    return filesForCurrentView.slice(0, visibleFileCount);
+  }, [filesForCurrentView, visibleFileCount]);
+
+  const hasMoreVisibleFiles = visibleFiles.length < filesForCurrentView.length;
+
+  useEffect(() => {
+    setVisibleFileCount(INITIAL_VISIBLE_FILE_COUNT);
+  }, [activeTab, activeFolder, viewMode, selectedSubfolder, files.images.length, files.videos.length]);
+
+  useEffect(() => {
+    if (!hasMoreVisibleFiles || !loadMoreTriggerRef.current) return;
+
+    const target = loadMoreTriggerRef.current;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some(entry => entry.isIntersecting)) {
+          observer.unobserve(target);
+          setVisibleFileCount(prev => Math.min(prev + VISIBLE_FILE_BATCH_SIZE, filesForCurrentView.length));
+        }
+      },
+      {
+        threshold: 0.01,
+        rootMargin: '500px 0px'
+      }
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hasMoreVisibleFiles, filesForCurrentView.length, visibleFileCount]);
 
   // Files available for navigation in preview modal
   const navigableFiles = useMemo(() => {
@@ -1072,6 +1114,8 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                                 modified: folder.thumbnailFile.modified
                               })}
                               alt={folder.name}
+                              loading="lazy"
+                              decoding="async"
                               className="w-full h-full object-cover opacity-60 group-hover:opacity-100 transition-opacity"
                               onError={(e) => {
                                 // Fallback to lastFile if thumbnailFile fails
@@ -1108,9 +1152,9 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                   {/* Files Section Second */}
                   {folderContent.files.length > 0 ? (
                     <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-px">
-                      {folderContent.files.map((file, index) => (
+                      {visibleFiles.map((file, index) => (
                         <LazyImage
-                          key={`${file.filename}-${file.subfolder}-${file.type}-${index}`}
+                          key={`${file.filename}-${file.subfolder}-${file.type}`}
                           file={file}
                           index={index}
                           onImageClick={handleFileClick}
@@ -1138,9 +1182,9 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                   exit={{ opacity: 0 }}
                   className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-px"
                 >
-                  {currentFiles.map((file, index) => (
+                  {visibleFiles.map((file, index) => (
                     <LazyImage
-                      key={`${file.filename}-${file.subfolder}-${file.type}-${index}`}
+                      key={`${file.filename}-${file.subfolder}-${file.type}`}
                       file={file}
                       index={index}
                       onImageClick={handleFileClick}
@@ -1155,6 +1199,14 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                 </motion.div>
               )}
             </AnimatePresence>
+            {hasMoreVisibleFiles && (
+              <div ref={loadMoreTriggerRef} className="flex flex-col items-center justify-center py-8">
+                <Loader2 className="h-6 w-6 text-white/30 animate-spin" />
+                <p className="mt-2 text-xs text-white/40 tracking-wide">
+                  Showing {visibleFiles.length} / {filesForCurrentView.length}
+                </p>
+              </div>
+            )}
           </div>
         )}
       </main>

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -74,6 +74,8 @@ import { DEFAULT_CANVAS_CONFIG } from '@/config/canvasConfig';
 import { useConnectionStore } from '@/ui/store/connectionStore';
 import { useGlobalStore } from '@/ui/store/globalStore';
 import { useLatentPreviewStore } from '@/ui/store/latentPreviewStore';
+import { useNodeExecutionPreviewStore } from '@/ui/store/nodeExecutionPreviewStore';
+import { useNodeSamplerPreviewStore } from '@/ui/store/nodeSamplerPreviewStore';
 
 // Types
 import type { IComfyGraphNode, IComfyWorkflow, IComfyWidget } from '@/shared/types/app/base';
@@ -205,6 +207,9 @@ const WorkflowEditor: React.FC = () => {
   const { url: serverUrl, isConnected } = useConnectionStore();
 
   const { isLatentPreviewFullscreen } = useLatentPreviewStore();
+  const executionNodePreviews = useNodeExecutionPreviewStore(state => state.previewsByNode);
+  const clearNodeExecutionPreviews = useNodeExecutionPreviewStore(state => state.clearPreviews);
+  const registerSamplerWorkflowNodes = useNodeSamplerPreviewStore(state => state.registerWorkflowNodes);
 
   // Get groups with mapped nodes
   const workflowGroups = useMemo((): Group[] => {
@@ -796,6 +801,7 @@ const WorkflowEditor: React.FC = () => {
     groupBounds,
     selectedNode,
     modifiedWidgetValues: widgetEditor.modifiedWidgetValues,
+    executionNodePreviews,
     repositionMode: {
       isActive: canvasInteraction.repositionMode.isActive,
       selectedNodeId: canvasInteraction.repositionMode.selectedNodeId,
@@ -822,7 +828,8 @@ const WorkflowEditor: React.FC = () => {
     if (id) {
       setQueueRefreshTrigger(prev => prev + 1);
     }
-  }, [id]);
+    clearNodeExecutionPreviews();
+  }, [id, clearNodeExecutionPreviews]);
 
   // Load workflow on mount
   useEffect(() => {
@@ -878,6 +885,14 @@ const WorkflowEditor: React.FC = () => {
 
       // Use nodes directly from ComfyGraphProcessor - no conversion
       const nodes = graph._nodes || [];
+
+      registerSamplerWorkflowNodes(
+        nodes.map((node: IComfyGraphNode) => ({
+          id: node.id,
+          type: node.type,
+          title: node.title
+        }))
+      );
 
       // Check for missing models in node widgets (COMBO widgets)
       const detectedMissingModels = detectMissingModels(nodes);

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -214,6 +214,9 @@ const WorkflowEditor: React.FC = () => {
   const executionNodePreviews = useNodeExecutionPreviewStore(state => state.previewsByNode);
   const clearNodeExecutionPreviews = useNodeExecutionPreviewStore(state => state.clearPreviews);
   const registerSamplerWorkflowNodes = useNodeSamplerPreviewStore(state => state.registerWorkflowNodes);
+  const samplerWorkflowNodesKey = (currentGraph?._nodes || [])
+    .map((node: IComfyGraphNode) => `${node.id}:${node.type || ''}:${node.title || ''}`)
+    .join(',');
 
   // Get groups with mapped nodes
   const workflowGroups = useMemo((): Group[] => {
@@ -858,19 +861,20 @@ const WorkflowEditor: React.FC = () => {
   }, [isConnected]);
 
   useEffect(() => {
-    if (!currentGraph?._nodes) {
+    const nodes = currentGraph?._nodes || [];
+    if (nodes.length === 0) {
       registerSamplerWorkflowNodes([]);
       return;
     }
 
     registerSamplerWorkflowNodes(
-      currentGraph._nodes.map((node: IComfyGraphNode) => ({
+      nodes.map((node: IComfyGraphNode) => ({
         id: node.id,
         type: node.type,
         title: node.title
       }))
     );
-  }, [currentGraph?._nodes, registerSamplerWorkflowNodes]);
+  }, [samplerWorkflowNodesKey, registerSamplerWorkflowNodes]);
 
   // #endregion useEffects
 

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -75,7 +75,11 @@ import { useConnectionStore } from '@/ui/store/connectionStore';
 import { useGlobalStore } from '@/ui/store/globalStore';
 import { useLatentPreviewStore } from '@/ui/store/latentPreviewStore';
 import { useNodeExecutionPreviewStore } from '@/ui/store/nodeExecutionPreviewStore';
-import { useNodeSamplerPreviewStore } from '@/ui/store/nodeSamplerPreviewStore';
+import {
+  useNodeSamplerPreviewStore,
+  initNodeSamplerPreviewListeners,
+  disposeNodeSamplerPreviewListeners
+} from '@/ui/store/nodeSamplerPreviewStore';
 
 // Types
 import type { IComfyGraphNode, IComfyWorkflow, IComfyWidget } from '@/shared/types/app/base';
@@ -843,6 +847,30 @@ const WorkflowEditor: React.FC = () => {
       loadNodeMetadata(workflow.graph._nodes);
     }
   }, [isConnected, workflow?.graph?._nodes, nodeMetadata.size, metadataLoading]);
+
+  useEffect(() => {
+    if (!isConnected) return;
+
+    initNodeSamplerPreviewListeners();
+    return () => {
+      disposeNodeSamplerPreviewListeners();
+    };
+  }, [isConnected]);
+
+  useEffect(() => {
+    if (!currentGraph?._nodes) {
+      registerSamplerWorkflowNodes([]);
+      return;
+    }
+
+    registerSamplerWorkflowNodes(
+      currentGraph._nodes.map((node: IComfyGraphNode) => ({
+        id: node.id,
+        type: node.type,
+        title: node.title
+      }))
+    );
+  }, [currentGraph?._nodes, registerSamplerWorkflowNodes]);
 
   // #endregion useEffects
 

--- a/src/components/workflow/WorkflowStackEditor.tsx
+++ b/src/components/workflow/WorkflowStackEditor.tsx
@@ -27,6 +27,10 @@ import { convertGraphToAPI } from '@/infrastructure/api/ComfyApiFunctions';
 import { autoChangeSeed } from '@/shared/utils/seedProcessing';
 import { useConnectionStore } from '@/ui/store/connectionStore';
 import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
+import { InlineImagePreview } from '@/components/media/InlineImagePreview';
+import { useNodeExecutionPreviewStore, NodeExecutionPreviewFile } from '@/ui/store/nodeExecutionPreviewStore';
+
+const EMPTY_EXECUTION_PREVIEWS: readonly NodeExecutionPreviewFile[] = [];
 
 // Custom morphing icon component (copied from WorkflowHeader)
 const SaveToCheckIcon: React.FC<{
@@ -114,6 +118,8 @@ interface StackNodeProps {
 
 const StackNode: React.FC<StackNodeProps> = ({ node, widgetEditor, onModeChange, globalExpandAction, executingNodeId }) => {
     const { t } = useTranslation();
+    const executionNodePreviewFiles =
+        useNodeExecutionPreviewStore(state => state.previewsByNode.get(node.id)) || EMPTY_EXECUTION_PREVIEWS;
 
     const widgets = useMemo(() => {
         if (node.getWidgets) {
@@ -180,6 +186,15 @@ const StackNode: React.FC<StackNodeProps> = ({ node, widgetEditor, onModeChange,
     const fileOperations = useFileOperations({
         onSetWidgetValue: (nodeId, paramName, value) => setWidgetValue(nodeId, paramName, value)
     });
+
+    const latestExecutionPreview = executionNodePreviewFiles.length > 0
+        ? executionNodePreviewFiles[executionNodePreviewFiles.length - 1]
+        : null;
+    const latestExecutionPreviewPath = latestExecutionPreview
+        ? (latestExecutionPreview.subfolder
+            ? `${latestExecutionPreview.subfolder}/${latestExecutionPreview.filename}`
+            : latestExecutionPreview.filename)
+        : '';
 
     const [fileSelectionState, setFileSelectionState] = useState<{
         isOpen: boolean;
@@ -326,6 +341,25 @@ const StackNode: React.FC<StackNodeProps> = ({ node, widgetEditor, onModeChange,
                     </div>
                 </div>
 
+                {latestExecutionPreview && (
+                    <div className="rounded-xl overflow-hidden border border-white/10 bg-black/20">
+                        <InlineImagePreview
+                            imagePreview={latestExecutionPreview}
+                            isFromExecution={true}
+                            onClick={() => {
+                                if (latestExecutionPreviewPath) {
+                                    fileOperations.handleFilePreview(latestExecutionPreviewPath);
+                                }
+                            }}
+                            themeOverride={{
+                                container: 'bg-transparent',
+                                text: 'text-white/80',
+                                secondaryText: 'text-white/60'
+                            }}
+                        />
+                    </div>
+                )}
+
                 {/* Collapsible Content */}
                 <AnimatePresence initial={false}>
                     {isExpanded && (
@@ -447,13 +481,15 @@ export const WorkflowStackEditor: React.FC<WorkflowStackEditorProps> = ({ graph,
     const [executingNodeId, setExecutingNodeId] = useState<string | null>(null);
     const currentPromptIdRef = useRef<string | null>(null);
     const { isConnected } = useConnectionStore();
+    const clearNodeExecutionPreviews = useNodeExecutionPreviewStore(state => state.clearPreviews);
 
     // Trigger queue refresh when ID changes
     useEffect(() => {
         if (id) {
             setQueueRefreshTrigger(prev => prev + 1);
         }
-    }, [id]);
+        clearNodeExecutionPreviews();
+    }, [id, clearNodeExecutionPreviews]);
 
     // Subscribe to execution events to highlight the currently running node
     useEffect(() => {

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -15,9 +15,9 @@ import {
   NodeBounds,
   GroupBounds,
   ViewportTransform,
-  RenderingOptions,
-  NodeExecutionPreviewFile
+  RenderingOptions
 } from '@/shared/utils/rendering/CanvasRendererService';
+import type { NodeExecutionPreviewFile } from '@/shared/types/app/NodeExecutionPreviewFile';
 import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
 import { useGlobalStore } from '@/ui/store/globalStore';
 

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -15,7 +15,8 @@ import {
   NodeBounds,
   GroupBounds,
   ViewportTransform,
-  RenderingOptions
+  RenderingOptions,
+  NodeExecutionPreviewFile
 } from '@/shared/utils/rendering/CanvasRendererService';
 import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
 import { useGlobalStore } from '@/ui/store/globalStore';
@@ -49,6 +50,7 @@ interface UseCanvasRendererProps {
   groupBounds: GroupBounds[];
   selectedNode: IComfyGraphNode | null;
   modifiedWidgetValues?: Map<number, Record<string, any>>;
+  executionNodePreviews?: Map<number, NodeExecutionPreviewFile[]>;
   repositionMode?: {
     isActive: boolean;
     selectedNodeId: number | null;
@@ -76,6 +78,7 @@ export const useCanvasRenderer = ({
   groupBounds,
   selectedNode,
   modifiedWidgetValues,
+  executionNodePreviews,
   repositionMode,
   connectionMode,
   missingNodeIds,
@@ -333,6 +336,7 @@ export const useCanvasRenderer = ({
           viewportScale: viewport.scale, // Pass viewport scale for responsive font sizing
           modifiedNodeIds, // Add modified nodes for green outline
           modifiedWidgetValues, // Add modified widget values for accurate display
+          executionNodePreviews,
           repositionMode: repositionMode || null, // Add repositioning mode info
           connectionMode: connectionMode || null, // Add connection mode info for highlighting
           missingNodeIds: missingNodeIds || new Set(), // Add missing node IDs for red outline
@@ -365,7 +369,7 @@ export const useCanvasRenderer = ({
       window.removeEventListener('resize', resizeCanvas);
       canvas.removeEventListener('imageLoaded', handleImageLoaded);
     };
-  }, [workflow, viewport, nodeBounds, groupBounds, selectedNode, config, executionState, modifiedWidgetValues, repositionMode, missingNodeIds]);
+  }, [workflow, viewport, nodeBounds, groupBounds, selectedNode, config, executionState, modifiedWidgetValues, executionNodePreviews, repositionMode, missingNodeIds]);
 
   return {
     config,

--- a/src/infrastructure/websocket/GlobalWebSocketService.ts
+++ b/src/infrastructure/websocket/GlobalWebSocketService.ts
@@ -416,8 +416,6 @@ class GlobalWebSocketService extends EventEmitter {
             // 🔍 Smart Detection Logic for different ComfyUI versions
             if (type === 1) {
               // Type 1 (Legacy): [Type 4B] + [ImageType 4B] + [Data]
-              const imageType = view.getUint32(4, false); // 1: JPEG, 2: PNG
-              const mimeType = imageType === 2 ? 'image/png' : 'image/jpeg';
 
               // Node ID is NOT in the packet for Type 1.
               // User requested to NOT show Node ID for Type 1 instead of guessing.
@@ -461,7 +459,6 @@ class GlobalWebSocketService extends EventEmitter {
             if (!imageData || imageData.byteLength === 0) return;
 
             const blob = new Blob([imageData], { type: 'image/jpeg' });
-            const imageUrl = URL.createObjectURL(blob);
 
             // Emit in ComfyApiClient format
             this.emit('binary_image_received', {

--- a/src/infrastructure/websocket/GlobalWebSocketService.ts
+++ b/src/infrastructure/websocket/GlobalWebSocketService.ts
@@ -9,7 +9,7 @@
 // EventEmitter implementation with ID support (compatible with original ComfyApiClient)
 class EventEmitter {
   private events: Record<string, Function[]> = {};
-  private listenerIds: Map<string, string> = new Map();
+  private listenerIds: Map<string, { event: string; listener: Function }> = new Map();
   private idCounter = 0;
 
   on(event: string, listener: Function): string {
@@ -18,7 +18,7 @@ class EventEmitter {
     }
     const id = `${event}_${++this.idCounter}`;
     this.events[event].push(listener);
-    this.listenerIds.set(id, event);
+    this.listenerIds.set(id, { event, listener });
     return id;
   }
 
@@ -31,17 +31,32 @@ class EventEmitter {
   off(event: string, listener: Function) {
     if (this.events[event]) {
       this.events[event] = this.events[event].filter(l => l !== listener);
+      if (this.events[event].length === 0) {
+        delete this.events[event];
+      }
+
+      for (const [id, metadata] of this.listenerIds.entries()) {
+        if (metadata.event === event && metadata.listener === listener) {
+          this.listenerIds.delete(id);
+        }
+      }
     }
   }
 
   offById(event: string, id: string) {
-    if (this.events[event] && this.listenerIds.has(id)) {
-      const targetEvent = this.listenerIds.get(id);
-      if (targetEvent === event) {
-        // Remove the listener by finding its index
-        this.listenerIds.delete(id);
+    const metadata = this.listenerIds.get(id);
+    if (!metadata || metadata.event !== event) {
+      return;
+    }
+
+    if (this.events[event]) {
+      this.events[event] = this.events[event].filter(listener => listener !== metadata.listener);
+      if (this.events[event].length === 0) {
+        delete this.events[event];
       }
     }
+
+    this.listenerIds.delete(id);
   }
 
   removeAllListeners() {
@@ -81,6 +96,7 @@ class GlobalWebSocketService extends EventEmitter {
   private webSocket: WebSocket | null = null;
   private clientId: string;
   private reconnectTimer: NodeJS.Timeout | null = null;
+  private reconnectScheduled = false;
 
   // State management
   private state: GlobalWebSocketState = {
@@ -321,6 +337,8 @@ class GlobalWebSocketService extends EventEmitter {
       return;
     }
 
+    this.clearReconnectTimer();
+
     console.log(`🔄 [GlobalWebSocketService] Attempting connection:`, {
       url: this.serverUrl,
       clientId: this.clientId,
@@ -348,10 +366,7 @@ class GlobalWebSocketService extends EventEmitter {
       });
 
       // Clear any existing reconnect timer
-      if (this.reconnectTimer) {
-        clearTimeout(this.reconnectTimer);
-        this.reconnectTimer = null;
-      }
+      this.clearReconnectTimer();
 
       // 🎯 Rolling buffer is always active, no need to start/stop
 
@@ -509,7 +524,7 @@ class GlobalWebSocketService extends EventEmitter {
       });
 
       this.emit('error', { type: 'connection_error', error });
-      this.attemptReconnect();
+      this.scheduleReconnect();
     };
 
     this.webSocket.onclose = (event) => {
@@ -536,7 +551,7 @@ class GlobalWebSocketService extends EventEmitter {
       // Even "clean" closes (1000) might be server timeouts that we want to recover from
       if (this.state.reconnectAttempts < this.state.maxReconnectAttempts) {
         console.log(`🔄 [GlobalWebSocketService] Connection closed (code: ${event.code}), attempting reconnect...`);
-        this.attemptReconnect();
+        this.scheduleReconnect();
       }
     };
   }
@@ -547,10 +562,7 @@ class GlobalWebSocketService extends EventEmitter {
   disconnect(): void {
 
     // Clear timers
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
+    this.clearReconnectTimer();
 
     // Keep rolling buffer on disconnect for navigation scenarios
 
@@ -573,7 +585,27 @@ class GlobalWebSocketService extends EventEmitter {
   /**
    * Attempt reconnection with exponential backoff
    */
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectScheduled = false;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectScheduled || this.reconnectTimer) {
+      return;
+    }
+
+    this.attemptReconnect();
+  }
+
   private attemptReconnect(): void {
+    if (this.reconnectScheduled || this.reconnectTimer) {
+      return;
+    }
+
     if (this.state.reconnectAttempts >= this.state.maxReconnectAttempts) {
       console.error('❌ Max reconnect attempts reached for global WebSocket');
       this.updateState({
@@ -598,7 +630,10 @@ class GlobalWebSocketService extends EventEmitter {
       reconnectAttempts: attempt
     });
 
+    this.reconnectScheduled = true;
     this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.reconnectScheduled = false;
       console.log(`🔄 [GlobalWebSocketService] Executing reconnection attempt ${attempt}`);
       this.connect();
     }, delay);

--- a/src/locale/en/common.json
+++ b/src/locale/en/common.json
@@ -587,6 +587,7 @@
         "selectFile": "Select File",
         "filesTotal": "{{count}} files total",
         "folderSummary": "Total {{count}} {{folder}} {{type}}",
+        "showingVisible": "Showing {{visible}} / {{total}}",
         "selectedCount": "{{count}} selected",
         "selectionSummary": "{{count}} {{type}}",
         "selectionCombined": "{{folderCount}} folders, {{fileCount}} images selected",

--- a/src/locale/ja/common.json
+++ b/src/locale/ja/common.json
@@ -583,6 +583,7 @@
         "selectFile": "ファイルを選択",
         "filesTotal": "合計 {{count}} ファイル",
         "folderSummary": "合計 {{count}} 個の {{folder}} {{type}}",
+        "showingVisible": "Showing {{visible}} / {{total}}",
         "selectedCount": "{{count}} 個選択済み",
         "selectionSummary": "{{count}} 個の {{type}}",
         "selectionCombined": "フォルダ{{folderCount}}件、ファイル{{fileCount}}件を選択中",

--- a/src/locale/ja/common.json
+++ b/src/locale/ja/common.json
@@ -583,7 +583,7 @@
         "selectFile": "ファイルを選択",
         "filesTotal": "合計 {{count}} ファイル",
         "folderSummary": "合計 {{count}} 個の {{folder}} {{type}}",
-        "showingVisible": "Showing {{visible}} / {{total}}",
+        "showingVisible": "表示 {{visible}} / {{total}} 件",
         "selectedCount": "{{count}} 個選択済み",
         "selectionSummary": "{{count}} 個の {{type}}",
         "selectionCombined": "フォルダ{{folderCount}}件、ファイル{{fileCount}}件を選択中",

--- a/src/locale/ko/common.json
+++ b/src/locale/ko/common.json
@@ -587,7 +587,7 @@
         "selectFile": "파일 선택",
         "filesTotal": "총 {{count}}개 파일",
         "folderSummary": "총 {{count}}개 {{folder}} {{type}}",
-        "showingVisible": "Showing {{visible}} / {{total}}",
+        "showingVisible": "{{visible}} / {{total}}개 표시",
         "selectedCount": "{{count}}개 선택됨",
         "selectionSummary": "{{count}}개 {{type}}",
         "selectionCombined": "폴더 {{folderCount}}개, 이미지 {{fileCount}}개 선택됨",

--- a/src/locale/ko/common.json
+++ b/src/locale/ko/common.json
@@ -587,6 +587,7 @@
         "selectFile": "파일 선택",
         "filesTotal": "총 {{count}}개 파일",
         "folderSummary": "총 {{count}}개 {{folder}} {{type}}",
+        "showingVisible": "Showing {{visible}} / {{total}}",
         "selectedCount": "{{count}}개 선택됨",
         "selectionSummary": "{{count}}개 {{type}}",
         "selectionCombined": "폴더 {{folderCount}}개, 이미지 {{fileCount}}개 선택됨",

--- a/src/locale/zh/common.json
+++ b/src/locale/zh/common.json
@@ -584,6 +584,7 @@
         "selectFile": "选择文件",
         "filesTotal": "共 {{count}} 个文件",
         "folderSummary": "共 {{count}} 个 {{folder}} {{type}}",
+        "showingVisible": "Showing {{visible}} / {{total}}",
         "selectedCount": "已选 {{count}} 个",
         "selectionSummary": "{{count}} 个 {{type}}",
         "selectionCombined": "已选择 {{folderCount}} 个文件夹，{{fileCount}} 张图像",

--- a/src/locale/zh/common.json
+++ b/src/locale/zh/common.json
@@ -584,7 +584,7 @@
         "selectFile": "选择文件",
         "filesTotal": "共 {{count}} 个文件",
         "folderSummary": "共 {{count}} 个 {{folder}} {{type}}",
-        "showingVisible": "Showing {{visible}} / {{total}}",
+        "showingVisible": "显示 {{visible}} / {{total}} 项",
         "selectedCount": "已选 {{count}} 个",
         "selectionSummary": "{{count}} 个 {{type}}",
         "selectionCombined": "已选择 {{folderCount}} 个文件夹，{{fileCount}} 张图像",

--- a/src/shared/types/app/NodeExecutionPreviewFile.ts
+++ b/src/shared/types/app/NodeExecutionPreviewFile.ts
@@ -1,0 +1,5 @@
+export interface NodeExecutionPreviewFile {
+  filename: string;
+  subfolder?: string;
+  type?: 'input' | 'output' | 'temp' | string;
+}

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -1326,7 +1326,13 @@ export function renderNodes(
             const widgetLineHeight = widgetHeight + widgetSpacing;
 
             // First, collect IMAGE/VIDEO widgets and initiate loading
-            const imageWidgets: { widget: any; value: string; cacheKey: string; source: string | NodeExecutionPreviewFile }[] = [];
+            const imageWidgets: {
+              widget: any;
+              value: string;
+              cacheKey: string;
+              source: string | NodeExecutionPreviewFile;
+              isRuntimePreview: boolean;
+            }[] = [];
             const shouldInitiateLoading = !nodeImageLoadingInitiated.has(node.id);
             if (shouldInitiateLoading) {
               nodeImageLoadingInitiated.add(node.id);
@@ -1336,20 +1342,26 @@ export function renderNodes(
               widget: any,
               value: string,
               source: string | NodeExecutionPreviewFile,
-              cacheKey?: string
+              cacheKey?: string,
+              isModifiedWidgetValue = false
             ) => {
               const finalCacheKey = cacheKey || value;
 
               if (imageWidgets.some(item => item.cacheKey === finalCacheKey)) return;
 
-              imageWidgets.push({ widget, value, cacheKey: finalCacheKey, source });
-
-              const isNewForNode = addNodeImageReference(node.id, finalCacheKey);
+              const isRuntimeExecutionPreview = typeof source !== 'string';
+              imageWidgets.push({
+                widget,
+                value,
+                cacheKey: finalCacheKey,
+                source,
+                isRuntimePreview: isRuntimeExecutionPreview
+              });
 
               // Runtime execution previews can change per run; allow loading new keys even after initial node scan.
-              const isRuntimeExecutionPreview = typeof source !== 'string';
+              const isNewForNode = addNodeImageReference(node.id, finalCacheKey);
               const shouldLoadImage =
-                (shouldInitiateLoading || (isRuntimeExecutionPreview && isNewForNode)) &&
+                (shouldInitiateLoading || isRuntimeExecutionPreview || isModifiedWidgetValue || isNewForNode) &&
                 !imageCache.has(finalCacheKey) &&
                 !imageLoadingPromises.has(finalCacheKey);
 
@@ -1369,14 +1381,15 @@ export function renderNodes(
               const name = (widget.name || '').toLowerCase();
               // Check modifiedWidgetValues first, then fall back to widget.value
               const modifiedValues = modifiedWidgetValues?.get(node.id);
-              const value = modifiedValues?.[widget.name] !== undefined ? modifiedValues[widget.name] : widget.value;
+              const hasModifiedWidgetValue = modifiedValues?.[widget.name] !== undefined;
+              const value = hasModifiedWidgetValue ? modifiedValues[widget.name] : widget.value;
 
               // Check if it's an IMAGE or VIDEO widget
               if ((name.includes('image') || name.includes('img') || name.includes('video') ||
                 name === 'filename' || name === 'file' || name === 'input') &&
                 value && typeof value === 'string' &&
                 (value.includes('.') || value.includes('/'))) {
-                addImageWidget(widget, value, value);
+                addImageWidget(widget, value, value, undefined, hasModifiedWidgetValue);
               }
             }
 
@@ -1732,7 +1745,13 @@ export function renderNodes(
                   let compactX = bounds.x + bounds.width - compactSize - 8;
                   const compactY = bounds.y + 8;
                   const compactRadius = 5;
-                  const { cacheKey } = imageWidgets[0];
+                  const compactPreviewWidget = imageWidgets.find(item =>
+                    item.isRuntimePreview ||
+                    item.widget?.isRuntimePreview ||
+                    item.widget?.type === 'runtimePreview' ||
+                    item.widget?.runtimePreview === true
+                  ) || imageWidgets[0];
+                  const { cacheKey } = compactPreviewWidget;
                   const indicatorSize = 12;
                   const indicatorOffset = 4;
                   const indicatorX = bounds.x + bounds.width - indicatorSize - indicatorOffset;

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -5,6 +5,7 @@ import type { IComfyGraphNode, IComfyGraphLink } from '@/shared/types/app/base';
 import { DEFAULT_CANVAS_CONFIG, CanvasConfig } from '@/config/canvasConfig';
 import { IComfyGraphGroup } from '@/shared/types/app/base';
 import { ComfyGraphNode } from '@/core/domain/ComfyGraphNode';
+import type { NodeExecutionPreviewFile } from '@/shared/types/app/NodeExecutionPreviewFile';
 import { useConnectionStore } from '@/ui/store/connectionStore';
 
 // Alias for backward compatibility
@@ -17,12 +18,6 @@ const imageLoadingPromises = new Map<string, Promise<HTMLImageElement>>();
 const nodeImageLoadingInitiated = new Set<number>();
 // Track which images belong to which nodes
 const nodeImageMap = new Map<number, Set<string>>();
-
-export interface NodeExecutionPreviewFile {
-  filename: string;
-  subfolder?: string;
-  type?: 'input' | 'output' | 'temp' | string;
-}
 
 /**
  * Clear node image loading tracking (called when workflow changes)
@@ -1669,10 +1664,32 @@ export function renderNodes(
                 } else if (hasRuntimeExecutionPreviews) {
                   // Fallback: draw a compact thumbnail badge so execution preview is still visible on small nodes.
                   const compactSize = Math.max(28, Math.min(44, Math.min(bounds.width, bounds.height) * 0.28));
-                  const compactX = bounds.x + bounds.width - compactSize - 8;
+                  let compactX = bounds.x + bounds.width - compactSize - 8;
                   const compactY = bounds.y + 8;
                   const compactRadius = 5;
                   const { cacheKey } = imageWidgets[0];
+                  const indicatorSize = 12;
+                  const indicatorOffset = 4;
+                  const indicatorX = bounds.x + bounds.width - indicatorSize - indicatorOffset;
+                  const indicatorY = bounds.y + indicatorOffset;
+                  const hasExecutionIndicator = isExecuting || isError;
+
+                  if (hasExecutionIndicator) {
+                    const compactRight = compactX + compactSize;
+                    const compactBottom = compactY + compactSize;
+                    const indicatorRight = indicatorX + indicatorSize;
+                    const indicatorBottom = indicatorY + indicatorSize;
+                    const overlapsExecutionIndicator = (
+                      compactX < indicatorRight &&
+                      compactRight > indicatorX &&
+                      compactY < indicatorBottom &&
+                      compactBottom > indicatorY
+                    );
+
+                    if (overlapsExecutionIndicator) {
+                      compactX = Math.max(bounds.x + 6, compactX - (indicatorSize + indicatorOffset));
+                    }
+                  }
 
                   if (imageCache.has(cacheKey)) {
                     const img = imageCache.get(cacheKey)!;

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -18,6 +18,12 @@ const nodeImageLoadingInitiated = new Set<number>();
 // Track which images belong to which nodes
 const nodeImageMap = new Map<number, Set<string>>();
 
+export interface NodeExecutionPreviewFile {
+  filename: string;
+  subfolder?: string;
+  type?: 'input' | 'output' | 'temp' | string;
+}
+
 /**
  * Clear node image loading tracking (called when workflow changes)
  */
@@ -89,25 +95,34 @@ function getVideoThumbnailFilename(videoFilename: string): string {
 /**
  * Load an image from ComfyUI server
  */
-async function loadComfyImage(filename: string, nodeId?: number): Promise<HTMLImageElement> {
+async function loadComfyImage(source: string | NodeExecutionPreviewFile, nodeId?: number): Promise<HTMLImageElement> {
   // Get server URL from connectionStore
   const serverUrl = useConnectionStore.getState().url || 'http://localhost:8188';
 
+  const isExecutionPreview = typeof source !== 'string';
+  const sourceType = isExecutionPreview ? (source.type || 'output') : 'input';
+  const sourceSubfolder = isExecutionPreview ? (source.subfolder || '') : '';
+  const sourceFilename = isExecutionPreview ? source.filename : source;
+
+  const cacheKey = isExecutionPreview
+    ? `${sourceType}/${sourceSubfolder}/${sourceFilename}`
+    : sourceFilename;
+
   // For video files, load the PNG thumbnail instead
-  let targetFilename = filename;
-  if (isVideoFile(filename)) {
-    targetFilename = getVideoThumbnailFilename(filename);
-    console.log(`🎬 [Canvas] Loading thumbnail for video: ${filename} -> ${targetFilename}`);
+  let targetFilename = sourceFilename;
+  if (isVideoFile(sourceFilename)) {
+    targetFilename = getVideoThumbnailFilename(sourceFilename);
+    console.log(`[Canvas] Loading thumbnail for video: ${sourceFilename} -> ${targetFilename}`);
   }
 
-  // Check cache first (use original filename as cache key for consistency)
-  if (imageCache.has(filename)) {
-    return imageCache.get(filename)!;
+  // Check cache first
+  if (imageCache.has(cacheKey)) {
+    return imageCache.get(cacheKey)!;
   }
 
   // Check if already loading
-  if (imageLoadingPromises.has(filename)) {
-    return imageLoadingPromises.get(filename)!;
+  if (imageLoadingPromises.has(cacheKey)) {
+    return imageLoadingPromises.get(cacheKey)!;
   }
 
   // Create loading promise
@@ -115,45 +130,45 @@ async function loadComfyImage(filename: string, nodeId?: number): Promise<HTMLIm
     const img = new Image();
 
     // Parse filename and subfolder
-    let actualFilename: string;
-    let subfolder: string = '';
+    let actualFilename: string = targetFilename;
+    let subfolder: string = sourceSubfolder;
+    const type: string = sourceType;
 
-    if (targetFilename.includes('/')) {
+    // Regular widget preview values are path-like strings under input/
+    if (!isExecutionPreview && targetFilename.includes('/')) {
       const lastSlashIndex = targetFilename.lastIndexOf('/');
       subfolder = targetFilename.substring(0, lastSlashIndex);
       actualFilename = targetFilename.substring(lastSlashIndex + 1);
-    } else {
-      actualFilename = targetFilename;
     }
 
     // Build URL for ComfyUI file view
-    const url = `${serverUrl}/view?filename=${encodeURIComponent(actualFilename)}&type=input${subfolder ? `&subfolder=${encodeURIComponent(subfolder)}` : ''}`;
+    const url = `${serverUrl}/view?filename=${encodeURIComponent(actualFilename)}&type=${encodeURIComponent(type)}${subfolder ? `&subfolder=${encodeURIComponent(subfolder)}` : ''}`;
 
     img.crossOrigin = 'anonymous';
     img.onload = () => {
-      imageCache.set(filename, img);  // Use original filename as key
-      imageLoadingPromises.delete(filename);
+      imageCache.set(cacheKey, img);
+      imageLoadingPromises.delete(cacheKey);
 
       // Track which node this image belongs to
       if (nodeId !== undefined) {
         if (!nodeImageMap.has(nodeId)) {
           nodeImageMap.set(nodeId, new Set());
         }
-        nodeImageMap.get(nodeId)!.add(filename);
+        nodeImageMap.get(nodeId)!.add(cacheKey);
       }
 
       resolve(img);
     };
 
     img.onerror = () => {
-      imageLoadingPromises.delete(filename);
+      imageLoadingPromises.delete(cacheKey);
       reject(new Error(`Failed to load image: ${targetFilename}`));
     };
 
     img.src = url;
   });
 
-  imageLoadingPromises.set(filename, loadPromise);
+  imageLoadingPromises.set(cacheKey, loadPromise);
   return loadPromise;
 }
 
@@ -205,6 +220,7 @@ export interface RenderingOptions {
   viewportScale?: number; // Viewport scale for responsive font sizing
   modifiedNodeIds?: Set<number>; // Nodes with temporary widget changes
   modifiedWidgetValues?: Map<number, Record<string, any>>; // Actual modified widget values
+  executionNodePreviews?: Map<number, NodeExecutionPreviewFile[]>; // Runtime execution previews by node
   repositionMode?: {
     isActive: boolean;
     selectedNodeId: number | null;
@@ -847,7 +863,7 @@ export function renderNodes(
   config: CanvasConfig = DEFAULT_CANVAS_CONFIG,
   options: RenderingOptions = {}
 ): void {
-  const { selectedNode, executingNodeId, errorNodeId, nodeExecutionProgress, showText = true, viewportScale, modifiedNodeIds, modifiedWidgetValues, repositionMode, connectionMode, missingNodeIds, longPressState, visibleRect } = options;
+  const { selectedNode, executingNodeId, errorNodeId, nodeExecutionProgress, showText = true, viewportScale, modifiedNodeIds, modifiedWidgetValues, executionNodePreviews, repositionMode, connectionMode, missingNodeIds, longPressState, visibleRect } = options;
 
   // Sort nodes by collapsed state first, then connection mode priority, then by order
   // Lower values are drawn first (behind), higher values are drawn last (in front)
@@ -1229,9 +1245,10 @@ export function renderNodes(
         const treatAsCollapsed = slotAreaHeight > bounds.height;
 
         // Draw widgets with LOD system - below slot area (only if not treating as collapsed)
-        if (!treatAsCollapsed && node.widgets && node.getWidgets) {
-          const widgets = node.getWidgets();
-          if (widgets.length > 0) {
+        if (!treatAsCollapsed) {
+          const widgets = node.getWidgets ? node.getWidgets() : [];
+          const executionPreviewFiles = executionNodePreviews?.get(node.id) || [];
+          if (widgets.length > 0 || executionPreviewFiles.length > 0) {
             // Widget area starts below title and slot area
             const widgetStartY = Math.max(bounds.y + titleYOffset + 30, bounds.y + slotAreaHeight + 10);
             const widgetHeight = 24;
@@ -1239,11 +1256,49 @@ export function renderNodes(
             const widgetLineHeight = widgetHeight + widgetSpacing;
 
             // First, collect IMAGE/VIDEO widgets and initiate loading
-            const imageWidgets: { widget: any; value: string }[] = [];
+            const imageWidgets: { widget: any; value: string; cacheKey: string; source: string | NodeExecutionPreviewFile }[] = [];
             const shouldInitiateLoading = !nodeImageLoadingInitiated.has(node.id);
             if (shouldInitiateLoading) {
               nodeImageLoadingInitiated.add(node.id);
             }
+
+            const addImageWidget = (
+              widget: any,
+              value: string,
+              source: string | NodeExecutionPreviewFile,
+              cacheKey?: string
+            ) => {
+              const finalCacheKey = cacheKey || value;
+
+              if (imageWidgets.some(item => item.cacheKey === finalCacheKey)) return;
+
+              imageWidgets.push({ widget, value, cacheKey: finalCacheKey, source });
+
+              if (!nodeImageMap.has(node.id)) {
+                nodeImageMap.set(node.id, new Set());
+              }
+              const nodeImages = nodeImageMap.get(node.id)!;
+              const isNewForNode = !nodeImages.has(finalCacheKey);
+              nodeImages.add(finalCacheKey);
+
+              // Runtime execution previews can change per run; allow loading new keys even after initial node scan.
+              const isRuntimeExecutionPreview = typeof source !== 'string';
+              const shouldLoadImage =
+                (shouldInitiateLoading || (isRuntimeExecutionPreview && isNewForNode)) &&
+                !imageCache.has(finalCacheKey) &&
+                !imageLoadingPromises.has(finalCacheKey);
+
+              if (shouldLoadImage) {
+                loadComfyImage(source, node.id).then(() => {
+                  // Request a redraw when image loads
+                  if (ctx.canvas && ctx.canvas.parentElement) {
+                    ctx.canvas.dispatchEvent(new Event('imageLoaded'));
+                  }
+                }).catch(() => {
+                  console.log('Failed to load preview image:', value);
+                });
+              }
+            };
 
             for (const widget of widgets) {
               const name = (widget.name || '').toLowerCase();
@@ -1256,35 +1311,28 @@ export function renderNodes(
                 name === 'filename' || name === 'file' || name === 'input') &&
                 value && typeof value === 'string' &&
                 (value.includes('.') || value.includes('/'))) {
-                imageWidgets.push({ widget, value });
-
-                // Track this image for the node
-                if (!nodeImageMap.has(node.id)) {
-                  nodeImageMap.set(node.id, new Set());
-                }
-                nodeImageMap.get(node.id)!.add(value);
-
-                // Only initiate loading on first render of this node
-                if (shouldInitiateLoading && !imageCache.has(value) && !imageLoadingPromises.has(value)) {
-                  loadComfyImage(value, node.id).then(img => {
-                    // Request a redraw when image loads
-                    if (ctx.canvas && ctx.canvas.parentElement) {
-                      ctx.canvas.dispatchEvent(new Event('imageLoaded'));
-                    }
-                  }).catch(err => {
-                    console.log('Failed to load preview image:', value);
-                  });
-                }
+                addImageWidget(widget, value, value);
               }
             }
 
-            // Calculate available height for widgets - widgets are prioritized
+            // Add runtime execution previews for SaveImage/PreviewImage style nodes
+            for (const previewFile of executionPreviewFiles) {
+              if (!previewFile?.filename) continue;
+              const cacheKey = `${previewFile.type || 'output'}/${previewFile.subfolder || ''}/${previewFile.filename}`;
+              addImageWidget(null, previewFile.filename, previewFile, cacheKey);
+            }
+
+            // Calculate available height for widgets - keep space for runtime execution previews when present.
             const availableHeight = bounds.height - (widgetStartY - bounds.y) - 10;
-            const totalWidgetHeight = widgets.length * widgetLineHeight;
-            const maxWidgetsToShow = Math.min(widgets.length, Math.floor(availableHeight / widgetLineHeight));
+            const hasRuntimeExecutionPreviews = executionPreviewFiles.length > 0;
+            const reservedPreviewHeight = hasRuntimeExecutionPreviews && imageWidgets.length > 0
+              ? Math.min(72, availableHeight * 0.45)
+              : 0;
+            const widgetBudgetHeight = Math.max(0, availableHeight - reservedPreviewHeight);
+            const maxWidgetsToShow = Math.min(widgets.length, Math.floor(widgetBudgetHeight / widgetLineHeight));
             const allWidgetsShown = widgets.length === maxWidgetsToShow;
 
-            if (maxWidgetsToShow > 0) {
+            if (maxWidgetsToShow > 0 || imageWidgets.length > 0) {
               // Render widgets based on LOD level
               widgets.slice(0, maxWidgetsToShow).forEach((widget, index) => {
                 const widgetY = widgetStartY + (index * widgetLineHeight);
@@ -1510,9 +1558,8 @@ export function renderNodes(
                 ctx.fillText(moreText, bounds.x + bounds.width / 2, bounds.y + bounds.height - 12);
               }
 
-              // Draw image preview at bottom ONLY if all widgets are shown and we have images
-              // Images are shown at ALL LOD levels for better visibility
-              if (allWidgetsShown && imageWidgets.length > 0) {
+              // Draw image previews: always for runtime execution previews, otherwise only when all widgets fit.
+              if (imageWidgets.length > 0 && (allWidgetsShown || hasRuntimeExecutionPreviews)) {
                 // Calculate the position and size for the preview area
                 const widgetEndY = widgetStartY + (maxWidgetsToShow * widgetLineHeight);
                 const remainingHeight = bounds.y + bounds.height - widgetEndY - 15; // Leave some padding
@@ -1538,17 +1585,17 @@ export function renderNodes(
                   let imageX = previewX;
 
                   for (let i = 0; i < numImagesToShow; i++) {
-                    const { value } = imageWidgets[i];
+                    const { value, cacheKey } = imageWidgets[i];
 
                     // Check if image is in cache
-                    if (imageCache.has(value)) {
-                      const img = imageCache.get(value)!;
+                    if (imageCache.has(cacheKey)) {
+                      const img = imageCache.get(cacheKey)!;
 
                       // Track this cached image for the node if not already tracked
                       if (!nodeImageMap.has(node.id)) {
                         nodeImageMap.set(node.id, new Set());
                       }
-                      nodeImageMap.get(node.id)!.add(value);
+                      nodeImageMap.get(node.id)!.add(cacheKey);
 
                       // Draw container with fixed width and dynamic height
                       ctx.save();
@@ -1619,6 +1666,59 @@ export function renderNodes(
                     ctx.textBaseline = 'middle';
                     ctx.fillText(`+${imageWidgets.length - 3}`, imageX - imageSpacing / 2, previewY + previewHeight / 2);
                   }
+                } else if (hasRuntimeExecutionPreviews) {
+                  // Fallback: draw a compact thumbnail badge so execution preview is still visible on small nodes.
+                  const compactSize = Math.max(28, Math.min(44, Math.min(bounds.width, bounds.height) * 0.28));
+                  const compactX = bounds.x + bounds.width - compactSize - 8;
+                  const compactY = bounds.y + 8;
+                  const compactRadius = 5;
+                  const { cacheKey } = imageWidgets[0];
+
+                  if (imageCache.has(cacheKey)) {
+                    const img = imageCache.get(cacheKey)!;
+                    ctx.save();
+                    ctx.beginPath();
+                    ctx.roundRect(compactX, compactY, compactSize, compactSize, compactRadius);
+                    ctx.clip();
+
+                    const aspectRatio = img.width / img.height;
+                    let sourceX = 0;
+                    let sourceY = 0;
+                    let sourceWidth = img.width;
+                    let sourceHeight = img.height;
+
+                    if (aspectRatio > 1) {
+                      sourceWidth = img.height;
+                      sourceX = (img.width - sourceWidth) / 2;
+                    } else {
+                      sourceHeight = img.width;
+                      sourceY = (img.height - sourceHeight) / 2;
+                    }
+
+                    ctx.drawImage(
+                      img,
+                      sourceX,
+                      sourceY,
+                      sourceWidth,
+                      sourceHeight,
+                      compactX,
+                      compactY,
+                      compactSize,
+                      compactSize
+                    );
+                    ctx.restore();
+                  } else {
+                    ctx.fillStyle = 'rgba(255, 255, 255, 0.06)';
+                    ctx.beginPath();
+                    ctx.roundRect(compactX, compactY, compactSize, compactSize, compactRadius);
+                    ctx.fill();
+                  }
+
+                  ctx.strokeStyle = 'rgba(255, 255, 255, 0.25)';
+                  ctx.lineWidth = 1;
+                  ctx.beginPath();
+                  ctx.roundRect(compactX, compactY, compactSize, compactSize, compactRadius);
+                  ctx.stroke();
                 }
               }
             }

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -19,8 +19,13 @@ const nodeImageLoadingInitiated = new Set<number>();
 // Track which images belong to which nodes
 const nodeImageMap = new Map<number, Set<string>>();
 const imageCacheRecency = new Map<string, true>();
+const failedImageTimestamps = new Map<string, number>();
 const MAX_IMAGE_CACHE_ENTRIES = 200;
+const IMAGE_LOAD_FAILURE_COOLDOWN_MS = 30000;
 
+/**
+ * Marks an image key as recently used in the LRU recency map.
+ */
 function markImageKeyAsRecentlyUsed(cacheKey: string) {
   if (imageCacheRecency.has(cacheKey)) {
     imageCacheRecency.delete(cacheKey);
@@ -28,10 +33,24 @@ function markImageKeyAsRecentlyUsed(cacheKey: string) {
   imageCacheRecency.set(cacheKey, true);
 }
 
-function removeImageCacheEntry(cacheKey: string) {
+/**
+ * Removes a cache key from cache bookkeeping and node references.
+ *
+ * `preserveLoadingPromise` is used during eviction to avoid dropping
+ * in-flight promise dedupe entries and triggering duplicate fetches.
+ */
+function removeImageCacheEntry(
+  cacheKey: string,
+  options?: { preserveLoadingPromise?: boolean; preserveFailureTimestamp?: boolean }
+) {
   imageCache.delete(cacheKey);
-  imageLoadingPromises.delete(cacheKey);
   imageCacheRecency.delete(cacheKey);
+  if (!options?.preserveLoadingPromise) {
+    imageLoadingPromises.delete(cacheKey);
+  }
+  if (!options?.preserveFailureTimestamp) {
+    failedImageTimestamps.delete(cacheKey);
+  }
 
   for (const [nodeId, nodeImages] of Array.from(nodeImageMap.entries())) {
     if (!nodeImages.delete(cacheKey)) {
@@ -47,16 +66,25 @@ function removeImageCacheEntry(cacheKey: string) {
   }
 }
 
+/**
+ * Evicts least recently used keys until cache recency size is within limits.
+ */
 function evictLeastRecentlyUsedEntries() {
   while (imageCacheRecency.size > MAX_IMAGE_CACHE_ENTRIES) {
     const leastRecentlyUsedKey = imageCacheRecency.keys().next().value as string | undefined;
     if (!leastRecentlyUsedKey) {
       break;
     }
-    removeImageCacheEntry(leastRecentlyUsedKey);
+    removeImageCacheEntry(leastRecentlyUsedKey, {
+      preserveLoadingPromise: true,
+      preserveFailureTimestamp: true
+    });
   }
 }
 
+/**
+ * Registers an image key for a node and returns whether it is new for that node.
+ */
 function addNodeImageReference(nodeId: number, cacheKey: string): boolean {
   if (!nodeImageMap.has(nodeId)) {
     nodeImageMap.set(nodeId, new Set());
@@ -72,6 +100,9 @@ function addNodeImageReference(nodeId: number, cacheKey: string): boolean {
   return isNewForNode;
 }
 
+/**
+ * Returns a cached image and marks it as recently used.
+ */
 function getCachedImage(cacheKey: string): HTMLImageElement | undefined {
   const cachedImage = imageCache.get(cacheKey);
   if (!cachedImage) {
@@ -82,6 +113,9 @@ function getCachedImage(cacheKey: string): HTMLImageElement | undefined {
   return cachedImage;
 }
 
+/**
+ * Stores an image in cache, marks recency, and applies LRU eviction.
+ */
 function setCachedImage(cacheKey: string, image: HTMLImageElement) {
   imageCache.set(cacheKey, image);
   markImageKeyAsRecentlyUsed(cacheKey);
@@ -94,6 +128,7 @@ function setCachedImage(cacheKey: string, image: HTMLImageElement) {
 export function clearNodeImageLoadingCache() {
   nodeImageLoadingInitiated.clear();
   nodeImageMap.clear();
+  failedImageTimestamps.clear();
 }
 
 /**
@@ -119,6 +154,7 @@ export function clearNodeImageCache(nodeId?: number) {
     imageLoadingPromises.clear();
     nodeImageMap.clear();
     imageCacheRecency.clear();
+    failedImageTimestamps.clear();
   }
 }
 
@@ -218,6 +254,7 @@ async function loadComfyImage(source: string | NodeExecutionPreviewFile, nodeId?
     img.crossOrigin = 'anonymous';
     img.onload = () => {
       setCachedImage(cacheKey, img);
+      failedImageTimestamps.delete(cacheKey);
       imageLoadingPromises.delete(cacheKey);
 
       // Track which node this image belongs to
@@ -1360,18 +1397,25 @@ export function renderNodes(
 
               // Runtime execution previews can change per run; allow loading new keys even after initial node scan.
               const isNewForNode = addNodeImageReference(node.id, finalCacheKey);
+              const lastFailureTs = failedImageTimestamps.get(finalCacheKey);
+              const hasRecentLoadFailure =
+                typeof lastFailureTs === 'number' &&
+                (Date.now() - lastFailureTs) < IMAGE_LOAD_FAILURE_COOLDOWN_MS;
               const shouldLoadImage =
                 (shouldInitiateLoading || isRuntimeExecutionPreview || isModifiedWidgetValue || isNewForNode) &&
+                !hasRecentLoadFailure &&
                 !imageCache.has(finalCacheKey) &&
                 !imageLoadingPromises.has(finalCacheKey);
 
               if (shouldLoadImage) {
                 loadComfyImage(source, node.id).then(() => {
+                  failedImageTimestamps.delete(finalCacheKey);
                   // Request a redraw when image loads
                   if (ctx.canvas && ctx.canvas.parentElement) {
                     ctx.canvas.dispatchEvent(new Event('imageLoaded'));
                   }
                 }).catch(() => {
+                  failedImageTimestamps.set(finalCacheKey, Date.now());
                   console.log('Failed to load preview image:', value);
                 });
               }

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -18,6 +18,75 @@ const imageLoadingPromises = new Map<string, Promise<HTMLImageElement>>();
 const nodeImageLoadingInitiated = new Set<number>();
 // Track which images belong to which nodes
 const nodeImageMap = new Map<number, Set<string>>();
+const imageCacheRecency = new Map<string, true>();
+const MAX_IMAGE_CACHE_ENTRIES = 200;
+
+function markImageKeyAsRecentlyUsed(cacheKey: string) {
+  if (imageCacheRecency.has(cacheKey)) {
+    imageCacheRecency.delete(cacheKey);
+  }
+  imageCacheRecency.set(cacheKey, true);
+}
+
+function removeImageCacheEntry(cacheKey: string) {
+  imageCache.delete(cacheKey);
+  imageLoadingPromises.delete(cacheKey);
+  imageCacheRecency.delete(cacheKey);
+
+  for (const [nodeId, nodeImages] of Array.from(nodeImageMap.entries())) {
+    if (!nodeImages.delete(cacheKey)) {
+      continue;
+    }
+
+    // Let nodes re-initiate loads for keys that were evicted from cache.
+    nodeImageLoadingInitiated.delete(nodeId);
+
+    if (nodeImages.size === 0) {
+      nodeImageMap.delete(nodeId);
+    }
+  }
+}
+
+function evictLeastRecentlyUsedEntries() {
+  while (imageCacheRecency.size > MAX_IMAGE_CACHE_ENTRIES) {
+    const leastRecentlyUsedKey = imageCacheRecency.keys().next().value as string | undefined;
+    if (!leastRecentlyUsedKey) {
+      break;
+    }
+    removeImageCacheEntry(leastRecentlyUsedKey);
+  }
+}
+
+function addNodeImageReference(nodeId: number, cacheKey: string): boolean {
+  if (!nodeImageMap.has(nodeId)) {
+    nodeImageMap.set(nodeId, new Set());
+  }
+
+  const nodeImages = nodeImageMap.get(nodeId)!;
+  const isNewForNode = !nodeImages.has(cacheKey);
+  nodeImages.add(cacheKey);
+
+  markImageKeyAsRecentlyUsed(cacheKey);
+  evictLeastRecentlyUsedEntries();
+
+  return isNewForNode;
+}
+
+function getCachedImage(cacheKey: string): HTMLImageElement | undefined {
+  const cachedImage = imageCache.get(cacheKey);
+  if (!cachedImage) {
+    return undefined;
+  }
+
+  markImageKeyAsRecentlyUsed(cacheKey);
+  return cachedImage;
+}
+
+function setCachedImage(cacheKey: string, image: HTMLImageElement) {
+  imageCache.set(cacheKey, image);
+  markImageKeyAsRecentlyUsed(cacheKey);
+  evictLeastRecentlyUsedEntries();
+}
 
 /**
  * Clear node image loading tracking (called when workflow changes)
@@ -38,9 +107,8 @@ export function clearNodeImageCache(nodeId?: number) {
     // Clear cached images for this specific node only
     const nodeImages = nodeImageMap.get(nodeId);
     if (nodeImages) {
-      nodeImages.forEach(filename => {
-        imageCache.delete(filename);
-        imageLoadingPromises.delete(filename);
+      nodeImages.forEach(cacheKey => {
+        removeImageCacheEntry(cacheKey);
       });
       nodeImageMap.delete(nodeId);
     }
@@ -50,6 +118,7 @@ export function clearNodeImageCache(nodeId?: number) {
     imageCache.clear();
     imageLoadingPromises.clear();
     nodeImageMap.clear();
+    imageCacheRecency.clear();
   }
 }
 
@@ -111,13 +180,20 @@ async function loadComfyImage(source: string | NodeExecutionPreviewFile, nodeId?
   }
 
   // Check cache first
-  if (imageCache.has(cacheKey)) {
-    return imageCache.get(cacheKey)!;
+  const cachedImage = getCachedImage(cacheKey);
+  if (cachedImage) {
+    if (nodeId !== undefined) {
+      addNodeImageReference(nodeId, cacheKey);
+    }
+    return cachedImage;
   }
 
   // Check if already loading
-  if (imageLoadingPromises.has(cacheKey)) {
-    return imageLoadingPromises.get(cacheKey)!;
+  const existingLoadPromise = imageLoadingPromises.get(cacheKey);
+  if (existingLoadPromise) {
+    markImageKeyAsRecentlyUsed(cacheKey);
+    evictLeastRecentlyUsedEntries();
+    return existingLoadPromise;
   }
 
   // Create loading promise
@@ -141,15 +217,12 @@ async function loadComfyImage(source: string | NodeExecutionPreviewFile, nodeId?
 
     img.crossOrigin = 'anonymous';
     img.onload = () => {
-      imageCache.set(cacheKey, img);
+      setCachedImage(cacheKey, img);
       imageLoadingPromises.delete(cacheKey);
 
       // Track which node this image belongs to
       if (nodeId !== undefined) {
-        if (!nodeImageMap.has(nodeId)) {
-          nodeImageMap.set(nodeId, new Set());
-        }
-        nodeImageMap.get(nodeId)!.add(cacheKey);
+        addNodeImageReference(nodeId, cacheKey);
       }
 
       resolve(img);
@@ -164,6 +237,8 @@ async function loadComfyImage(source: string | NodeExecutionPreviewFile, nodeId?
   });
 
   imageLoadingPromises.set(cacheKey, loadPromise);
+  markImageKeyAsRecentlyUsed(cacheKey);
+  evictLeastRecentlyUsedEntries();
   return loadPromise;
 }
 
@@ -1269,12 +1344,7 @@ export function renderNodes(
 
               imageWidgets.push({ widget, value, cacheKey: finalCacheKey, source });
 
-              if (!nodeImageMap.has(node.id)) {
-                nodeImageMap.set(node.id, new Set());
-              }
-              const nodeImages = nodeImageMap.get(node.id)!;
-              const isNewForNode = !nodeImages.has(finalCacheKey);
-              nodeImages.add(finalCacheKey);
+              const isNewForNode = addNodeImageReference(node.id, finalCacheKey);
 
               // Runtime execution previews can change per run; allow loading new keys even after initial node scan.
               const isRuntimeExecutionPreview = typeof source !== 'string';
@@ -1580,17 +1650,12 @@ export function renderNodes(
                   let imageX = previewX;
 
                   for (let i = 0; i < numImagesToShow; i++) {
-                    const { value, cacheKey } = imageWidgets[i];
+                    const { cacheKey } = imageWidgets[i];
 
                     // Check if image is in cache
-                    if (imageCache.has(cacheKey)) {
-                      const img = imageCache.get(cacheKey)!;
-
-                      // Track this cached image for the node if not already tracked
-                      if (!nodeImageMap.has(node.id)) {
-                        nodeImageMap.set(node.id, new Set());
-                      }
-                      nodeImageMap.get(node.id)!.add(cacheKey);
+                    const img = getCachedImage(cacheKey);
+                    if (img) {
+                      addNodeImageReference(node.id, cacheKey);
 
                       // Draw container with fixed width and dynamic height
                       ctx.save();
@@ -1691,8 +1756,9 @@ export function renderNodes(
                     }
                   }
 
-                  if (imageCache.has(cacheKey)) {
-                    const img = imageCache.get(cacheKey)!;
+                  const img = getCachedImage(cacheKey);
+                  if (img) {
+                    addNodeImageReference(node.id, cacheKey);
                     ctx.save();
                     ctx.beginPath();
                     ctx.roundRect(compactX, compactY, compactSize, compactSize, compactRadius);

--- a/src/ui/store/latentPreviewStore.ts
+++ b/src/ui/store/latentPreviewStore.ts
@@ -61,7 +61,7 @@ export const useLatentPreviewStore = create<LatentPreviewState>()(
                         return;
                     }
 
-                    if (state.imageUrl) {
+                    if (state.imageUrl?.startsWith('blob:')) {
                         try {
                             URL.revokeObjectURL(state.imageUrl);
                         } catch (e) {
@@ -88,7 +88,7 @@ export const useLatentPreviewStore = create<LatentPreviewState>()(
 
                 clearPreview: () => {
                     const state = get();
-                    if (state.imageUrl) {
+                    if (state.imageUrl?.startsWith('blob:')) {
                         URL.revokeObjectURL(state.imageUrl);
                     }
                     set({

--- a/src/ui/store/nodeExecutionPreviewStore.ts
+++ b/src/ui/store/nodeExecutionPreviewStore.ts
@@ -1,11 +1,8 @@
 import { create } from 'zustand';
 import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
+import type { NodeExecutionPreviewFile } from '@/shared/types/app/NodeExecutionPreviewFile';
 
-export interface NodeExecutionPreviewFile {
-  filename: string;
-  subfolder?: string;
-  type?: 'input' | 'output' | 'temp' | string;
-}
+export type { NodeExecutionPreviewFile } from '@/shared/types/app/NodeExecutionPreviewFile';
 
 interface NodeExecutionPreviewState {
   previewsByNode: Map<number, NodeExecutionPreviewFile[]>;

--- a/src/ui/store/nodeExecutionPreviewStore.ts
+++ b/src/ui/store/nodeExecutionPreviewStore.ts
@@ -1,0 +1,98 @@
+import { create } from 'zustand';
+import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
+
+export interface NodeExecutionPreviewFile {
+  filename: string;
+  subfolder?: string;
+  type?: 'input' | 'output' | 'temp' | string;
+}
+
+interface NodeExecutionPreviewState {
+  previewsByNode: Map<number, NodeExecutionPreviewFile[]>;
+  setNodePreviews: (nodeId: number, files: NodeExecutionPreviewFile[]) => void;
+  clearPreviews: () => void;
+}
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp', 'avif']);
+
+const isPreviewImageFile = (value: unknown): value is NodeExecutionPreviewFile => {
+  if (!value || typeof value !== 'object') return false;
+
+  const file = value as Record<string, unknown>;
+  if (typeof file.filename !== 'string' || file.filename.length === 0) return false;
+
+  const ext = file.filename.split('.').pop()?.toLowerCase();
+  if (!ext || !IMAGE_EXTENSIONS.has(ext)) return false;
+
+  return true;
+};
+
+const extractExecutionPreviewFiles = (container: unknown, depth = 0): NodeExecutionPreviewFile[] => {
+  if (!container || typeof container !== 'object' || depth > 3) return [];
+
+  const record = container as Record<string, unknown>;
+  const files: NodeExecutionPreviewFile[] = [];
+
+  for (const key of ['images', 'gifs']) {
+    const arr = record[key];
+    if (!Array.isArray(arr)) continue;
+
+    for (const item of arr) {
+      if (isPreviewImageFile(item)) {
+        files.push({
+          filename: item.filename,
+          subfolder: item.subfolder || '',
+          type: item.type || 'output'
+        });
+      }
+    }
+  }
+
+  // Some nodes wrap previews under `ui`, and payload shapes can vary by node pack.
+  for (const value of Object.values(record)) {
+    if (!value || typeof value !== 'object') continue;
+    files.push(...extractExecutionPreviewFiles(value, depth + 1));
+  }
+
+  const uniqueByPath = new Map<string, NodeExecutionPreviewFile>();
+  for (const file of files) {
+    const key = `${file.type || 'output'}/${file.subfolder || ''}/${file.filename}`;
+    if (!uniqueByPath.has(key)) uniqueByPath.set(key, file);
+  }
+
+  return Array.from(uniqueByPath.values());
+};
+
+export const useNodeExecutionPreviewStore = create<NodeExecutionPreviewState>((set) => ({
+  previewsByNode: new Map(),
+
+  setNodePreviews: (nodeId, files) => {
+    set((state) => {
+      const next = new Map(state.previewsByNode);
+      next.set(nodeId, files);
+      return { previewsByNode: next };
+    });
+  },
+
+  clearPreviews: () => set({ previewsByNode: new Map() })
+}));
+
+globalWebSocketService.on('execution_started', () => {
+  useNodeExecutionPreviewStore.getState().clearPreviews();
+});
+
+globalWebSocketService.on('executed', (event: any) => {
+  try {
+    const data = event?.data || event;
+    const nodeId = Number(data?.node);
+    if (!Number.isFinite(nodeId)) return;
+
+    const files = extractExecutionPreviewFiles(data?.output);
+    if (files.length === 0) return;
+
+    useNodeExecutionPreviewStore.getState().setNodePreviews(nodeId, files);
+  } catch (error) {
+    console.warn('[NodeExecutionPreviewStore] Failed to process executed previews:', error);
+  }
+});
+

--- a/src/ui/store/nodeSamplerPreviewStore.ts
+++ b/src/ui/store/nodeSamplerPreviewStore.ts
@@ -100,8 +100,8 @@ export const useNodeSamplerPreviewStore = create<NodeSamplerPreviewState>((set) 
       }
 
       const nextPreviews = new Map(state.previewsByNode);
-      for (const [nodeId, frames] of nextPreviews.entries()) {
-        if (workflowNodeIds.has(nodeId)) continue;
+      for (const [nodeId, frames] of state.previewsByNode.entries()) {
+        if (workflowNodeIds.has(nodeId) && samplerNodeIds.has(nodeId)) continue;
         frames.forEach((frame) => {
           revokeIfBlobUrl(frame.imageUrl);
         });

--- a/src/ui/store/nodeSamplerPreviewStore.ts
+++ b/src/ui/store/nodeSamplerPreviewStore.ts
@@ -102,7 +102,9 @@ export const useNodeSamplerPreviewStore = create<NodeSamplerPreviewState>((set) 
       const nextPreviews = new Map(state.previewsByNode);
       for (const [nodeId, frames] of nextPreviews.entries()) {
         if (workflowNodeIds.has(nodeId)) continue;
-        frames.forEach((frame) => revokeIfBlobUrl(frame.imageUrl));
+        frames.forEach((frame) => {
+          revokeIfBlobUrl(frame.imageUrl);
+        });
         nextPreviews.delete(nodeId);
       }
 
@@ -152,7 +154,9 @@ export const useNodeSamplerPreviewStore = create<NodeSamplerPreviewState>((set) 
       const frames = state.previewsByNode.get(normalizedNodeId);
       if (!frames || frames.length === 0) return state;
 
-      frames.forEach((frame) => revokeIfBlobUrl(frame.imageUrl));
+      frames.forEach((frame) => {
+        revokeIfBlobUrl(frame.imageUrl);
+      });
 
       const next = new Map(state.previewsByNode);
       next.delete(normalizedNodeId);
@@ -163,7 +167,9 @@ export const useNodeSamplerPreviewStore = create<NodeSamplerPreviewState>((set) 
   clearPreviews: () => {
     set((state) => {
       state.previewsByNode.forEach((frames) => {
-        frames.forEach((frame) => revokeIfBlobUrl(frame.imageUrl));
+        frames.forEach((frame) => {
+          revokeIfBlobUrl(frame.imageUrl);
+        });
       });
       return { previewsByNode: new Map() };
     });

--- a/src/ui/store/nodeSamplerPreviewStore.ts
+++ b/src/ui/store/nodeSamplerPreviewStore.ts
@@ -171,14 +171,16 @@ export const useNodeSamplerPreviewStore = create<NodeSamplerPreviewState>((set) 
 }));
 
 let listenersRegistered = false;
+let binaryImageListenerId: string | null = null;
+let executionStartedListenerId: string | null = null;
 
-const ensureNodeSamplerPreviewListeners = () => {
+export const initNodeSamplerPreviewListeners = () => {
   if (listenersRegistered) return;
   listenersRegistered = true;
 
   // Known-sampler-only mode:
   // associate latent preview frames only with the currently executing known sampler node.
-  globalWebSocketService.on('binary_image_received', (rawEvent: unknown) => {
+  binaryImageListenerId = globalWebSocketService.on('binary_image_received', (rawEvent: unknown) => {
     const event = asRecord(rawEvent);
     if (!event) return;
 
@@ -196,9 +198,22 @@ const ensureNodeSamplerPreviewListeners = () => {
     });
   });
 
-  globalWebSocketService.on('execution_started', () => {
+  executionStartedListenerId = globalWebSocketService.on('execution_started', () => {
     useNodeSamplerPreviewStore.getState().clearPreviews();
   });
 };
 
-ensureNodeSamplerPreviewListeners();
+export const disposeNodeSamplerPreviewListeners = () => {
+  if (!listenersRegistered) return;
+
+  if (binaryImageListenerId) {
+    globalWebSocketService.offById('binary_image_received', binaryImageListenerId);
+  }
+  if (executionStartedListenerId) {
+    globalWebSocketService.offById('execution_started', executionStartedListenerId);
+  }
+
+  binaryImageListenerId = null;
+  executionStartedListenerId = null;
+  listenersRegistered = false;
+};

--- a/src/ui/store/nodeSamplerPreviewStore.ts
+++ b/src/ui/store/nodeSamplerPreviewStore.ts
@@ -1,0 +1,204 @@
+import { create } from 'zustand';
+import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
+
+const DEFAULT_MAX_PREVIEWS_PER_NODE = 1;
+
+const KNOWN_SAMPLER_TYPE_TOKENS = [
+  'ksampler',
+  'samplercustomadvanced',
+  'samplercustom',
+  'ksampleradvanced'
+] as const;
+
+export interface SamplerPreviewFrame {
+  imageUrl: string;
+  nodeId: string;
+  timestamp: number;
+}
+
+export interface WorkflowNodeDescriptor {
+  id: string | number;
+  type?: string | null;
+  title?: string | null;
+}
+
+interface NodeSamplerPreviewState {
+  previewsByNode: Map<string, SamplerPreviewFrame[]>;
+  workflowNodeIds: Set<string>;
+  samplerNodeIds: Set<string>;
+  maxPreviewsPerNode: number;
+  registerWorkflowNodes: (nodes: WorkflowNodeDescriptor[]) => void;
+  setNodePreview: (params: {
+    blob: Blob;
+    nodeId: string | number;
+    timestamp: number;
+  }) => void;
+  clearNodePreviews: (nodeId: string | number) => void;
+  clearPreviews: () => void;
+}
+
+const normalizeNodeId = (value: unknown): string | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value !== 'string') return null;
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'unknown' || trimmed === 'null' || trimmed === 'undefined') {
+    return null;
+  }
+  return trimmed;
+};
+
+const normalizeToken = (value: string | null | undefined): string => {
+  if (!value) return '';
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+};
+
+export const isKnownSamplerNodeDescriptor = (node: WorkflowNodeDescriptor): boolean => {
+  const typeToken = normalizeToken(node.type || null);
+  const titleToken = normalizeToken(node.title || null);
+
+  return KNOWN_SAMPLER_TYPE_TOKENS.some((token) => {
+    return typeToken === token || typeToken.includes(token) || titleToken.includes(token);
+  });
+};
+
+const revokeIfBlobUrl = (url: string | null | undefined) => {
+  if (!url || !url.startsWith('blob:')) return;
+  try {
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.warn('[NodeSamplerPreviewStore] Failed to revoke blob URL:', error);
+  }
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object') return null;
+  return value as Record<string, unknown>;
+};
+
+export const useNodeSamplerPreviewStore = create<NodeSamplerPreviewState>((set) => ({
+  previewsByNode: new Map(),
+  workflowNodeIds: new Set(),
+  samplerNodeIds: new Set(),
+  maxPreviewsPerNode: DEFAULT_MAX_PREVIEWS_PER_NODE,
+
+  registerWorkflowNodes: (nodes) => {
+    set((state) => {
+      const workflowNodeIds = new Set<string>();
+      const samplerNodeIds = new Set<string>();
+
+      for (const node of nodes) {
+        const normalizedNodeId = normalizeNodeId(node.id);
+        if (!normalizedNodeId) continue;
+
+        workflowNodeIds.add(normalizedNodeId);
+        if (isKnownSamplerNodeDescriptor(node)) {
+          samplerNodeIds.add(normalizedNodeId);
+        }
+      }
+
+      const nextPreviews = new Map(state.previewsByNode);
+      for (const [nodeId, frames] of nextPreviews.entries()) {
+        if (workflowNodeIds.has(nodeId)) continue;
+        frames.forEach((frame) => revokeIfBlobUrl(frame.imageUrl));
+        nextPreviews.delete(nodeId);
+      }
+
+      return {
+        workflowNodeIds,
+        samplerNodeIds,
+        previewsByNode: nextPreviews
+      };
+    });
+  },
+
+  setNodePreview: ({ blob, nodeId, timestamp }) => {
+    const normalizedNodeId = normalizeNodeId(nodeId);
+    if (!normalizedNodeId) return;
+
+    set((state) => {
+      if (!state.samplerNodeIds.has(normalizedNodeId)) return state;
+      if (state.workflowNodeIds.size > 0 && !state.workflowNodeIds.has(normalizedNodeId)) return state;
+
+      const imageUrl = URL.createObjectURL(blob);
+      const existingFrames = state.previewsByNode.get(normalizedNodeId) || [];
+      const nextFrames = [
+        {
+          imageUrl,
+          nodeId: normalizedNodeId,
+          timestamp
+        } satisfies SamplerPreviewFrame,
+        ...existingFrames
+      ];
+
+      while (nextFrames.length > state.maxPreviewsPerNode) {
+        const removed = nextFrames.pop();
+        if (removed) revokeIfBlobUrl(removed.imageUrl);
+      }
+
+      const nextMap = new Map(state.previewsByNode);
+      nextMap.set(normalizedNodeId, nextFrames);
+      return { previewsByNode: nextMap };
+    });
+  },
+
+  clearNodePreviews: (nodeId) => {
+    const normalizedNodeId = normalizeNodeId(nodeId);
+    if (!normalizedNodeId) return;
+
+    set((state) => {
+      const frames = state.previewsByNode.get(normalizedNodeId);
+      if (!frames || frames.length === 0) return state;
+
+      frames.forEach((frame) => revokeIfBlobUrl(frame.imageUrl));
+
+      const next = new Map(state.previewsByNode);
+      next.delete(normalizedNodeId);
+      return { previewsByNode: next };
+    });
+  },
+
+  clearPreviews: () => {
+    set((state) => {
+      state.previewsByNode.forEach((frames) => {
+        frames.forEach((frame) => revokeIfBlobUrl(frame.imageUrl));
+      });
+      return { previewsByNode: new Map() };
+    });
+  }
+}));
+
+let listenersRegistered = false;
+
+const ensureNodeSamplerPreviewListeners = () => {
+  if (listenersRegistered) return;
+  listenersRegistered = true;
+
+  // Known-sampler-only mode:
+  // associate latent preview frames only with the currently executing known sampler node.
+  globalWebSocketService.on('binary_image_received', (rawEvent: unknown) => {
+    const event = asRecord(rawEvent);
+    if (!event) return;
+
+    const blob = event.blob instanceof Blob ? event.blob : null;
+    if (!blob || blob.size === 0) return;
+
+    const executionState = globalWebSocketService.getCurrentExecutionState();
+    const executingNodeId = normalizeNodeId(executionState.executingNodeId);
+    if (!executingNodeId) return;
+
+    useNodeSamplerPreviewStore.getState().setNodePreview({
+      blob,
+      nodeId: executingNodeId,
+      timestamp: typeof event.timestamp === 'number' ? event.timestamp : Date.now()
+    });
+  });
+
+  globalWebSocketService.on('execution_started', () => {
+    useNodeSamplerPreviewStore.getState().clearPreviews();
+  });
+};
+
+ensureNodeSamplerPreviewListeners();


### PR DESCRIPTION
This PR adds node-level preview support to comfy-mobile-ui.

Features:
• PreviewImage and SaveImage nodes now display their outputs directly in the workflow UI.
• Improved gallery loading performance
• Sampler latent previews are displayed within the node view in addition to the existing floating preview bar.

Implementation:
• Added nodeExecutionPreviewStore to track execution previews per node.
• Added nodeSamplerPreviewStore to track sampler latent previews. (Possibly also for future custom sampler integration)
• Updated GlobalWebSocketService to route preview data to node preview stores.
• Updated OutputsGallery and workflow components to render node previews.

Build status:
✓ npm run build passes
✓ Existing latent preview functionality preserved

Testing:
✓ Tested with KSampler and SamplerCustomAdvanced
✓ PreviewImage and SaveImage nodes render previews correctly
✓ Existing floating latent preview remains functional

I closed the previous PR to fix some coderabbit issues with Codex

Codex output: 
Verified against current code: all listed findings were still valid, and I fixed each one.

-Added empty-path guard before preview fetch in NodeDetailModal.tsx:1168 so onFilePreview is only called with a non-empty trimmed previewPath.
-Fixed LazyImage reuse visibility state in OutputsGallery.tsx:120 by re-enabling isInView when index < 12 on index changes.
Replaced hardcoded Showing {visible} / {total} with i18n interpolation in OutputsGallery.tsx:1212, and added gallery.showingVisible keys in:en/common.json:590,zh/common.json:587,ja/common.json:586,ko/common.json:590
-Added graph-change re-registration effect for sampler allowlist in WorkflowEditor.tsx:860.
-Added explicit sampler listener init/dispose usage in WorkflowEditor.tsx:851.
-Prevented compact runtime thumbnail overlap with execution indicator by adjusting compactX when intersection is detected in CanvasRendererService.ts:1664.
-Made reconnect scheduling idempotent in GlobalWebSocketService.ts:588 and routed onerror/onclose through scheduleReconnect (GlobalWebSocketService.ts:527, GlobalWebSocketService.ts:554).
-Fixed offById to remove the actual callback from event arrays (not just delete ID) in GlobalWebSocketService.ts:46.
-Removed duplicated NodeExecutionPreviewFile declarations and centralized to shared type:New sharedtype:NodeExecutionPreviewFile.ts:1,Store imports/re-exports shared type: nodeExecutionPreviewStore.ts:3,Renderer imports shared type: CanvasRendererService.ts:8
-Removed import-time sampler listener side effects and exposed explicit APIs in nodeSamplerPreviewStore.ts:177 and nodeSamplerPreviewStore.ts:206.

Validation run:

npx tsc --noEmit passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 노드 실행 미리보기 및 라이브(샘플러) 미리보기 UI 추가
  * 노드별 실행/샘플러 프레임을 수집하는 스토어 및 실시간 리스너 도입
  * 출력 갤러리에 배치형 무한 스크롤(지연 로딩) 추가

* **개선사항**
  * 이미지 미리보기 클릭 시 실행 미리보기 경로 처리 개선
  * 캔버스 렌더링에 실행 미리보기 통합 및 이미지 캐시·로드 개선
  * 웹소켓 재연결 흐름 및 실행 상태 추적 안정성 향상

* **지역화**
  * 갤러리 “Showing {{visible}} / {{total}}” 문구 추가(EN/JA/KO/ZH)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->