### PR TITLE
feat: folder-move destination picker, multi-select, and a labeled list toolbar

### DIFF
--- a/src/components/workflow/FolderDetailModal.tsx
+++ b/src/components/workflow/FolderDetailModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, Folder, FileText, Trash2, AlertTriangle } from 'lucide-react';
+import { X, Folder, FileText, Trash2, AlertTriangle, FolderInput } from 'lucide-react';
 import { FolderItem, FolderStructure } from '@/types/folder';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -14,6 +14,7 @@ interface FolderDetailModalProps {
     allWorkflows: Workflow[];
     onClose: () => void;
     onDelete: (folderId: string) => void;
+    onMove?: (folder: FolderItem) => void;
 }
 
 const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
@@ -23,6 +24,7 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
     allWorkflows,
     onClose,
     onDelete,
+    onMove,
 }) => {
     const { t } = useTranslation();
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -202,11 +204,21 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
                                 </div>
 
                                 {/* Footer */}
-                                <div className="relative z-10 px-6 py-4 border-t border-white/10 dark:border-slate-600/10 bg-white/30 dark:bg-slate-900/30 backdrop-blur-xl">
+                                <div className="relative z-10 px-6 py-4 border-t border-white/10 dark:border-slate-600/10 bg-white/30 dark:bg-slate-900/30 backdrop-blur-xl flex gap-3">
+                                    {onMove && (
+                                        <Button
+                                            onClick={() => onMove(folder)}
+                                            variant="ghost"
+                                            className="flex-1 py-3 rounded-2xl bg-blue-500/10 border border-blue-400/30 text-blue-600 dark:text-blue-400 hover:bg-blue-500/20 hover:text-blue-700 dark:hover:text-blue-300 flex items-center justify-center gap-2"
+                                        >
+                                            <FolderInput className="w-5 h-5" />
+                                            {t('folder.moveTitle')}
+                                        </Button>
+                                    )}
                                     <Button
                                         onClick={handleDeleteClick}
                                         variant="ghost"
-                                        className="w-full py-3 rounded-2xl bg-red-500/10 border border-red-400/30 text-red-600 dark:text-red-400 hover:bg-red-500/20 hover:text-red-700 dark:hover:text-red-300 flex items-center justify-center gap-2"
+                                        className="flex-1 py-3 rounded-2xl bg-red-500/10 border border-red-400/30 text-red-600 dark:text-red-400 hover:bg-red-500/20 hover:text-red-700 dark:hover:text-red-300 flex items-center justify-center gap-2"
                                     >
                                         <Trash2 className="w-5 h-5" />
                                         {t('folder.deleteFolder')}

--- a/src/components/workflow/FolderGridItem.tsx
+++ b/src/components/workflow/FolderGridItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Folder, ChevronRight } from 'lucide-react';
+import { Folder, ChevronRight, Check } from 'lucide-react';
 import { FolderItem } from '@/types/folder';
 import { useLongPress } from '@/hooks/useLongPress';
 
@@ -9,6 +9,7 @@ interface FolderGridItemProps {
   onClick: () => void;
   onLongPress: () => void;
   isSelected?: boolean;
+  selectionMode?: boolean;
   workflowCount?: number;
 }
 
