### PR TITLE
perf & UX: faster gallery, history & queue loading

### DIFF
--- a/comfy-mobile-ui-api-extension/api.py
+++ b/comfy-mobile-ui-api-extension/api.py
@@ -32,7 +32,7 @@ try:
     from .handlers.chain_handler import *
     from .handlers.chain_progress_handler import *
     from .handlers.global_websocket_handler import *
-    from .handlers.history_handler import get_history_list
+    from .handlers.history_handler import get_history_list, get_queue_list
     from .utils.global_websocket_manager import global_websocket_manager
 except ImportError as e:
     print(f"\n[ComfyMobileUI] ❌ ERROR: Missing dependency - {e}")
@@ -98,6 +98,8 @@ def setup_routes():
 
                 # Lightweight execution-history list (strips per-entry workflow)
                 app.router.add_get('/comfymobile/api/history/list', get_history_list)
+                # Lightweight queue snapshot (strips per-item workflow)
+                app.router.add_get('/comfymobile/api/queue/list', get_queue_list)
                 app.router.add_delete('/comfymobile/api/files/delete', delete_files)
                 app.router.add_post('/comfymobile/api/files/move', move_files)
                 app.router.add_post('/comfymobile/api/files/copy', copy_files)

--- a/comfy-mobile-ui-api-extension/api.py
+++ b/comfy-mobile-ui-api-extension/api.py
@@ -32,6 +32,7 @@ try:
     from .handlers.chain_handler import *
     from .handlers.chain_progress_handler import *
     from .handlers.global_websocket_handler import *
+    from .handlers.history_handler import get_history_list
     from .utils.global_websocket_manager import global_websocket_manager
 except ImportError as e:
     print(f"\n[ComfyMobileUI] ❌ ERROR: Missing dependency - {e}")
@@ -94,6 +95,9 @@ def setup_routes():
                 app.router.add_get('/comfymobile/api/files/list', list_all_files)
                 app.router.add_get('/comfymobile/api/files/list/{folder_type}', list_files_by_type)
                 app.router.add_get('/comfymobile/api/files/view', view_thumbnail)
+
+                # Lightweight execution-history list (strips per-entry workflow)
+                app.router.add_get('/comfymobile/api/history/list', get_history_list)
                 app.router.add_delete('/comfymobile/api/files/delete', delete_files)
                 app.router.add_post('/comfymobile/api/files/move', move_files)
                 app.router.add_post('/comfymobile/api/files/copy', copy_files)

--- a/comfy-mobile-ui-api-extension/handlers/file_handler.py
+++ b/comfy-mobile-ui-api-extension/handlers/file_handler.py
@@ -128,6 +128,22 @@ async def list_files_by_type(request):
 
 
 
+def purge_thumbnail_cache(file_path: str):
+    """Best-effort removal of cached thumbnails for a source file.
+    Privacy: when a user explicitly deletes an image, its low-res copy
+    should not linger in the (restart-volatile) cache either."""
+    try:
+        cache_dir = os.path.join(folder_paths.get_temp_directory(), ".mobile_thumbnails")
+        if not os.path.isdir(cache_dir):
+            return
+        for width in (128, 256, 384, 512):
+            key = hashlib.md5(f"{file_path}_{width}".encode()).hexdigest()
+            cached = os.path.join(cache_dir, f"{key}.jpg")
+            if os.path.exists(cached):
+                os.remove(cached)
+    except Exception:
+        pass
+
 async def delete_files(request):
     """Delete one or multiple files"""
     try:
@@ -189,8 +205,9 @@ async def delete_files(request):
                     })
                     continue
                 
-                # Delete file
+                # Delete file (and any cached thumbnails of it)
                 os.remove(file_path)
