### PR TITLE
feat: live history panel updates + unseen-completion indicator

### DIFF
--- a/src/components/controls/FloatingControlsPanel.tsx
+++ b/src/components/controls/FloatingControlsPanel.tsx
@@ -151,7 +151,41 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
   }, [isSettingsOpen, isSearchOpen, isConsoleOpen, isHistoryOpen, windowHeight]);
   const navigate = useNavigate();
   const { openPromptHistory } = usePromptHistoryStore();
+  const hasUnseenCompletion = usePromptHistoryStore((s) => s.hasUnseenCompletion);
+  const setPanelOpen = usePromptHistoryStore((s) => s.setPanelOpen);
+  const markWatched = usePromptHistoryStore((s) => s.markWatched);
+  const handleCompletion = usePromptHistoryStore((s) => s.handleCompletion);
   const { id } = useParams<{ id: string }>();
+
+  // Action-bar clock indicator: show a dot only for a run that finished while
+  // the history panel was CLOSED and the user hasn't looked since.
+  // - The panel's open state lives in the store so the (mount-once) completion
+  //   handler reads it live: a run that finishes while the panel is open never
+  //   raises the dot, and opening the panel clears it.
+  // - While the panel is open we record the executing prompt id as "watched",
+  //   so if that run's completion event lands just after the panel closes it is
+  //   still treated as seen. This is the exact case the user hit: watch a run
+  //   finish with the panel open, close it, and the trailing event must not
+  //   light the dot.
+  useEffect(() => {
+    setPanelOpen(isHistoryOpen);
+    return () => setPanelOpen(false);
+  }, [isHistoryOpen, setPanelOpen]);
+  const isHistoryOpenRef = useRef(isHistoryOpen);
+  isHistoryOpenRef.current = isHistoryOpen;
+  useEffect(() => {
+    const onFinished = (event: any) => handleCompletion(event?.data?.prompt_id ?? null);
+    const onWatch = (event: any) => {
+      if (isHistoryOpenRef.current) markWatched(event?.data?.prompt_id ?? null);
+    };
+    const subs = [
+      ['execution_success', globalWebSocketService.on('execution_success', onFinished)],
+      ['execution_error', globalWebSocketService.on('execution_error', onFinished)],
+      ['execution_start', globalWebSocketService.on('execution_start', onWatch)],
+      ['executing', globalWebSocketService.on('executing', onWatch)],
+    ];
+    return () => subs.forEach(([evt, id]) => globalWebSocketService.offById(evt, id));
+  }, [handleCompletion, markWatched]);
   const { url: serverUrl } = useConnectionStore();
   const { t } = useTranslation();
 
@@ -601,6 +635,9 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
             >
               <Clock className="h-4 w-4" />
             </Button>
+            {hasUnseenCompletion && !isHistoryOpen && (
+              <span className="pointer-events-none absolute top-1 right-1 h-2.5 w-2.5 rounded-full bg-red-500 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9)] dark:shadow-[0_0_0_1.5px_rgba(15,23,42,0.8)] animate-pulse" />
+            )}
           </div>
 
           {/* Divider */}

--- a/src/components/history/PromptHistory.tsx
+++ b/src/components/history/PromptHistory.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { X, Clock, CheckCircle, XCircle, AlertTriangle, Loader2, RefreshCw, Eye, Image as ImageIcon, Video, FileText, Layers, ChevronDown } from 'lucide-react';
 import ComfyUIService from '@/infrastructure/api/ComfyApiClient';
 import { usePromptHistoryStore } from '@/ui/store/promptHistoryStore';
+import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
 import { FilePreviewModal } from '@/components/modals/FilePreviewModal';
 import { JsonViewerModal } from '@/components/modals/JsonViewerModal';
 import { useConnectionStore } from '@/ui/store/connectionStore';
@@ -285,6 +286,35 @@ export const PromptHistoryContent: React.FC<{
       loadOutputHistory();
     }
   }, [activeTab]);