@@ -17,6 +18,7 @@ const FolderGridItem: React.FC<FolderGridItemProps> = ({
   onClick,
   onLongPress,
   isSelected = false,
+  selectionMode = false,
   workflowCount = 0,
 }) => {
   const { t } = useTranslation();
@@ -57,8 +59,19 @@ const FolderGridItem: React.FC<FolderGridItemProps> = ({
           </div>
         </div>
 
-        {/* Arrow Icon */}
-        <ChevronRight className="w-4 h-4 text-slate-600 group-hover:text-slate-400 transition-colors flex-shrink-0" />
+        {/* Selection checkbox / Arrow Icon */}
+        {selectionMode ? (
+          <div
+            className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center border-2 transition-colors ${isSelected
+              ? 'bg-blue-500 border-blue-500 text-white'
+              : 'bg-transparent border-slate-500 text-transparent'
+              }`}
+          >
+            <Check className="w-3.5 h-3.5" />
+          </div>
+        ) : (
+          <ChevronRight className="w-4 h-4 text-slate-600 group-hover:text-slate-400 transition-colors flex-shrink-0" />
+        )}
       </div>
 
       {/* Hover Gradient Overlay */}

--- a/src/components/workflow/MoveToFolderSheet.tsx
+++ b/src/components/workflow/MoveToFolderSheet.tsx
@@ -1,0 +1,308 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  X,
+  Home,
+  Folder,
+  FolderPlus,
+  ChevronRight,
+  CornerLeftUp,
+  Check,
+  FileText,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { FolderStructure } from '@/types/folder';
+
+export interface MoveItem {
+  id: string;
+  type: 'workflow' | 'folder';
+  /** Folder the item currently lives in (null = root). */
+  sourceFolderId: string | null;
+}
+
+interface MoveToFolderSheetProps {
+  isOpen: boolean;
+  items: MoveItem[];
+  /** Name to show in the header chip when moving a single item. */
+  itemLabel?: string;
+  folderStructure: FolderStructure;
+  onClose: () => void;
+  onConfirm: (targetFolderId: string | null) => void;
+  onCreateFolder: (name: string, parentId: string | null) => string;
+}
+
+/**
+ * Destination picker for moving workflows / folders. Instead of "carrying" an
+ * item and tapping a target (which can't reach nested or cross-branch folders),
+ * the user browses the folder tree here and taps "move here" at any level.
+ * Folders being moved (and their descendants) are disabled as targets.
+ */
+const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
+  isOpen,
+  items,
+  itemLabel,
+  folderStructure,
+  onClose,
+  onConfirm,
+  onCreateFolder,
+}) => {
+  const { t } = useTranslation();
+  const [pickerFolderId, setPickerFolderId] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+
+  // Start each open at Home so the destination choice is predictable.
+  useEffect(() => {
+    if (isOpen) {
+      setPickerFolderId(null);
+      setIsCreating(false);
+      setNewName('');
+    }
+  }, [isOpen]);
+
+  // A folder can't be moved into itself or any of its descendants.
+  const blockedIds = useMemo(() => {
+    const blocked = new Set<string>();
+    const addSubtree = (id: string) => {
+      if (blocked.has(id)) return;
+      blocked.add(id);
+      folderStructure.folders[id]?.children.forEach(addSubtree);
+    };
+    items.filter((i) => i.type === 'folder').forEach((i) => addSubtree(i.id));
+    return blocked;
+  }, [items, folderStructure]);
+
+  const sourceIds = useMemo(
+    () => new Set(items.map((i) => i.sourceFolderId)),
+    [items]
+  );
+
+  const childFolders = useMemo(() => {
+    const ids = pickerFolderId
+      ? folderStructure.folders[pickerFolderId]?.children || []
+      : folderStructure.rootFolders;
+    return ids
+      .map((id) => folderStructure.folders[id])
+      .filter(Boolean)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [pickerFolderId, folderStructure]);
+
+  const crumbs = useMemo(() => {
+    const path: { id: string | null; name: string }[] = [];
+    let curr = pickerFolderId;
+    while (curr) {
+      const f = folderStructure.folders[curr];
+      if (!f) break;
+      path.unshift({ id: curr, name: f.name });
+      curr = f.parentId;
+    }
+    return [{ id: null, name: t('folder.home') }, ...path];
+  }, [pickerFolderId, folderStructure, t]);
+
+  // Moving to the folder the items already live in is a no-op.
+  const allAlreadyHere = items.length > 0 && items.every((it) => it.sourceFolderId === pickerFolderId);
+  const currentFolderName = pickerFolderId ? folderStructure.folders[pickerFolderId]?.name : null;
+
+  const handleCreate = () => {
+    const name = newName.trim();
+    if (!name) return;
+    const newId = onCreateFolder(name, pickerFolderId);
+    setNewName('');
+    setIsCreating(false);
+    setPickerFolderId(newId);
+  };
+
+  const chipText =
+    items.length === 1 && itemLabel ? itemLabel : t('folder.movingItems', { count: items.length });
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="fixed inset-0 z-[10000] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm sm:px-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) onClose();
+          }}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 40, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 40, scale: 0.98 }}
+            transition={{ duration: 0.22, ease: 'easeOut' }}
+            className="relative w-full sm:max-w-md max-h-[82vh] flex flex-col bg-white/95 dark:bg-slate-900/95 backdrop-blur-3xl rounded-t-3xl sm:rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Grabber */}
+            <div className="sm:hidden pt-2 flex justify-center">
+              <div className="w-9 h-1 rounded-full bg-slate-300 dark:bg-slate-600" />
+            </div>
+
+            {/* Header */}
+            <div className="flex items-center justify-between gap-2 px-5 pt-3 pb-3 border-b border-slate-200/60 dark:border-slate-700/60">
+              <div className="flex items-center gap-2 min-w-0">
+                <h2 className="text-base font-bold text-slate-900 dark:text-slate-100 shrink-0">
+                  {t('folder.moveTitle')}
+                </h2>
+                <span className="inline-flex items-center gap-1.5 min-w-0 px-2.5 py-1 rounded-full bg-blue-500/15 text-blue-600 dark:text-blue-300 text-xs font-medium">
+                  {items.length === 1 && itemLabel ? (
+                    <FileText className="w-3.5 h-3.5 shrink-0" />
+                  ) : (
+                    <Folder className="w-3.5 h-3.5 shrink-0" />
+                  )}
+                  <span className="truncate">{chipText}</span>
+                </span>
+              </div>
+              <button
+                onClick={onClose}
+                className="shrink-0 p-2 rounded-xl bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+                aria-label={t('common.close')}
+              >
+                <X className="w-4 h-4 text-slate-600 dark:text-slate-300" />
+              </button>
+            </div>
+
+            {/* Breadcrumb */}
+            <div className="flex items-center gap-1 px-5 py-2.5 overflow-x-auto scrollbar-hide text-sm whitespace-nowrap border-b border-slate-200/40 dark:border-slate-800/60">
+              {crumbs.map((c, i) => (
+                <React.Fragment key={c.id || 'root'}>
+                  {i > 0 && <ChevronRight className="w-3.5 h-3.5 text-slate-400 shrink-0" />}
+                  <button
+                    onClick={() => setPickerFolderId(c.id)}
+                    className={`inline-flex items-center gap-1 transition-colors ${
+                      i === crumbs.length - 1
+                        ? 'text-slate-900 dark:text-slate-100 font-semibold'
+                        : 'text-slate-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400'
+                    }`}
+                  >
+                    {c.id === null && <Home className="w-3.5 h-3.5" />}
+                    {c.name}
+                  </button>
+                </React.Fragment>
+              ))}
+            </div>
+
+            {/* Folder list */}
+            <div className="flex-1 overflow-y-auto px-3 py-2 min-h-[120px]">
+              {/* Up one level */}
+              {pickerFolderId && (
+                <button
+                  onClick={() =>
+                    setPickerFolderId(folderStructure.folders[pickerFolderId]?.parentId ?? null)
+                  }
+                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors"
+                >
+                  <div className="w-9 h-9 rounded-lg bg-slate-500/10 text-slate-400 flex items-center justify-center shrink-0">
+                    <CornerLeftUp className="w-4.5 h-4.5" />
+                  </div>
+                  <span className="text-sm text-slate-500 dark:text-slate-400">{t('folder.goUp')}</span>
+                </button>
+              )}
+
+              {childFolders.length === 0 && !pickerFolderId && (
+                <div className="py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+                  {t('folder.noFolders')}
+                </div>
+              )}
+              {childFolders.length === 0 && pickerFolderId && (
+                <div className="py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+                  {t('folder.noSubfolders')}
+                </div>
+              )}
+
+              {childFolders.map((folder) => {
+                const blocked = blockedIds.has(folder.id);
+                const isSource = sourceIds.has(folder.id);
+                const count = folder.workflows.length + folder.children.length;
+                return (
+                  <button
+                    key={folder.id}
+                    disabled={blocked}
+                    onClick={() => !blocked && setPickerFolderId(folder.id)}
+                    className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl transition-colors ${
+                      blocked
+                        ? 'opacity-40 cursor-not-allowed'
+                        : 'hover:bg-slate-100 dark:hover:bg-slate-800/60'
+                    }`}
+                  >
+                    <div className="w-9 h-9 rounded-lg bg-amber-500/10 text-amber-500 flex items-center justify-center shrink-0">
+                      <Folder className="w-4.5 h-4.5 fill-current opacity-80" />
+                    </div>
+                    <div className="flex-1 min-w-0 text-left">
+                      <div className="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">
+                        {folder.name}
+                      </div>
+                      <div className="text-xs text-slate-400 dark:text-slate-500 truncate">
+                        {blocked
+                          ? t('folder.movingItems', { count: 1 })
+                          : isSource
+                          ? t('folder.currentLocation')
+                          : `${count} ${count === 1 ? t('common.item') : t('common.items')}`}
+                      </div>
+                    </div>
+                    {!blocked && <ChevronRight className="w-4 h-4 text-slate-400 shrink-0" />}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* New folder inline input */}
+            {isCreating && (
+              <div className="flex items-center gap-2 px-4 py-2.5 border-t border-slate-200/60 dark:border-slate-700/60">
+                <Folder className="w-5 h-5 text-amber-500 shrink-0" />
+                <Input
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleCreate();
+                    if (e.key === 'Escape') {
+                      setIsCreating(false);
+                      setNewName('');
+                    }
+                  }}
+                  placeholder={t('folder.namePlaceholder')}
+                  className="h-9 flex-1 min-w-0"
+                  autoFocus
+                />
+                <Button size="sm" onClick={handleCreate} disabled={!newName.trim()} className="h-9 shrink-0">
+                  <Check className="w-4 h-4" />
+                </Button>
+              </div>
+            )}
+
+            {/* Footer actions */}
+            <div className="flex items-center gap-2 px-4 py-3 border-t border-slate-200/60 dark:border-slate-700/60 bg-white/40 dark:bg-slate-900/40">
+              <Button
+                variant="outline"
+                onClick={() => setIsCreating((v) => !v)}
+                className="h-11 gap-2 shrink-0 rounded-xl"
+              >
+                <FolderPlus className="w-4.5 h-4.5" />
+                <span className="hidden xs:inline">{t('folder.newFolder')}</span>
+              </Button>
+              <Button
+                onClick={() => onConfirm(pickerFolderId)}
+                disabled={allAlreadyHere}
+                className="h-11 flex-1 gap-2 rounded-xl bg-blue-600 hover:bg-blue-700 text-white border-none disabled:opacity-40"
+              >
+                <Check className="w-4.5 h-4.5 shrink-0" />
+                <span className="truncate">
+                  {currentFolderName
+                    ? t('folder.moveIntoNamed', { name: currentFolderName })
+                    : t('folder.moveIntoHome')}
+                </span>
+              </Button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default MoveToFolderSheet;

--- a/src/components/workflow/WorkflowDetailModal.tsx
+++ b/src/components/workflow/WorkflowDetailModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, Calendar, User, Tag, FileText, AlertCircle, Server, Play, Copy, Trash2, Plus, Check } from 'lucide-react';
+import { X, Calendar, User, Tag, FileText, AlertCircle, Server, Play, Copy, Trash2, Plus, Check, FolderInput } from 'lucide-react';
 import { Workflow } from '@/shared/types/app/IComfyWorkflow';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -20,6 +20,7 @@ interface WorkflowDetailModalProps {
   onWorkflowUpdated?: (updatedWorkflow: Workflow) => void;
   onWorkflowDeleted?: (workflowId: string) => void;
   onWorkflowCopied?: (newWorkflow: Workflow) => void;
+  onMove?: (workflow: Workflow) => void;
 }
 
 const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