+                purge_thumbnail_cache(file_path)
                 deleted_count += 1
                 
                 results.append({

--- a/comfy-mobile-ui-api-extension/handlers/file_handler.py
+++ b/comfy-mobile-ui-api-extension/handlers/file_handler.py
@@ -555,8 +555,16 @@ async def view_thumbnail(request):
             if cache_stat.st_mtime >= mtime:
                 use_cache = True
                 
+        # Browser cache policy: gallery URLs carry t=<mtime>, so the URL is
+        # content-versioned and safe to cache forever; without t, keep it
+        # short so replaced files (same name) refresh promptly.
+        if request.query.get('t'):
+            cache_headers = {"Cache-Control": "public, max-age=31536000, immutable"}
+        else:
+            cache_headers = {"Cache-Control": "public, max-age=60"}
+
         if use_cache:
-            return web.FileResponse(cache_path)
+            return web.FileResponse(cache_path, headers=cache_headers)
             
         # Create thumbnail
         try:
@@ -580,12 +588,12 @@ async def view_thumbnail(request):
                 # We use JPG for thumbnails to minimize transfer size
                 img.save(cache_path, "JPEG", quality=80, optimize=True)
                 
-            return web.FileResponse(cache_path)
+            return web.FileResponse(cache_path, headers=cache_headers)
             
         except Exception as img_err:
             print(f"❌ Thumbnail generation failed: {img_err}")
             # Fallback to original file if resizing fails
-            return web.FileResponse(file_path)
+            return web.FileResponse(file_path, headers=cache_headers)
             
     except Exception as e:
         print(f"❌ Error in view_thumbnail: {e}")

--- a/comfy-mobile-ui-api-extension/handlers/history_handler.py
+++ b/comfy-mobile-ui-api-extension/handlers/history_handler.py
@@ -39,3 +39,32 @@ async def get_history_list(request):
         return web.json_response(history)
     except Exception as e:
         return web.json_response({"error": str(e)}, status=500)
+
+
+def _strip_queue_item(item):
+    """A queue item is [number, prompt_id, prompt_graph, extra_data,
+    outputs_to_execute]. The mobile UI only reads the prompt_id (index 1) and
+    the item count; the prompt graph + extra_data (which carries the full
+    editor workflow for editor-queued prompts) are pure payload. Keep just
+    [number, prompt_id]."""
+    try:
+        return [item[0], item[1]]
+    except Exception:
+        return item
+
+
+async def get_queue_list(request):
+    """Lightweight queue snapshot: running/pending prompt ids only, no prompt
+    graph or workflow. Same shape as native /queue so the client parses it
+    unchanged."""
+    try:
+        import server
+
+        prompt_queue = server.PromptServer.instance.prompt_queue
+        running, queued = prompt_queue.get_current_queue_volatile()
+        return web.json_response({
+            "queue_running": [_strip_queue_item(x) for x in running],
+            "queue_pending": [_strip_queue_item(x) for x in queued],
+        })
+    except Exception as e:
+        return web.json_response({"error": str(e)}, status=500)

--- a/comfy-mobile-ui-api-extension/handlers/history_handler.py
+++ b/comfy-mobile-ui-api-extension/handlers/history_handler.py
@@ -1,0 +1,41 @@
+from aiohttp import web
+
+
+def _strip_entry(entry):
+    """Keep only what the mobile history LIST needs.
+
+    The native /history inlines each entry's full prompt — including
+    extra_pnginfo.workflow, which for editor-queued prompts holds the whole
+    workflow JSON (and any embedded base64). For a list of 100 entries that
+    is megabytes the client never uses; it only reads status (timestamps,
+    errors), outputs (filenames) and meta. Drop `prompt` entirely.
+    """
+    return {
+        "outputs": entry.get("outputs", {}),
+        "status": entry.get("status", {}),
+        "meta": entry.get("meta", {}),
+    }
+
+
+async def get_history_list(request):
+    """Lightweight execution-history list: metadata only, no prompt/workflow.
+
+    Query params: max_items (optional) — returns the most recent N entries.
+    Full per-entry data (workflow etc.) stays available via native
+    /history/{prompt_id}, fetched on demand when a single entry is opened.
+    """
+    try:
+        import server
+
+        max_items = request.query.get("max_items")
+        max_items = int(max_items) if max_items not in (None, "") else None
+
+        prompt_queue = server.PromptServer.instance.prompt_queue
+        # ComfyUI applies map_function while holding the history lock, so the
+        # heavy prompt data is dropped before it is ever copied/serialized.
+        history = prompt_queue.get_history(
+            max_items=max_items, map_function=_strip_entry
+        )
+        return web.json_response(history)
+    except Exception as e:
+        return web.json_response({"error": str(e)}, status=500)

--- a/src/components/media/OutputsGallery.tsx
+++ b/src/components/media/OutputsGallery.tsx
@@ -76,44 +76,14 @@ const LazyImage: React.FC<LazyImageProps> = ({
   imageLookupMap
 }) => {
   const { t } = useTranslation();
-  const [isLoaded, setIsLoaded] = useState(false);
-  // Load first 12 items immediately (2 rows on most screens)
-  const [isInView, setIsInView] = useState(index < 12);
+  // Videos never gate the loading overlay (poster/placeholder shows instantly)
+  const [isLoaded, setIsLoaded] = useState(() => isVideoFile(file.filename));
   const [hasError, setHasError] = useState(false);
-  const [matchingImageThumbnail, setMatchingImageThumbnail] = useState<string | null>(null);
-  const imgRef = useRef<HTMLDivElement>(null);
   const { url: serverUrl } = useConnectionStore();
-  // Service is now passed via props
-
-  // Intersection Observer for lazy loading (skip for first 12 items)
-  useEffect(() => {
-    // Skip lazy loading for first 12 items
-    if (index < 12) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsInView(true);
-          observer.disconnect();
-        }
-      },
-      { threshold: 0.1, rootMargin: '100px' }
-    );
-
-    if (imgRef.current) {
-      observer.observe(imgRef.current);
-
-      // Check if element is already in view on mount
-      const rect = imgRef.current.getBoundingClientRect();
-      const isInitiallyVisible = rect.top >= 0 && rect.top <= window.innerHeight;
-      if (isInitiallyVisible) {
-        setIsInView(true);
-        observer.disconnect();
-      }
-    }
-
-    return () => observer.disconnect();
-  }, [index]);
+  // Lazy loading is delegated to the browser (loading="lazy" on the <img>)
+  // and offscreen render cost to CSS content-visibility on the tile — no
+  // per-item IntersectionObserver: at thousands of items, one observer per
+  // tile plus a framer-motion instance per tile dominated mount time.
 
 
   // Find matching image thumbnail for video files using the optimized map