+
+  // Live updates: while the panel is open, refresh when the server reports a
+  // finished run or a queue change, so a completed prompt moves from queue to
+  // history (and new pending items appear) without a manual refresh tap.
+  // Refs keep the WS subscription stable while always calling the latest
+  // fetchers for the active tab.
+  const activeTabRef = useRef(activeTab);
+  activeTabRef.current = activeTab;
+  const refetchRef = useRef<() => void>(() => {});
+  refetchRef.current = () => {
+    if (activeTabRef.current === 'queues') {
+      fetchHistory();
+    } else {
+      loadOutputHistory();
+    }
+  };
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const schedule = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => refetchRef.current(), 500);
+    };
+    const events = ['execution_success', 'execution_error', 'status'];
+    const ids = events.map((evt) => [evt, globalWebSocketService.on(evt, schedule)] as const);
+    return () => {
+      if (timer) clearTimeout(timer);
+      ids.forEach(([evt, id]) => globalWebSocketService.offById(evt, id));
+    };
+  }, []);
 
   const fetchHistory = async () => {
     setIsLoading(true);

--- a/src/ui/store/promptHistoryStore.ts
+++ b/src/ui/store/promptHistoryStore.ts
@@ -4,10 +4,47 @@ interface PromptHistoryStore {
   isOpen: boolean;
   openPromptHistory: () => void;
   closePromptHistory: () => void;
+
+  // ---- Action-bar "unseen completion" indicator ----
+  // The dot must appear ONLY for a run that finished while the panel was
+  // closed and the user hasn't looked since. The tricky case: the user
+  // watches a run finish with the panel open, then closes it — and the
+  // run's execution_success can land just AFTER the close. A plain
+  // open/closed check flags that as unseen. So we also remember the prompt
+  // id the panel was showing while open ("watched"); a completion for a
+  // watched run never raises the dot, even if its event arrives late.
+  hasUnseenCompletion: boolean;
+  /** True while a history panel (embedded dropdown) is mounted/open. */
+  panelOpen: boolean;
+  /** Prompt id most recently seen executing while a panel was open. */
+  watchedPromptId: string | null;
+
+  setPanelOpen: (open: boolean) => void;
+  markWatched: (promptId: string | null | undefined) => void;
+  handleCompletion: (promptId: string | null | undefined) => void;
 }
 
 export const usePromptHistoryStore = create<PromptHistoryStore>((set) => ({
   isOpen: false,
   openPromptHistory: () => set({ isOpen: true }),
   closePromptHistory: () => set({ isOpen: false }),
+
+  hasUnseenCompletion: false,
+  panelOpen: false,
+  watchedPromptId: null,
+
+  setPanelOpen: (open) =>
+    set(open ? { panelOpen: true, hasUnseenCompletion: false } : { panelOpen: false }),
+
+  markWatched: (promptId) => {
+    if (promptId) set({ watchedPromptId: promptId });
+  },
+
+  handleCompletion: (promptId) =>
+    set((s) => {
+      // Seen if the panel is open now, or if this is the run the panel was
+      // showing while open (its completion just arrived late).
+      const seen = s.panelOpen || (!!promptId && promptId === s.watchedPromptId);
+      return seen ? {} : { hasUnseenCompletion: true };
+    }),
 }));


### PR DESCRIPTION
Makes the execution history/queue panel update itself, and adds an action-bar cue for runs that finish while you're not looking. Both ride the global WebSocket — no new polling.

## Highlights

**Live panel updates (no manual refresh)**
While the history & queue panel is open, it subscribes to `execution_success` / `execution_error` / `status` over the global WebSocket and refetches the active tab (debounced 500ms). A finished prompt moves from **queue → history** and newly queued items appear on their own — no more tapping refresh and waiting.

**Action-bar "unseen completion" dot**
The clock icon shows a blinking red dot (mirroring the gear's missing-model dot) when a run finishes while the panel is **closed** and you haven't looked since. Opening the panel clears it.

The tricky part is that the dot must fire *only* while closed. A naive open/closed check breaks in one case: watch a run finish with the panel open, then close it — the run's `execution_success` can land just **after** the close and light the dot for something you already saw. So the store tracks two things instead of a single open/closed flag:
- `panelOpen` — read live by the completion handler, so a run that finishes while open never raises the dot.
- `watchedPromptId` — the prompt id seen executing while the panel was open. A completion for a watched run is treated as seen even if its event arrives late.

A run is "unseen" only when it finishes while the panel is closed **and** was never watched. New closed-state runs still raise the dot normally (the watched id doesn't leak forward).

## Files
- `src/ui/store/promptHistoryStore.ts` — `panelOpen` / `watchedPromptId` state + `setPanelOpen` / `markWatched` / `handleCompletion`.
- `src/components/controls/FloatingControlsPanel.tsx` — syncs panel open-state, subscribes to WS completion/execution events, renders the dot.
- `src/components/history/PromptHistory.tsx` — the open-panel live refetch subscription.

## Verification
Tested on device against a real ComfyUI run (events driven by actual executions):
- closed → run completes → **dot appears**
- open panel → **dot clears**, and the panel auto-refreshes the new entry into view
- watch a run finish with the panel **open**, then close → **no dot** (the reported bug)
- a fresh run completed while closed afterward → **dot appears** again (no watched-id leak)

`tsc --noEmit` clean. No new dependencies; unchanged when no WebSocket events arrive.