@@ -30,6 +31,7 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
   onWorkflowUpdated,
   onWorkflowDeleted,
   onWorkflowCopied,
+  onMove,
 }) => {
   const { t } = useTranslation();
   const [thumbnailUrl, setThumbnailUrl] = useState<string | undefined>(workflow?.thumbnail);
@@ -447,6 +449,17 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                 >
                   <Copy className="w-5 h-5" />
                 </Button>
+                {onMove && workflow && (
+                  <Button
+                    onClick={() => onMove(workflow)}
+                    variant="outline"
+                    className="flex-1 py-6 rounded-2xl bg-white/50 dark:bg-slate-700/50 backdrop-blur-md border border-slate-200/50 dark:border-slate-600/50 hover:bg-white/70 dark:hover:bg-slate-700/70 transition-all duration-200 flex items-center justify-center gap-2"
+                    title={t('workflow.move')}
+                    disabled={isLoading}
+                  >
+                    <FolderInput className="w-5 h-5" />
+                  </Button>
+                )}
                 <Button
                   onClick={() => setShowDeleteConfirm(true)}
                   variant="outline"

--- a/src/components/workflow/WorkflowGridItem.tsx
+++ b/src/components/workflow/WorkflowGridItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FileText, AlertCircle, Clock, MoreVertical } from 'lucide-react';
+import { FileText, AlertCircle, Clock, Check } from 'lucide-react';
 import { Workflow } from '@/shared/types/app/IComfyWorkflow';
 import { generateWorkflowThumbnail } from '@/shared/utils/rendering/CanvasRendererService';
 import { useLongPress } from '@/hooks/useLongPress';