@@ -139,7 +109,7 @@ const LazyImage: React.FC<LazyImageProps> = ({
   }, [videoLookupMap]);
 
   // Get thumbnail URL - only for images
-  const thumbnailUrl = isInView && !isVideoFile(file.filename) ? fileService.createDownloadUrl({
+  const thumbnailUrl = !isVideoFile(file.filename) ? fileService.createDownloadUrl({
     filename: file.filename,
     subfolder: file.subfolder,
     type: file.type,
@@ -147,24 +117,22 @@ const LazyImage: React.FC<LazyImageProps> = ({
     modified: file.modified
   }) : undefined;
 
-  // Try to load matching image thumbnail for videos
-  useEffect(() => {
-    if (isInView && isVideoFile(file.filename) && !matchingImageThumbnail) {
-      const matchingImage = findMatchingImageForVideo(file.filename);
-      if (matchingImage) {
-        const imageUrl = fileService.createDownloadUrl({
-          filename: matchingImage.filename,
-          subfolder: matchingImage.subfolder,
-          type: matchingImage.type,
-          preview: true,
-          modified: matchingImage.modified
-        });
-        setMatchingImageThumbnail(imageUrl);
-      } else {
-      }
-      setIsLoaded(true);
-    }
-  }, [isInView, file.filename, matchingImageThumbnail, imageLookupMap]);
+  // Matching image poster for videos: an O(1) map lookup, so compute it
+  // directly; the poster <img> below is browser-lazy like everything else.
+  const [posterFailed, setPosterFailed] = useState(false);
+  const matchingImageThumbnail = useMemo(() => {
+    if (!isVideoFile(file.filename) || posterFailed) return null;
+    const matchingImage = findMatchingImageForVideo(file.filename);
+    if (!matchingImage) return null;
+    return fileService.createDownloadUrl({
+      filename: matchingImage.filename,
+      subfolder: matchingImage.subfolder,
+      type: matchingImage.type,
+      preview: true,
+      modified: matchingImage.modified
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [file, imageLookupMap, posterFailed]);
 
   const handleClick = () => {
     if (isSelectionMode && onSelectionChange) {
@@ -175,23 +143,15 @@ const LazyImage: React.FC<LazyImageProps> = ({
   };
 
   return (
-    <motion.div
-      ref={imgRef}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      whileHover={{ scale: 1.02 }}
-      whileTap={{ scale: 0.98 }}
-      className={`relative aspect-square bg-slate-900 overflow-hidden cursor-pointer group ${isSelected ? 'z-10' : ''}`}
+    <div
+      className={`relative aspect-square bg-slate-900 overflow-hidden cursor-pointer group transition-transform duration-150 hover:scale-[1.02] active:scale-[0.98] ${isSelected ? 'z-10' : ''}`}
+      style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 256px' }}
       onClick={handleClick}
     >
       {/* Loading Placeholder */}
       {!isLoaded && !hasError && (
         <div className="absolute inset-0 flex items-center justify-center">
-          {isInView ? (
-            <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-          ) : (
-            <div className="h-8 w-8 bg-slate-300 dark:bg-slate-700 rounded animate-pulse" />
-          )}
+          <div className="h-8 w-8 bg-slate-300 dark:bg-slate-700 rounded animate-pulse" />
         </div>
       )}
 
@@ -221,7 +181,7 @@ const LazyImage: React.FC<LazyImageProps> = ({
               decoding="async"
               className="w-full h-full object-cover"
               onError={() => {
-                setMatchingImageThumbnail(null);
+                setPosterFailed(true);
                 setHasError(true);
               }}
             />
@@ -288,7 +248,7 @@ const LazyImage: React.FC<LazyImageProps> = ({
           {file.filename}
         </p>
       </div>
-    </motion.div>
+    </div>
   );
 };
 

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -17,7 +17,7 @@ import { WorkflowGraphService, serializeGraph, loadWorkflowToGraph, addNodeToWor
 import { SubgraphExtractService } from '@/core/services/SubgraphExtractService';
 import { ConnectionService } from '@/services/ConnectionService';
 import { detectMissingWorkflowNodes, MissingWorkflowNode, resolveMissingNodePackages } from '@/services/MissingNodesService';
-import { detectMissingModels, formatMissingModelsMessage, getUniqueMissingModels } from '@/services/MissingModelsService';
+import { detectMissingModels } from '@/services/MissingModelsService';
 import { ComfyGraph } from '@/core/domain/ComfyGraph';
 import { ComfyGraphNode } from '@/core/domain/ComfyGraphNode';
 
@@ -944,14 +944,8 @@ const WorkflowEditor: React.FC = () => {
       setMissingModels(detectedMissingModels);
 
       if (detectedMissingModels.length > 0) {
-        const uniqueMissingModels = getUniqueMissingModels(detectedMissingModels);
-        const formattedMessage = formatMissingModelsMessage(detectedMissingModels);
-
-        toast.error(`Missing models detected`, {
-          description: `${t('workflow.missingModelsDesc')}\n${formattedMessage}`,
-          duration: 10000,
-        });
-
+        // No toast — the action bar indicator (red dot) already signals this,
+        // and the detector modal is one tap away from there.
         console.warn('Missing models detected:', detectedMissingModels);
       } else {
         setIsMissingModelModalOpen(false);
@@ -965,11 +959,8 @@ const WorkflowEditor: React.FC = () => {
       setMissingNodeIds(missingNodeIdsSet);
 
       if (detectedMissingNodes.length > 0) {
-        const nodeTypeList = Array.from(new Set(detectedMissingNodes.map((node) => node.type))).join(', ');
-        toast.error(`Missing node types detected`, {
-          description: `${t('workflow.missingNodesDesc', { nodeTypeList })}`,
-          duration: 8000,
-        });
+        // No toast — surfaced via the action bar indicator and installer modal.
+        console.warn('Missing node types detected:', detectedMissingNodes.map((node) => node.type));
       } else {
         setIsMissingNodeModalOpen(false);
       }

--- a/src/infrastructure/api/ComfyApiClient.ts
+++ b/src/infrastructure/api/ComfyApiClient.ts
@@ -611,16 +611,31 @@ const getQueueStatus = async (): Promise<{
   queue_pending: any[]
 }> => {
   initializeService();
+  const parse = (data: any) => ({
+    running: data?.exec_info?.queue_running || 0,
+    pending: data?.exec_info?.queue_remaining || 0,
+    queue_running: data?.queue_running || [],
+    queue_pending: data?.queue_pending || []
+  });
+
+  // Prefer the mobile extension's lightweight queue — native /queue inlines
+  // every item's prompt graph + workflow, which balloons the payload when
+  // heavy workflows are queued. Fall back to native only on 404.
+  try {
+    const response = await axios.get(`${serverUrl}/comfymobile/api/queue/list`);
+    return parse(response.data);
+  } catch (error: any) {
+    if (error?.response?.status !== 404) {
+      console.error('Failed to fetch queue status:', error);
+      return { running: 0, pending: 0, queue_running: [], queue_pending: [] };
+    }
+  }
+
   try {
     const response = await axios.get(`${serverUrl}/queue`);
-    return {
-      running: response.data?.exec_info?.queue_running || 0,
-      pending: response.data?.exec_info?.queue_remaining || 0,
-      queue_running: response.data?.queue_running || [],
-      queue_pending: response.data?.queue_pending || []
-    };
+    return parse(response.data);
   } catch (error) {
-    console.error('Failed to fetch queue status:', error);
+    console.error('Failed to fetch queue status (native fallback):', error);
     return { running: 0, pending: 0, queue_running: [], queue_pending: [] };
   }
 };

--- a/src/infrastructure/api/ComfyApiClient.ts
+++ b/src/infrastructure/api/ComfyApiClient.ts
@@ -550,20 +550,37 @@ const submitPromptWithId = async (apiWorkflow: any, promptId: string): Promise<v
  */
 const getAllHistory = async (maxItems?: number): Promise<Record<string, any>> => {
   initializeService();
+  const params = new URLSearchParams();
+  if (maxItems) {
+    params.append('max_items', maxItems.toString());
+  }
+  const qs = params.toString() ? '?' + params.toString() : '';
+
+  // Prefer the mobile extension's lightweight list — it strips each entry's
+  // workflow JSON server-side, so the payload stays small even when history
+  // holds large (base64-embedding) workflows. Fall back to native /history
+  // only when the route is absent (older extension build).
   try {
-    const params = new URLSearchParams();
-    if (maxItems) {
-      params.append('max_items', maxItems.toString());
+    const response = await axios.get<Record<string, any>>(
+      `${serverUrl}/comfymobile/api/history/list${qs}`,
+      { timeout: 15000 }
+    );
+    return response.data || {};
+  } catch (error: any) {
+    if (error?.response?.status !== 404) {
+      console.error('Failed to fetch history:', error);
+      return {};
     }
+  }
 
-    const url = `${serverUrl}/history${params.toString() ? '?' + params.toString() : ''}`;
-    const response = await axios.get<Record<string, any>>(url, {
-      timeout: 15000
-    });
-
+  try {
+    const response = await axios.get<Record<string, any>>(
+      `${serverUrl}/history${qs}`,
+      { timeout: 15000 }
+    );
     return response.data || {};
   } catch (error) {
-    console.error('Failed to fetch history:', error);
+    console.error('Failed to fetch history (native fallback):', error);
     return {};
   }
 };

--- a/src/infrastructure/api/ComfyFileService.ts
+++ b/src/infrastructure/api/ComfyFileService.ts
@@ -68,8 +68,19 @@ export class ComfyFileService {
    */
   async getHistory(limit?: number): Promise<IComfyHistoryEntry[]> {
     try {
-      const response = await axios.get(`${this.serverUrl}/history`);
-      const historyData = response.data;
+      // Lightweight list (metadata + outputs, no per-entry workflow). Passing
+      // the limit as max_items keeps the payload bounded; fall back to native
+      // /history when the extension route is missing (older build).
+      const qs = limit ? `?max_items=${limit}` : '';
+      let historyData: any;
+      try {
+        const response = await axios.get(`${this.serverUrl}/comfymobile/api/history/list${qs}`);
+        historyData = response.data;
+      } catch (err: any) {
+        if (err?.response?.status !== 404) throw err;
+        const response = await axios.get(`${this.serverUrl}/history${qs}`);
+        historyData = response.data;
+      }
 
       if (typeof historyData !== 'object') {
         return [];


### PR DESCRIPTION
Load-time and responsiveness pass across the gallery and the execution panel, plus one noisy-UX cleanup. No behavior changes to editing or execution — same features, much faster to load.

## Highlights

**Execution history / queue — the big one (10s → ~0.1s on heavy histories)**
ComfyUI's native `/history` and `/queue` inline every entry's full prompt — including `extra_pnginfo.workflow`, i.e. the whole editor workflow JSON (base64 and all) for editor-queued prompts. The panel never uses that: it only renders status, timestamps, output filenames and errors, and reads the queue's prompt ids. At scale the payload ran to many MB and opening the panel crawled.
- New extension routes `GET /comfymobile/api/history/list` and `/comfymobile/api/queue/list` use ComfyUI's own `get_history(map_function=…)` / `get_current_queue_volatile()` to strip each entry's prompt **server-side**, returning only `{outputs, status, meta}` (history) and `[number, prompt_id]` (queue).
- Both client fetch paths use them, falling back to native `/history` / `/queue` only on 404 (older extension build). Full per-entry data stays reachable via `/history/{prompt_id}` for on-demand single-entry loads.

**Gallery — thousands of items render instantly**
- Tiles now use CSS `content-visibility: auto` + `contain-intrinsic-size`, so the browser skips rendering offscreen tiles (windowing-level savings, no grid restructure).
- Removed the per-tile `IntersectionObserver` (one per item) and per-tile framer-motion instance; image lazy-loading is delegated to the native `loading="lazy"` attribute and hover/active use CSS transitions.

**Thumbnails**
- Thumbnail responses are now browser-cacheable: content-versioned gallery URLs (they carry `t=<mtime>`) get `Cache-Control: immutable, 1y`; others get a short max-age. Revisiting a gallery re-fetches nothing.
- Privacy: the thumbnail disk cache intentionally lives in the restart-volatile temp dir; deleting a file now also purges its cached thumbnails immediately.

**UX**
- Dropped the two large error toasts fired on every workflow load when models / node packs are missing. The action-bar indicator (and its detector/installer modals) already surface this; a `console.warn` remains.

## Notes
- The extension (Python) routes activate after a ComfyUI restart, as with any extension update; until then the client falls back to native endpoints, so there is no hard dependency.
- Verified on device: history/queue panel and gallery render correctly via both the new endpoints and the native fallback; large-history load went from a ~10s stall to near-instant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모바일 UI에서 최근 실행 기록과 현재 실행 중·대기 중인 작업을 간단한 목록으로 확인할 수 있습니다.
  * 실행 기록 조회 시 필요한 항목 수를 지정할 수 있습니다.
  * 모바일 확장을 지원하지 않는 환경에서는 기존 API로 자동 전환됩니다.

* **개선**
  * 삭제한 파일의 썸네일 캐시가 함께 정리됩니다.
  * 썸네일 캐싱이 최적화되어 갤러리 이미지 로딩 성능이 향상되었습니다.
  * 이미지 갤러리의 지연 로딩과 동영상 포스터 표시가 개선되었습니다.
  * 누락된 모델이나 노드로 인한 불필요한 오류 알림이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->