@@ -10,6 +10,7 @@ interface WorkflowGridItemProps {
   onClick: () => void;
   onLongPress: () => void;
   isSelected?: boolean;
+  selectionMode?: boolean;
 }
 
 const WorkflowGridItem: React.FC<WorkflowGridItemProps> = ({
@@ -17,6 +18,7 @@ const WorkflowGridItem: React.FC<WorkflowGridItemProps> = ({
   onClick,
   onLongPress,
   isSelected = false,
+  selectionMode = false,
 }) => {
   const { t } = useTranslation();
   const [thumbnailUrl, setThumbnailUrl] = useState<string | undefined>(workflow.thumbnail);
@@ -84,6 +86,18 @@ const WorkflowGridItem: React.FC<WorkflowGridItemProps> = ({
         {/* Selected Overlay */}
         {isSelected && (
           <div className="absolute inset-0 bg-blue-500/20 backdrop-blur-[1px]" />
+        )}
+
+        {/* Selection checkbox */}
+        {selectionMode && (
+          <div
+            className={`absolute top-2 left-2 z-20 w-6 h-6 rounded-full flex items-center justify-center border-2 transition-colors ${isSelected
+              ? 'bg-blue-500 border-blue-500 text-white'
+              : 'bg-black/40 border-white/70 text-transparent'
+              }`}
+          >
+            <Check className="w-3.5 h-3.5" />
+          </div>
         )}
       </div>
 

--- a/src/components/workflow/WorkflowList.tsx
+++ b/src/components/workflow/WorkflowList.tsx
@@ -13,7 +13,11 @@ import {
   Image,
   Link as LinkIcon,
   X,
-  ArrowRightLeft
+  ArrowRightLeft,
+  FolderInput,
+  FolderPlus,
+  Trash2,
+  AlertTriangle
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -25,10 +29,12 @@ import FolderDetailModal from './FolderDetailModal';
 import WorkflowDetailModal from './WorkflowDetailModal';
 import WorkflowEditModal from './WorkflowEditModal';
 import WorkflowUploadModal from './WorkflowUploadModal';
+import MoveToFolderSheet, { MoveItem } from './MoveToFolderSheet';
 import SideMenu from '@/components/controls/SideMenu';
 import {
   loadAllWorkflows,
   addWorkflow,
+  removeWorkflow,
 } from '@/infrastructure/storage/IndexedDBWorkflowService';
 import { WorkflowFileService } from '@/core/services/WorkflowFileService';
 import { toast } from 'sonner';
@@ -71,25 +77,28 @@ const WorkflowList: React.FC = () => {
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [selectedSortOrder, setSelectedSortOrder] = useState<SortOrder>('date-desc');
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
-  const [selectedItemForMove, setSelectedItemForMove] = useState<{
-    id: string;
-    type: 'workflow' | 'folder';
-    sourceFolderId: string | null;
-  } | null>(null);
+
+  // Multi-select: pick any workflows/folders, then move or delete them in bulk.
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
+
+  // "Move to folder" destination sheet (drives both single-item moves from the
+  // detail modals and bulk moves from the selection bar).
+  const [moveSheetItems, setMoveSheetItems] = useState<MoveItem[] | null>(null);
+  const [moveSheetLabel, setMoveSheetLabel] = useState<string | undefined>(undefined);
+
   const { t } = useTranslation();
 
   const navigate = useNavigate();
 
   const {
     folderStructure,
-    isEditMode,
     createFolder,
     deleteFolder,
     moveItem,
     setSortOrder,
     initializeRootWorkflows,
-    enterEditMode,
-    cancelEditMode,
     removeWorkflow: removeWorkflowFromStructure,
   } = useFolderManagement();
 
@@ -304,24 +313,100 @@ const WorkflowList: React.FC = () => {
     return [{ id: null, name: t('folder.home') }, ...path];
   }, [currentFolderId, folderStructure, t]);
 
+  // --- Selection & move helpers ---
+  const getItemType = (id: string): 'workflow' | 'folder' =>
+    folderStructure.folders[id] ? 'folder' : 'workflow';
+
+  // Resolve an item's real parent folder from the structure (not the current
+  // view), so moves stay correct even from search results or another branch.
+  const findSourceFolderId = (id: string, type: 'workflow' | 'folder'): string | null => {
+    if (type === 'folder') return folderStructure.folders[id]?.parentId ?? null;
+    const parent = Object.entries(folderStructure.folders).find(([, f]) =>
+      f.workflows.includes(id)
+    );
+    return parent ? parent[0] : null;
+  };
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const enterSelection = () => {
+    setSelectionMode(true);
+    setSelectedIds(new Set());
+  };
+  const exitSelection = () => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+
+  const openMoveSheet = (items: MoveItem[], label?: string) => {
+    if (!items.length) return;
+    setMoveSheetItems(items);
+    setMoveSheetLabel(label);
+  };
+
+  const openMoveForSelection = () => {
+    const items: MoveItem[] = Array.from(selectedIds).map((id) => {
+      const type = getItemType(id);
+      return { id, type, sourceFolderId: findSourceFolderId(id, type) };
+    });
+    openMoveSheet(items);
+  };
+
+  const handleConfirmMove = (targetFolderId: string | null) => {
+    const items = moveSheetItems || [];
+    items.forEach((it) =>
+      moveItem({
+        itemId: it.id,
+        itemType: it.type,
+        targetFolderId,
+        sourceFolderId: it.sourceFolderId,
+      })
+    );
+    setMoveSheetItems(null);
+    setMoveSheetLabel(undefined);
+    exitSelection();
+    toast.success(t('folder.moveSuccess'));
+  };
+
+  const handleBulkDelete = async () => {
+    const ids = Array.from(selectedIds);
+    const deletedWorkflowIds: string[] = [];
+    for (const id of ids) {
+      if (getItemType(id) === 'folder') {
+        deleteFolder(id);
+      } else {
+        try {
+          await removeWorkflow(id);
+        } catch (e) {
+          console.error('Failed to delete workflow:', e);
+        }
+        removeWorkflowFromStructure(id);
+        deletedWorkflowIds.push(id);
+      }
+    }
+    if (deletedWorkflowIds.length) {
+      setWorkflows((prev) => prev.filter((w) => !deletedWorkflowIds.includes(w.id)));
+    }
+    setShowBulkDeleteConfirm(false);
+    exitSelection();
+    toast.success(t('folder.deleteSuccess'));
+  };
+
   // Handlers for Items
   const handleWorkflowClick = (workflow: Workflow) => {
-    if (isEditMode) {
-      if (!selectedItemForMove) setSelectedItemForMove({ id: workflow.id, type: 'workflow', sourceFolderId: currentFolderId });
-      else if (selectedItemForMove.id === workflow.id) setSelectedItemForMove(null);
-      else setSelectedItemForMove({ id: workflow.id, type: 'workflow', sourceFolderId: currentFolderId });
-    } else {
-      handleWorkflowSelect(workflow);
-    }
+    if (selectionMode) toggleSelect(workflow.id);
+    else handleWorkflowSelect(workflow);
   };
 
   const handleFolderClick = (folderId: string) => {
-    if (isEditMode) {
-      if (selectedItemForMove) {
-        moveItem({ itemId: selectedItemForMove.id, itemType: selectedItemForMove.type, targetFolderId: folderId, sourceFolderId: selectedItemForMove.sourceFolderId });
-        setSelectedItemForMove(null);
-        toast.success(t('folder.moveSuccess'));
-      }
+    if (selectionMode) {
+      toggleSelect(folderId);
     } else {
       setCurrentFolderId(folderId);
       setSearchQuery('');
@@ -401,11 +486,11 @@ const WorkflowList: React.FC = () => {
         </div>
       </header>
 
-      {/* Sub Header (Search & Sort) */}
+      {/* Sub Header (Search) */}
       <div className="flex-none bg-white dark:bg-slate-950 border-b border-slate-200/60 dark:border-slate-800/60 z-30">
-        <div className="max-w-[1600px] mx-auto px-4 py-2 flex items-center justify-between gap-3">
+        <div className="max-w-[1600px] mx-auto px-4 py-2">
           {/* Search */}
-          <div className="relative flex-1">
+          <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
             <Input
               value={searchQuery}
@@ -422,21 +507,54 @@ const WorkflowList: React.FC = () => {
               </button>
             )}
           </div>
+        </div>
+      </div>
 
-          {/* Sort Button */}
+      {/* Action Toolbar (create / select / sort) */}
+      <div className="flex-none bg-white dark:bg-slate-950 border-b border-slate-200/60 dark:border-slate-800/60 z-30">
+        <div className="max-w-[1600px] mx-auto px-4 py-2 flex items-center flex-wrap gap-2">
+          {/* New Workflow */}
+          <Button
+            onClick={() => setIsUploadModalOpen(true)}
+            className="h-9 gap-2 rounded-xl text-sm bg-blue-600 hover:bg-blue-700 text-white border-none shadow-sm"
+          >
+            <Plus className="w-4 h-4" />
+            {t('workflow.uploadButton')}
+          </Button>
+          {/* New Folder */}
+          <Button
+            onClick={() => setIsCreatingFolder(true)}
+            variant="outline"
+            className="h-9 gap-2 rounded-xl text-sm border-slate-200 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900"
+          >
+            <FolderPlus className="w-4 h-4" />
+            {t('folder.newFolder')}
+          </Button>
+          {/* Select / multi-select mode */}
+          <Button
+            onClick={() => (selectionMode ? exitSelection() : enterSelection())}
+            variant="outline"
+            className={`h-9 gap-2 rounded-xl text-sm ${selectionMode
+              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 border-transparent'
+              : 'border-slate-200 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900'
+              }`}
+          >
+            {selectionMode ? <X className="w-4 h-4" /> : <ArrowRightLeft className="w-4 h-4" />}
+            {selectionMode ? t('workflow.cancelSelection') : t('workflow.selectItems')}
+          </Button>
+
+          {/* Sort (pinned right on wider screens) */}
           <Button
             variant="ghost"
             onClick={() => {
               const nextSort: SortOrder = selectedSortOrder === 'date-desc' ? 'name-asc' : 'date-desc';
               setSortOrder(nextSort);
             }}
-            className="h-10 px-3 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-900 font-medium text-slate-600 dark:text-slate-400 gap-2 shrink-0 text-xs sm:text-sm"
+            className="h-9 px-3 gap-2 rounded-xl text-sm text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 shrink-0 sm:ml-auto"
             title={t('workflow.sorting.title', 'Sort')}
           >
             <ArrowUpDown className="w-4 h-4" />
-            <span className="hidden sm:inline">
-              {selectedSortOrder.includes('date') ? t('workflow.sorting.newest') : t('workflow.sorting.name')}
-            </span>
+            {selectedSortOrder.includes('date') ? t('workflow.sorting.newest') : t('workflow.sorting.name')}
           </Button>
         </div>
       </div>
@@ -445,46 +563,25 @@ const WorkflowList: React.FC = () => {
       <div className="flex-none bg-slate-50/50 dark:bg-slate-950/50 border-b border-slate-200/60 dark:border-slate-800/60 z-30">
         <div className="max-w-[1600px] mx-auto px-4 py-3">
           {/* Folder Section Header */}
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center mb-4">
             <h2 className="text-lg font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
               <FolderIcon className="w-6 h-6" />
               {t('folder.title')}
             </h2>
-            {/* New Folder Button */}
-            <Button
-              onClick={() => setIsCreatingFolder(true)}
-              variant="ghost"
-              size="icon"
-              className="h-10 w-10 rounded-xl hover:bg-slate-200 dark:hover:bg-slate-800"
-              title={t('folder.newFolder')}
-            >
-              <Plus className="w-6 h-6 text-slate-600 dark:text-slate-400" />
-            </Button>
           </div>
 
           {/* Folders List */}
           <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
             {/* Parent Folder */}
-            {currentFolderId && (
+            {currentFolderId && !selectionMode && (
               <div className="min-w-[160px] shrink-0">
                 <ParentFolderGridItem
                   onClick={() => {
-                    if (isEditMode && selectedItemForMove) {
-                      moveItem({
-                        itemId: selectedItemForMove.id,
-                        itemType: selectedItemForMove.type,
-                        targetFolderId: folderStructure.folders[currentFolderId]?.parentId || null,
-                        sourceFolderId: currentFolderId
-                      });
-                      setSelectedItemForMove(null);
-                      toast.success(t('folder.moveToParentSuccess'));
-                    } else {
-                      const parentId = folderStructure.folders[currentFolderId]?.parentId;
-                      setCurrentFolderId(parentId);
-                    }
+                    const parentId = folderStructure.folders[currentFolderId]?.parentId ?? null;
+                    setCurrentFolderId(parentId);
                   }}
                   isTarget={false}
-                  isMoveMode={isEditMode}
+                  isMoveMode={false}
                 />
               </div>
             )}
@@ -527,7 +624,8 @@ const WorkflowList: React.FC = () => {
                     setIsFolderDetailModalOpen(true);
                   }}
                   workflowCount={folder.workflows.length + folder.children.length}
-                  isSelected={selectedItemForMove?.id === folder.id}
+                  isSelected={selectedIds.has(folder.id)}
+                  selectionMode={selectionMode}
                 />
               </div>
             ))}
@@ -545,43 +643,11 @@ const WorkflowList: React.FC = () => {
           )}
 
           {/* Workflows Header */}
-          <div className="flex items-center justify-between">
+          <div className="flex items-center">
             <h2 className="text-lg font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
               <FileText className="w-6 h-6" />
               {t('workflow.listTitle')} ({filteredContents.workflows.length})
             </h2>
-
-            {/* Workflow Actions - Moved here */}
-            <div className="flex items-center gap-1">
-              {/* New/Upload Workflow (Consolidated) */}
-              <Button
-                onClick={() => setIsUploadModalOpen(true)}
-                variant="ghost"
-                size="icon"
-                className="h-10 w-10 rounded-xl hover:bg-slate-200 dark:hover:bg-slate-800"
-                title={t('workflow.uploadButton')}
-              >
-                <Plus className="w-6 h-6 text-slate-600 dark:text-slate-400" />
-              </Button>
-
-              {/* Select/Move */}
-              <Button
-                variant={isEditMode ? "secondary" : "ghost"}
-                size="icon"
-                className={`h-10 w-10 rounded-xl ${isEditMode ? 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400' : 'hover:bg-slate-200 dark:hover:bg-slate-800'}`}
-                onClick={() => {
-                  if (isEditMode) {
-                    cancelEditMode();
-                    setSelectedItemForMove(null);
-                  } else {
-                    enterEditMode();
-                  }
-                }}
-                title={isEditMode ? t('workflow.cancelSelection') : t('workflow.selectItems')}
-              >
-                {isEditMode ? <X className="w-6 h-6" /> : <ArrowRightLeft className="w-6 h-6 text-slate-600 dark:text-slate-400" />}
-              </Button>
-            </div>
           </div>
 
           {/* Workflow Grid */}
@@ -599,7 +665,7 @@ const WorkflowList: React.FC = () => {
               </Button>
             </div>
           ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-6 pb-20">
+            <div className={`grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-6 ${selectionMode ? 'pb-32' : 'pb-20'}`}>
               {filteredContents.workflows.map((workflow) => (
                 <WorkflowGridItem
                   key={workflow.id}
@@ -609,13 +675,54 @@ const WorkflowList: React.FC = () => {
                     setDetailWorkflow(workflow);
                     setIsDetailModalOpen(true);
                   }}
-                  isSelected={selectedItemForMove?.id === workflow.id}
+                  isSelected={selectedIds.has(workflow.id)}
+                  selectionMode={selectionMode}
                 />
               ))}
             </div>
           )}
         </div>
       </main>
+
+      {/* Selection action bar */}
+      <AnimatePresence>
+        {selectionMode && (
+          <motion.div
+            initial={{ y: 90, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 90, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className="fixed bottom-0 inset-x-0 z-40 border-t border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-900/90 backdrop-blur-xl"
+          >
+            <div
+              className="max-w-[1600px] mx-auto px-4 py-3 flex items-center gap-2"
+              style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+            >
+              <span className="text-sm font-medium text-slate-700 dark:text-slate-300 shrink-0">
+                {t('workflow.selectedCount', { count: selectedIds.size })}
+              </span>
+              <div className="flex-1" />
+              <Button
+                onClick={openMoveForSelection}
+                disabled={selectedIds.size === 0}
+                className="h-10 gap-2 rounded-xl bg-blue-600 hover:bg-blue-700 text-white border-none disabled:opacity-40"
+              >
+                <FolderInput className="w-4 h-4" />
+                {t('workflow.move')}
+              </Button>
+              <Button
+                onClick={() => setShowBulkDeleteConfirm(true)}
+                disabled={selectedIds.size === 0}
+                variant="outline"
+                className="h-10 gap-2 rounded-xl border-red-300 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-40"
+              >
+                <Trash2 className="w-4 h-4" />
+                {t('common.delete')}
+              </Button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Modals */}
       <SideMenu
@@ -670,6 +777,14 @@ const WorkflowList: React.FC = () => {
           initializeRootWorkflows([newWorkflow.id, ...workflows.map((w) => w.id)]);
           toast.success(t('workflow.copySuccess', { name: newWorkflow.name }));
         }}
+        onMove={(wf) => {
+          setIsDetailModalOpen(false);
+          setDetailWorkflow(null);
+          openMoveSheet(
+            [{ id: wf.id, type: 'workflow', sourceFolderId: findSourceFolderId(wf.id, 'workflow') }],
+            wf.name
+          );
+        }}
       />
 
       <WorkflowEditModal
@@ -710,8 +825,82 @@ const WorkflowList: React.FC = () => {
               toast.error(t('folder.deleteError'));
             }
           }}
+          onMove={(folder) => {
+            setIsFolderDetailModalOpen(false);
+            setDetailFolder(null);
+            openMoveSheet(
+              [{ id: folder.id, type: 'folder', sourceFolderId: findSourceFolderId(folder.id, 'folder') }],
+              folder.name
+            );
+          }}
         />
       )}
+
+      {/* Move to folder sheet */}
+      <MoveToFolderSheet
+        isOpen={moveSheetItems !== null}
+        items={moveSheetItems || []}
+        itemLabel={moveSheetLabel}
+        folderStructure={folderStructure}
+        onClose={() => {
+          setMoveSheetItems(null);
+          setMoveSheetLabel(undefined);
+        }}
+        onConfirm={handleConfirmMove}
+        onCreateFolder={createFolder}
+      />
+
+      {/* Bulk delete confirmation */}
+      <AnimatePresence>
+        {showBulkDeleteConfirm && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setShowBulkDeleteConfirm(false);
+            }}
+          >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 20 }}
+              transition={{ duration: 0.2, ease: 'easeOut' }}
+              className="w-full max-w-sm bg-white dark:bg-slate-900 rounded-3xl shadow-2xl border border-slate-200 dark:border-slate-700 p-6 space-y-6"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex flex-col items-center text-center space-y-3">
+                <div className="w-14 h-14 rounded-full bg-red-500/10 flex items-center justify-center">
+                  <AlertTriangle className="w-7 h-7 text-red-600 dark:text-red-400" />
+                </div>
+                <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">
+                  {t('workflow.deleteSelectedConfirm')}
+                </h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
+                  {t('workflow.deleteSelectedMessage')}
+                </p>
+              </div>
+              <div className="flex gap-3">
+                <Button
+                  onClick={() => setShowBulkDeleteConfirm(false)}
+                  variant="outline"
+                  className="flex-1 h-12 rounded-xl border-slate-200 dark:border-slate-700"
+                >
+                  {t('common.cancel')}
+                </Button>
+                <Button
+                  onClick={handleBulkDelete}
+                  className="flex-1 h-12 rounded-xl bg-red-600 hover:bg-red-700 text-white border-none"
+                >
+                  {t('common.delete')}
+                </Button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/hooks/useFolderManagement.ts
+++ b/src/hooks/useFolderManagement.ts
@@ -100,10 +100,13 @@ export const useFolderManagement = () => {
     });
   }, []);
 
-  // Create a new folder
-  const createFolder = useCallback((name: string, parentId: string | null = null) => {
+  // Create a new folder. Returns the new folder's id so callers can act on it
+  // immediately (e.g. the "move to folder" sheet creates a folder and drills
+  // into it).
+  const createFolder = useCallback((name: string, parentId: string | null = null): string => {
+    const newFolderId = `folder_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
     const updateStructure = (prev: FolderStructure): FolderStructure => {
-      const newFolderId = `folder_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
       const newFolder: FolderItem = {
         id: newFolderId,
         name,
@@ -147,6 +150,8 @@ export const useFolderManagement = () => {
         return updated;
       });
     }
+
+    return newFolderId;
   }, [isEditMode, pendingStructure]);
 
   // Rename a folder

--- a/src/locale/en/common.json
+++ b/src/locale/en/common.json
@@ -297,7 +297,11 @@
             "formatsTitle": "Supported Formats",
             "formatsDesc": "You can upload standard ComfyUI workflow JSON files or PNG images that contain embedded workflow metadata.",
             "createNew": "Create New Empty Workflow"
-        }
+        },
+        "move": "Move",
+        "deleteSelectedConfirm": "Delete selected items?",
+        "deleteSelectedMessage": "Selected workflows are permanently deleted. Folders are removed, but their contents move up to the parent. This can't be undone.",
+        "selectedCount": "{{count}} selected"
     },
     "folder": {
         "title": "Folders",
@@ -320,7 +324,14 @@
         "moveToParent": "Move to Parent",
         "backToParent": "Back to Parent",
         "moveHere": "Move selected items here",
-        "goUp": "Go up one level"
+        "goUp": "Go up one level",
+        "moveTitle": "Move to folder",
+        "chooseDestination": "Choose a destination",
+        "moveIntoNamed": "Move to ‘{{name}}’",
+        "moveIntoHome": "Move to Home",
+        "currentLocation": "Current location",
+        "noSubfolders": "No subfolders here",
+        "movingItems": "Moving {{count}}"
     },
     "menu": {
         "appTitle": "ComfyUI Mobile",

--- a/src/locale/ja/common.json
+++ b/src/locale/ja/common.json
@@ -295,7 +295,11 @@
             "formatsTitle": "対応フォーマット",
             "formatsDesc": "標準のComfyUIワークフローJSONファイル、またはワークフローメタデータが埋め込まれたPNG画像をアップロードできます。",
             "createNew": "新しい空のワークフローを作成"
-        }
+        },
+        "move": "移動",
+        "deleteSelectedConfirm": "選択した項目を削除しますか？",
+        "deleteSelectedMessage": "選択したワークフローは完全に削除されます。フォルダは削除され、中身は親フォルダへ移動します。元に戻せません。",
+        "selectedCount": "{{count}}件選択"
     },
     "folder": {
         "title": "フォルダ",
@@ -318,7 +322,14 @@
         "moveToParent": "親フォルダへ移動",
         "backToParent": "親フォルダへ戻る",
         "moveHere": "選択した項目をここに移動",
-        "goUp": "1つ上の階層へ"
+        "goUp": "1つ上の階層へ",
+        "moveTitle": "フォルダへ移動",
+        "chooseDestination": "移動先を選択",
+        "moveIntoNamed": "「{{name}}」へ移動",
+        "moveIntoHome": "ホームへ移動",
+        "currentLocation": "現在の場所",
+        "noSubfolders": "サブフォルダはありません",
+        "movingItems": "{{count}}件を移動"
     },
     "menu": {
         "appTitle": "ComfyUIモバイル",

--- a/src/locale/ko/common.json
+++ b/src/locale/ko/common.json
@@ -297,7 +297,11 @@
             "formatsTitle": "지원되는 형식",
             "formatsDesc": "표준 ComfyUI 워크플로우 JSON 파일 또는 워크플로우 메타데이터가 포함된 PNG 이미지를 업로드할 수 있습니다.",
             "createNew": "새 빈 워크플로우 생성"
-        }
+        },
+        "move": "이동",
+        "deleteSelectedConfirm": "선택한 항목을 삭제할까요?",
+        "deleteSelectedMessage": "선택한 워크플로우는 영구 삭제됩니다. 폴더는 삭제되지만 내용은 상위 폴더로 이동합니다. 되돌릴 수 없습니다.",
+        "selectedCount": "{{count}}개 선택"
     },
     "folder": {
         "title": "폴더",
@@ -320,7 +324,14 @@
         "moveToParent": "상위로 이동",
         "backToParent": "상위로 돌아가기",
         "moveHere": "선택한 항목을 여기로 이동",
-        "goUp": "한 단계 위로"
+        "goUp": "한 단계 위로",
+        "moveTitle": "폴더로 이동",
+        "chooseDestination": "이동할 위치를 선택하세요",
+        "moveIntoNamed": "‘{{name}}’(으)로 이동",
+        "moveIntoHome": "홈으로 이동",
+        "currentLocation": "현재 위치",
+        "noSubfolders": "하위 폴더 없음",
+        "movingItems": "{{count}}개 이동 중"
     },
     "menu": {
         "appTitle": "ComfyUI 모바일",

--- a/src/locale/zh/common.json
+++ b/src/locale/zh/common.json
@@ -296,7 +296,11 @@
             "formatsTitle": "支持的格式",
             "formatsDesc": "您可以上传标准的 ComfyUI 工作流 JSON 文件或包含嵌入式工作流元数据的 PNG 图像。",
             "createNew": "创建新的空工作流"
-        }
+        },
+        "move": "移动",
+        "deleteSelectedConfirm": "删除所选项目？",
+        "deleteSelectedMessage": "所选工作流将被永久删除。文件夹会被删除，但其内容将移至上级文件夹。此操作无法撤销。",
+        "selectedCount": "已选 {{count}} 项"
     },
     "folder": {
         "title": "文件夹",
@@ -319,7 +323,14 @@
         "moveToParent": "移动到父级",
         "backToParent": "返回父级",
         "moveHere": "将所选项目移动到此处",
-        "goUp": "向上一级"
+        "goUp": "向上一级",
+        "moveTitle": "移动到文件夹",
+        "chooseDestination": "选择目标位置",
+        "moveIntoNamed": "移动到‘{{name}}’",
+        "moveIntoHome": "移动到主页",
+        "currentLocation": "当前位置",
+        "noSubfolders": "没有子文件夹",
+        "movingItems": "移动 {{count}} 项"
     },
     "menu": {
         "appTitle": "ComfyUI 移动版",


### PR DESCRIPTION
Reworks how workflows and folders get moved on the list screen, and tidies the screen's action buttons. Behavior/organization only — no visual redesign (that's a follow-up).

## The problem

Moving used to be a "carry an item, then tap a folder" mode. Tapping a folder moved the item into it immediately, so you could never navigate *into* a folder while holding something — nested destinations (`A/B/C`) were unreachable, and you could only pick an item that was visible at the current level, so cross-branch moves were effectively impossible. It was also single-item only, and the natural entry point (long-press detail) had no "move" at all.

## Move to folder — destination picker

New `MoveToFolderSheet`: browse the folder tree and tap **move here** at any level.
- Breadcrumb + drill-in + go-up navigation, so any depth is reachable.
- Inline **new folder** creates the folder and drills into it, ready to drop.
- A folder being moved (and its descendants) is disabled as a target; moving to the folder an item already lives in is a no-op.
- Each item's source folder is resolved from the structure (not the current view), so moves are correct even from global search results.
- Works for both workflows and folders.

## Multi-select

Selection mode puts checkboxes on workflow cards **and** folder tiles, with a bottom action bar (selected count · Move · Delete).
- Move opens the same sheet for the whole selection.
- Delete confirms first; workflows are removed, folders dissolve into their parent (matching existing single-delete semantics).

## Entry points
- Long-press → detail modal (workflow and folder) gains a **Move** action.
- Selection bar **Move** handles bulk.

Both reuse `MoveToFolderSheet`.

## List toolbar

`New Workflow` / `New Folder` / `Select Items` and the sort control were icon-only and scattered across the two section headers and the search row (and the select toggle, which also moves folders, sat under "Workflows"). They're now one **labeled** toolbar between the search bar and the folder section. It wraps to two rows on mobile; sort pins right on wider screens. Section headers are just titles now.

## Notes
- `useFolderManagement.createFolder` now returns the new folder id (needed for create-and-move).
- i18n keys added for en / ko / ja / zh.
- Verified on device: bulk move into a new folder, moving a folder into another folder (nesting), self/descendant target blocking, current-location no-op, bulk delete with confirm, disabled actions at zero selection, and the toolbar layout at mobile and desktop widths. `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 워크플로우와 폴더를 여러 개 선택해 한 번에 이동하거나 삭제할 수 있습니다.
  - 폴더 트리에서 목적지를 탐색하고 새 폴더를 생성한 뒤 항목을 이동할 수 있습니다.
  - 상세 화면에서도 워크플로우와 폴더를 이동할 수 있습니다.
  - 선택 모드에서 선택 상태가 체크 표시로 명확하게 표시됩니다.

- **개선 사항**
  - 이동할 수 없는 폴더는 목적지에서 자동으로 제외됩니다.
  - 영어, 한국어, 일본어, 중국어 이동 및 일괄 삭제 안내 문구가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->