### PR TITLE
design: tool-aesthetic design system across the app

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     
     <!-- Basic Meta Tags -->
     <meta name="description" content="Mobile-first interface for ComfyUI AI image generation workflows" />
-    <meta name="theme-color" content="#0f172a" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0f172a" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0f172a" />
+    <meta name="theme-color" content="#0b0c0f" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0b0c0f" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b0c0f" />
     
     <!-- Mobile Browser Control -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -23,10 +23,13 @@
     <link rel="apple-touch-icon" sizes="152x152" href="icons/icon-152x152.png" />
     <link rel="apple-touch-icon" sizes="192x192" href="icons/icon-192x192.png" />
     <link rel="manifest" href="manifest.json" />
-    
+
+    <!-- Pretendard (design-system body font; falls back to system-ui) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
+
     <title>ComfyMobileUI</title>
   </head>
-  <body style="margin: 0; padding: 0; background-color: #0f172a; overflow: hidden;">
+  <body style="margin: 0; padding: 0; background-color: #0b0c0f; overflow: hidden;">
     <div id="root"></div>
     
     <!-- Emergency Recovery Fallback -->

--- a/src/components/canvas-v2/CanvasHost.tsx
+++ b/src/components/canvas-v2/CanvasHost.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Loader2 } from 'lucide-react';
 import { useConnectionStore } from '@/ui/store/connectionStore';
 import {
   CanvasBridgeClient,
@@ -87,14 +86,17 @@ export const CanvasHost: React.FC<CanvasHostProps> = ({
         ref={iframeRef}
         src={`${serverUrl}/`}
         title="ComfyUI official canvas"
-        className="absolute inset-0 h-full w-full border-0 bg-slate-950"
+        className="absolute inset-0 h-full w-full border-0 bg-[#0b0c0f]"
         allow="clipboard-read; clipboard-write"
       />
       {!isReady && (
-        <div className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-slate-950/80">
-          <Loader2 className="h-6 w-6 animate-spin text-sky-400" />
-          <div className="text-sm text-slate-300">Loading official canvas…</div>
-          <div className="text-[11px] text-slate-500">{serverUrl}</div>
+        <div
+          className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-3"
+          style={{ background: 'rgba(11,12,15,0.85)' }}
+        >
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/[0.08] border-t-[#3069f0]" />
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[#565d6b]">Loading official canvas</div>
+          <div className="font-mono text-[10px] text-[#565d6b] px-1.5 py-0.5 rounded-[5px] border border-white/10">{serverUrl}</div>
         </div>
       )}
     </div>

--- a/src/components/canvas/CircularMenu.tsx
+++ b/src/components/canvas/CircularMenu.tsx
@@ -89,10 +89,10 @@ export const CircularMenu = forwardRef<CircularMenuRef, CircularMenuProps>((prop
     }));
 
     // Constants for Arc Layout
-    const RADIUS = 120; // Distance from center to icon center
-    const INNER_RADIUS = 40; // Center deadzone
-    const BUTTON_SIZE = 56;
-    const POINTER_SIZE = 20;
+    const RADIUS = 90; // Distance from center to icon center
+    const INNER_RADIUS = 30; // Center deadzone
+    const BUTTON_SIZE = 42;
+    const POINTER_SIZE = 15;
 
     // Arc Configuration (Top-heavy Fan)
     // 0 degrees is UP (12 o'clock)
@@ -179,7 +179,7 @@ export const CircularMenu = forwardRef<CircularMenuRef, CircularMenuProps>((prop
                     >
                         {/* Center Indicator / Node ID Debug */}
                         <div
-                            className="absolute flex items-center justify-center bg-slate-900/90 text-white rounded-full border border-slate-700 backdrop-blur-md shadow-xl select-none"
+                            className="absolute flex items-center justify-center bg-[#0b0c0f]/90 text-white rounded-full border border-white/[0.08] backdrop-blur-md shadow-xl select-none"
                             style={{
                                 width: INNER_RADIUS * 1.5,
                                 height: INNER_RADIUS * 1.5,
@@ -275,10 +275,10 @@ export const CircularMenu = forwardRef<CircularMenuRef, CircularMenuProps>((prop
                       w-full h-full flex items-center justify-center shadow-lg border-2
                       transition-all duration-200
                       ${isActive
-                                                ? 'bg-white border-blue-500 text-blue-600'
+                                                ? 'bg-white border-[#3069f0] text-blue-600'
                                                 : option.isSelected
-                                                    ? 'bg-slate-800 border-white text-white ring-2 ring-white ring-offset-2 ring-offset-slate-900/50 shadow-2xl scale-110' // Distinct selection style
-                                                    : 'bg-slate-900/95 border-slate-700 text-slate-300'
+                                                    ? 'bg-[#14171e] border-white text-white ring-2 ring-white ring-offset-2 ring-offset-black/50 shadow-2xl scale-110' // Distinct selection style
+                                                    : 'bg-[#0b0c0f]/95 border-white/[0.08] text-[#c8ccd4]'
                                             }
                     `}
                                         style={{
@@ -305,7 +305,7 @@ export const CircularMenu = forwardRef<CircularMenuRef, CircularMenuProps>((prop
                                                     }}
                                                 />
                                             ) : (
-                                                <option.icon size={26} strokeWidth={isActive ? 2.5 : 2} />
+                                                <option.icon size={19} strokeWidth={isActive ? 2.4 : 2} />
                                             )}
                                         </div>
                                     </div>

--- a/src/components/canvas/ConnectionBar.tsx
+++ b/src/components/canvas/ConnectionBar.tsx
@@ -47,28 +47,29 @@ export const ConnectionBar: React.FC<ConnectionBarProps> = ({
           animate={{ y: 0, opacity: 1 }}
           exit={{ y: 100, opacity: 0 }}
           transition={{ duration: 0.3, ease: "easeOut" }}
-          className="fixed bottom-6 left-4 right-4 z-50"
+          className="fixed bottom-6 left-4 right-4 z-50 flex justify-center"
         >
           {/* Frosted Clear Ice ConnectionBar */}
-          <div className="bg-slate-600/40 backdrop-blur-3xl rounded-[28px] shadow-[0_20px_50px_rgba(0,0,0,0.3)] border border-white/30 p-4 relative overflow-hidden">
+          <div className="rounded-[14px] border border-white/[0.09] p-2 relative overflow-hidden w-full max-w-[340px]"
+            style={{ background: 'rgba(15,17,22,0.9)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}>
             <div className="relative z-10">
               {/* Header */}
-              <div className="flex items-center justify-between mb-3">
-                <h3 className="text-base font-black text-white/90 tracking-tight">
-                  {t('node.createConnection')}
+              <div className="flex items-center justify-between mb-1.5 pl-0.5">
+                <h3 className="font-mono text-[9px] font-semibold text-[#7ba3f5]/80 tracking-[0.12em] uppercase truncate">
+                  {getStatusMessage()}
                 </h3>
                 <Button
                   onClick={onCancel}
                   variant="ghost"
                   size="sm"
-                  className="h-8 w-8 p-0 bg-white/10 hover:bg-white/20 text-white/70 hover:text-white rounded-full transition-all"
+                  className="h-6 w-6 p-0 bg-white/[0.05] hover:bg-white/[0.09] text-[#9aa3b2] hover:text-white rounded-md border border-white/[0.07] transition-all shrink-0 ml-2"
                 >
-                  <X className="h-4 w-4" />
+                  <X className="h-3 w-3" />
                 </Button>
               </div>
 
               {/* Node Selection Area - Compacted */}
-              <div className="flex items-center space-x-2 mb-4">
+              <div className="flex items-center space-x-1.5 mb-1.5">
                 {/* Source Node Slot */}
                 <div className="flex-1">
                   <button
@@ -79,25 +80,25 @@ export const ConnectionBar: React.FC<ConnectionBarProps> = ({
                     }}
                     disabled={!sourceNode}
                     className={`
-                      w-full relative rounded-[18px] border-2 border-dashed min-h-[52px] flex items-center justify-center transition-all duration-200 py-1.5
+                      w-full relative rounded-lg border border-dashed min-h-[36px] flex items-center justify-center transition-all duration-200 py-1
                       ${sourceNode
-                        ? 'border-blue-500/40 bg-blue-500/20 hover:bg-blue-500/30'
+                        ? 'border-[#3069f0]/40 bg-[#3069f0]/[0.12]'
                         : 'border-white/10 bg-white/5 cursor-default'
                       }
                     `}
                   >
                     {sourceNode ? (
                       <div className="text-center px-2 w-full">
-                        <div className="text-[11px] font-bold text-blue-300 break-all leading-tight">
+                        <div className="text-[10.5px] font-semibold text-[#7ba3f5] break-all leading-tight line-clamp-1 px-1">
                           {sourceNode.type}
                         </div>
-                        <div className="text-[9px] text-blue-400 mt-0.5 font-medium">
+                        <div className="font-mono text-[8.5px] text-[#5b8af5] mt-0.5">
                           ID: {sourceNode.id}
                         </div>
                       </div>
                     ) : (
                       <div className="text-center">
-                        <div className="text-[11px] text-white/40 font-bold">
+                        <div className="text-[10.5px] text-[#71798a] font-medium">
                           {t('node.sourceNode')}
                         </div>
                       </div>
@@ -110,7 +111,7 @@ export const ConnectionBar: React.FC<ConnectionBarProps> = ({
                   <ArrowRight className={`
                     h-4 w-4 transition-colors duration-200
                     ${canProceed
-                      ? 'text-blue-400'
+                      ? 'text-[#5b8af5]'
                       : 'text-white/20'
                     }
                   `} />
@@ -126,25 +127,25 @@ export const ConnectionBar: React.FC<ConnectionBarProps> = ({
                     }}
                     disabled={!targetNode}
                     className={`
-                      w-full relative rounded-[18px] border-2 border-dashed min-h-[52px] flex items-center justify-center transition-all duration-200 py-1.5
+                      w-full relative rounded-lg border border-dashed min-h-[36px] flex items-center justify-center transition-all duration-200 py-1
                       ${targetNode
-                        ? 'border-red-500/40 bg-red-500/20 hover:bg-red-500/30'
+                        ? 'border-[#f25555]/40 bg-[#f25555]/[0.12]'
                         : 'border-white/10 bg-white/5 cursor-default'
                       }
                     `}
                   >
                     {targetNode ? (
                       <div className="text-center px-2 w-full">
-                        <div className="text-[11px] font-bold text-red-300 break-all leading-tight">
+                        <div className="text-[10.5px] font-semibold text-[#f8b3b3] break-all leading-tight line-clamp-1 px-1">
                           {targetNode.type}
                         </div>
-                        <div className="text-[9px] text-red-400 mt-0.5 font-medium">
+                        <div className="font-mono text-[8.5px] text-[#f87c7c] mt-0.5">
                           ID: {targetNode.id}
                         </div>
                       </div>
                     ) : (
                       <div className="text-center">
-                        <div className="text-[11px] text-white/40 font-bold">
+                        <div className="text-[10.5px] text-[#71798a] font-medium">
                           {t('node.targetNode')}
                         </div>
                       </div>
@@ -158,7 +159,7 @@ export const ConnectionBar: React.FC<ConnectionBarProps> = ({
                 <Button
                   onClick={onCancel}
                   variant="outline"
-                  className="h-12 flex-1 rounded-[22px] bg-white/10 border-white/10 hover:bg-white/20 text-white font-bold transition-all active:scale-95"
+                  className="h-8 flex-1 rounded-lg bg-white/[0.05] border-white/[0.08] hover:bg-white/[0.08] text-[#c8ccd4] text-[11.5px] font-semibold transition-all active:scale-95"
                 >
                   {t('common.cancel')}
                 </Button>
@@ -166,33 +167,18 @@ export const ConnectionBar: React.FC<ConnectionBarProps> = ({
                   onClick={onProceed}
                   disabled={!canProceed}
                   className={`
-                    h-12 flex-1 rounded-[22px] shadow-lg transition-all duration-200 flex items-center justify-center space-x-2 font-black active:scale-95
+                    h-8 flex-1 rounded-lg shadow-lg transition-all duration-200 flex items-center justify-center gap-1.5 text-[11.5px] font-semibold active:scale-95
                     ${canProceed
-                      ? 'bg-blue-500/80 hover:bg-blue-600 text-white'
+                      ? 'bg-[#3069f0] hover:bg-[#3f78f5] text-white'
                       : 'bg-white/5 text-white/20 border-white/5'
                     }
                   `}
                 >
-                  <CheckCircle className="h-5 w-5" />
+                  <CheckCircle className="h-3 w-3" />
                   <span>{t('node.connectNodes')}</span>
                 </Button>
               </div>
 
-              {/* Status Indicator - Slim */}
-              <div className="mt-3 h-6 flex items-center justify-center">
-                <motion.div
-                  key={getStatusMessage()}
-                  initial={{ opacity: 0, scale: 0.95 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.95 }}
-                  transition={{ duration: 0.2 }}
-                  className="px-3 py-0.5 bg-blue-500/10 rounded-full border border-blue-500/20"
-                >
-                  <div className="text-[10px] font-bold text-blue-300/80 tracking-wide uppercase">
-                    {getStatusMessage()}
-                  </div>
-                </motion.div>
-              </div>
             </div>
           </div>
         </motion.div>

--- a/src/components/canvas/ConnectionModal.tsx
+++ b/src/components/canvas/ConnectionModal.tsx
@@ -84,24 +84,24 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
           />
 
           {/* Modal Container */}
-          <div className="fixed inset-0 z-[101] flex items-center justify-center p-4 sm:p-6 pwa-modal" style={{ pointerEvents: 'none' }}>
+          <div className="fixed inset-0 z-[101] flex items-center justify-center p-4 sm:p-4 pwa-modal" style={{ pointerEvents: 'none' }}>
             <motion.div
               initial={{ opacity: 0, scale: 0.96, y: 15 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.96, y: 15 }}
               transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-              className="relative w-full max-w-lg h-[75vh] pointer-events-auto flex flex-col overflow-hidden rounded-3xl shadow-2xl border border-white/10 text-white"
-              style={{ backgroundColor: '#374151' }}
+              className="relative w-full max-w-lg h-[75vh] pointer-events-auto flex flex-col overflow-hidden rounded-xl shadow-2xl border border-white/10 text-white"
+              style={{ backgroundColor: '#101217' }}
             >
               {/* Header */}
               <div className="px-6 py-5 border-b border-white/10 bg-black/20 backdrop-blur-xl">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">
-                    <div className="p-2.5 bg-blue-500/20 rounded-2xl border border-blue-500/30">
-                      <Cable className="h-6 w-6 text-blue-400" />
+                    <div className="p-2.5 bg-[#3069f0]/20 rounded-xl border border-[#3069f0]/30">
+                      <Cable className="h-6 w-6 text-[#5b8af5]" />
                     </div>
                     <div>
-                      <h2 className="text-xl font-extrabold tracking-tight text-white">
+                      <h2 className="text-[15px] font-extrabold tracking-tight text-white">
                         {t('node.createConnection')}
                       </h2>
                       <p className="text-xs font-bold uppercase tracking-widest text-white/80 mt-0.5">
@@ -128,11 +128,11 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
                       {t('node.source')}
                     </span>
                   </div>
-                  <div className="p-3 bg-blue-500/15 rounded-2xl border border-blue-500/30">
-                    <div className="text-sm font-black text-blue-200 truncate" title={sourceNode.type}>
+                  <div className="p-3 bg-[#3069f0]/15 rounded-xl border border-[#3069f0]/30">
+                    <div className="text-[12px] font-black text-blue-200 truncate" title={sourceNode.type}>
                       {sourceNode.type}
                     </div>
-                    <div className="text-[10px] font-mono text-blue-300/80 mt-0.5">
+                    <div className="text-[10px] font-mono text-[#7ba3f5]/80 mt-0.5">
                       ID: {sourceNode.id}
                     </div>
                   </div>
@@ -150,8 +150,8 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
                     </span>
                     <div className="w-1.5 h-1.5 rounded-full bg-red-400" />
                   </div>
-                  <div className="p-3 bg-red-500/15 rounded-2xl border border-red-500/30 text-right">
-                    <div className="text-sm font-black text-red-200 truncate" title={targetNode.type}>
+                  <div className="p-3 bg-[#f25555]/15 rounded-xl border border-[#f25555]/30 text-right">
+                    <div className="text-[12px] font-black text-red-200 truncate" title={targetNode.type}>
                       {targetNode.type}
                     </div>
                     <div className="text-[10px] font-mono text-red-300/80 mt-0.5">
@@ -164,9 +164,9 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
               {/* Connection Options List */}
               <div className="flex-1 overflow-y-auto custom-scrollbar bg-black/5">
                 {compatibility.isCompatible ? (
-                  <div className="p-6 space-y-3">
+                  <div className="p-4 space-y-3">
                     <div className="flex items-center space-x-2 mb-2 px-1">
-                      <div className="w-4 h-4 rounded-full bg-green-500/20 flex items-center justify-center">
+                      <div className="w-4 h-4 rounded-full bg-[#34c77b]/20 flex items-center justify-center">
                         <div className="w-1.5 h-1.5 rounded-full bg-green-400" />
                       </div>
                       <span className="text-[10px] font-bold uppercase tracking-widest text-white/90">
@@ -188,11 +188,11 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
                             onClick={() => handleConnectionSelect(connection.sourceSlot, connection.targetSlot)}
                             className="w-full relative group"
                           >
-                            <div className="p-4 bg-black/20 hover:bg-white/5 border border-white/5 hover:border-white/10 rounded-2xl transition-all duration-200 active:scale-[0.98]">
+                            <div className="p-4 bg-black/20 hover:bg-white/5 border border-white/5 hover:border-white/10 rounded-xl transition-all duration-200 active:scale-[0.98]">
                               <div className="flex items-center justify-between gap-4">
                                 {/* Source Info */}
                                 <div className="flex-1 min-w-0 text-left">
-                                  <div className={`text-sm font-bold transition-colors ${isNameMatch ? 'text-green-400' : 'text-white'}`}>
+                                  <div className={`text-[12px] font-bold transition-colors ${isNameMatch ? 'text-[#4ade80]' : 'text-white'}`}>
                                     {connection.sourceSlotName}
                                   </div>
                                   <div className="text-[10px] font-mono text-white/60 mt-0.5">
@@ -224,7 +224,7 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
 
                                 {/* Target Info */}
                                 <div className="flex-1 min-w-0 text-right">
-                                  <div className={`text-sm font-bold transition-colors ${isNameMatch ? 'text-green-400' : 'text-white'}`}>
+                                  <div className={`text-[12px] font-bold transition-colors ${isNameMatch ? 'text-[#4ade80]' : 'text-white'}`}>
                                     {connection.targetSlotName}
                                   </div>
                                   <div className="text-[10px] font-mono text-white/60 mt-0.5">
@@ -240,13 +240,13 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
                   </div>
                 ) : (
                   <div className="flex flex-col items-center justify-center h-full p-12 text-center">
-                    <div className="w-16 h-16 mb-4 bg-red-500/10 rounded-full flex items-center justify-center border border-red-500/20">
-                      <X className="h-8 w-8 text-red-400" />
+                    <div className="w-10 h-10 mb-4 bg-[#f25555]/10 rounded-full flex items-center justify-center border border-[#f25555]/20">
+                      <X className="h-8 w-8 text-[#f87c7c]" />
                     </div>
-                    <h3 className="text-lg font-extrabold text-white pr-4">
+                    <h3 className="text-[14px] font-extrabold text-white pr-4">
                       {t('node.noCompatibleConnections')}
                     </h3>
-                    <p className="text-sm text-white/80 mt-2">
+                    <p className="text-[12px] text-white/80 mt-2">
                       {t('node.noConnectionsDesc')}
                     </p>
                   </div>
@@ -257,7 +257,7 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
               <div className="px-6 py-5 bg-black/20 border-t border-white/10">
                 <Button
                   onClick={onClose}
-                  className="w-full h-12 rounded-[22px] bg-white/5 border border-white/10 hover:bg-white/10 text-white font-bold transition-all active:scale-95"
+                  className="w-full h-10 rounded-[22px] bg-white/5 border border-white/10 hover:bg-white/10 text-white font-bold transition-all active:scale-95"
                 >
                   {t('common.cancel')}
                 </Button>

--- a/src/components/canvas/DirectConnectionPanel.tsx
+++ b/src/components/canvas/DirectConnectionPanel.tsx
@@ -94,7 +94,7 @@ export const DirectConnectionPanel: React.FC<DirectConnectionPanelProps> = ({
         const currentMode = nodeAny.mode || 0;
         const isMuted = currentMode === 2;
         const isBypassed = currentMode === 4;
-        const baseColor = (nodeAny.bgcolor || nodeAny.color || (nodeAny.properties?.['Node Color'])) || '#374151';
+        const baseColor = (nodeAny.bgcolor || nodeAny.color || (nodeAny.properties?.['Node Color'])) || '#101217';
 
         if (isMuted) return '#3b82f6';
         if (isBypassed) return '#9333ea';
@@ -260,11 +260,11 @@ export const DirectConnectionPanel: React.FC<DirectConnectionPanelProps> = ({
                     {/* Header - Fixed Height */}
                     <div className="px-8 py-6 flex-shrink-0 flex items-center justify-between">
                         <div className="flex items-center space-x-4 min-w-0 flex-1">
-                            <div className="p-3 bg-blue-500 rounded-2xl shadow-lg ring-4 ring-blue-500/20 flex-shrink-0">
+                            <div className="p-3 bg-[#3069f0] rounded-xl shadow-lg ring-4 ring-blue-500/20 flex-shrink-0">
                                 <Cable className="w-6 h-6 text-white" />
                             </div>
                             <div className="min-w-0">
-                                <h2 className="text-2xl font-black text-white tracking-tight truncate">{t('node.connectNodes')}</h2>
+                                <h2 className="text-[16px] font-black text-white tracking-tight truncate">{t('node.connectNodes')}</h2>
                                 <div className="flex items-center space-x-2 text-white/40 text-[10px] uppercase font-bold tracking-widest mt-1">
                                     <span className="truncate max-w-[120px] sm:max-w-[200px]">{sourceNode.type}</span>
                                     <div className="w-1 h-1 rounded-full bg-white/20 flex-shrink-0" />
@@ -279,13 +279,13 @@ export const DirectConnectionPanel: React.FC<DirectConnectionPanelProps> = ({
                         className="flex-1 min-h-0 relative flex justify-between items-center px-4 overflow-hidden"
                     >
                         <div
-                            className="w-[42%] max-w-[320px] h-[90%] rounded-r-[40px] border-y border-r border-white/10 shadow-2xl flex flex-col py-8 pl-6 pr-2 relative overflow-hidden -ml-4"
+                            className="w-[42%] max-w-[320px] h-[90%] rounded-r-xl border-y border-r border-white/10 shadow-2xl flex flex-col py-5 pl-4 pr-2 relative overflow-hidden -ml-4"
                             style={{ backgroundColor: sourceBgColor }}
                         >
                             <div className="absolute top-0 left-0 w-1.5 h-full bg-black/20" />
                             <div className="mb-6">
-                                <span className="text-[10px] font-black uppercase tracking-[0.2em] text-blue-400">{t('node.sourceOutputs')}</span>
-                                <h3 className="text-lg font-bold text-white/90 line-clamp-2 break-all">{sourceNode.title || sourceNode.type}</h3>
+                                <span className="text-[10px] font-black uppercase tracking-[0.2em] text-[#5b8af5]">{t('node.sourceOutputs')}</span>
+                                <h3 className="text-[14px] font-bold text-white/90 line-clamp-2 break-all">{sourceNode.title || sourceNode.type}</h3>
                             </div>
                             <div
                                 className={`flex-1 ${activeDrag ? 'overflow-hidden' : 'overflow-y-auto'} custom-scrollbar flex flex-col`}
@@ -310,7 +310,7 @@ export const DirectConnectionPanel: React.FC<DirectConnectionPanelProps> = ({
                                                 ref={el => { leftSlotsRef.current[idx] = el; }}
                                                 onMouseDown={(e) => onDragStart(e, idx, output.type, true)}
                                                 onTouchStart={(e) => onDragStart(e, idx, output.type, true)}
-                                                className={`w-10 h-10 rounded-full bg-white/10 border-4 border-[#374151] flex flex-shrink-0 items-center justify-center cursor-crosshair active:scale-90 transition-all hover:bg-white/20 ${activeDrag ? 'pointer-events-none' : ''}`}
+                                                className={`w-10 h-10 rounded-full bg-black/25 border-[3px] border-white/15 flex flex-shrink-0 items-center justify-center cursor-crosshair active:scale-90 transition-all hover:bg-black/40 ${activeDrag ? 'pointer-events-none' : ''}`}
                                             >
                                                 <div
                                                     className="w-3 h-3 rounded-full pointer-events-none"
@@ -327,13 +327,13 @@ export const DirectConnectionPanel: React.FC<DirectConnectionPanelProps> = ({
                         </div>
 
                         <div
-                            className="w-[42%] max-w-[320px] h-[90%] rounded-l-[40px] border-y border-l border-white/10 shadow-2xl flex flex-col py-8 pr-6 pl-2 relative overflow-hidden -mr-4"
+                            className="w-[42%] max-w-[320px] h-[90%] rounded-l-xl border-y border-l border-white/10 shadow-2xl flex flex-col py-5 pr-4 pl-2 relative overflow-hidden -mr-4"
                             style={{ backgroundColor: targetBgColor }}
                         >
                             <div className="absolute top-0 right-0 w-1.5 h-full bg-black/20" />
                             <div className="mb-6 text-right">
-                                <span className="text-[10px] font-black uppercase tracking-[0.2em] text-red-400">{t('node.targetInputs')}</span>
-                                <h3 className="text-lg font-bold text-white/90 line-clamp-2 break-all">{targetNode.title || targetNode.type}</h3>
+                                <span className="text-[10px] font-black uppercase tracking-[0.2em] text-[#f87c7c]">{t('node.targetInputs')}</span>
+                                <h3 className="text-[14px] font-bold text-white/90 line-clamp-2 break-all">{targetNode.title || targetNode.type}</h3>
                             </div>
                             <div
                                 className={`flex-1 ${activeDrag ? 'overflow-hidden' : 'overflow-y-auto'} custom-scrollbar flex flex-col`}
@@ -357,7 +357,7 @@ export const DirectConnectionPanel: React.FC<DirectConnectionPanelProps> = ({
                                                 ref={el => { rightSlotsRef.current[idx] = el; }}
                                                 onMouseDown={(e) => onDragStart(e, idx, input.type, false)}
                                                 onTouchStart={(e) => onDragStart(e, idx, input.type, false)}
-                                                className={`w-10 h-10 rounded-full bg-white/10 border-4 border-[#374151] flex flex-shrink-0 items-center justify-center cursor-crosshair active:scale-90 transition-all hover:bg-white/20 ${activeDrag ? 'pointer-events-none' : ''}`}
+                                                className={`w-10 h-10 rounded-full bg-black/25 border-[3px] border-white/15 flex flex-shrink-0 items-center justify-center cursor-crosshair active:scale-90 transition-all hover:bg-black/40 ${activeDrag ? 'pointer-events-none' : ''}`}
                                             >
                                                 <div
                                                     className="w-3 h-3 rounded-full pointer-events-none"
@@ -444,13 +444,13 @@ export const DirectConnectionPanel: React.FC<DirectConnectionPanelProps> = ({
                             <Button
                                 variant="outline"
                                 onClick={onClose}
-                                className="h-14 px-10 rounded-[28px] bg-white/5 border-white/10 text-white font-bold hover:bg-white/10 active:scale-95 transition-all"
+                                className="h-10 px-10 rounded-[14px] bg-white/5 border-white/10 text-white font-bold hover:bg-white/10 active:scale-95 transition-all"
                             >
                                 {t('common.cancel')}
                             </Button>
                             <Button
                                 onClick={handleApply}
-                                className="h-14 px-10 rounded-[28px] bg-blue-500 hover:bg-blue-600 text-white font-black shadow-xl shadow-blue-500/20 active:scale-95 transition-all flex items-center space-x-2"
+                                className="h-10 px-10 rounded-[14px] bg-[#3069f0] hover:bg-[#3069f0] text-white font-black shadow-xl shadow-blue-500/20 active:scale-95 transition-all flex items-center space-x-2"
                             >
                                 <Check className="w-5 h-5" />
                                 <span>{t('node.applyChanges')}</span>

--- a/src/components/canvas/GroupInspector.tsx
+++ b/src/components/canvas/GroupInspector.tsx
@@ -95,25 +95,25 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
       case NodeMode.ALWAYS:
         return {
           label: t('node.mode.always'),
-          color: 'text-emerald-400',
+          color: 'text-[#4ade80]',
           icon: <Play className="w-3.5 h-3.5" />
         };
       case NodeMode.NEVER:
         return {
           label: t('node.mode.mute'),
-          color: 'text-[#3b82f6]',
+          color: 'text-[#5b8af5]',
           icon: <VolumeX className="w-3.5 h-3.5" />
         };
       case NodeMode.BYPASS:
         return {
           label: t('node.mode.bypass'),
-          color: 'text-[#9333ea]',
+          color: 'text-[#9a8af0]',
           icon: <Shuffle className="w-3.5 h-3.5" />
         };
       default:
         return {
           label: t('node.mode.always'),
-          color: 'text-emerald-400',
+          color: 'text-[#4ade80]',
           icon: <Play className="w-3.5 h-3.5" />
         };
     }
@@ -138,7 +138,7 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
 
   return createPortal(
     <AnimatePresence>
-      <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6" style={{ pointerEvents: 'none' }}>
+      <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-4" style={{ pointerEvents: 'none' }}>
         {/* Backdrop */}
         <motion.div
           initial={{ opacity: 0 }}
@@ -154,10 +154,10 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.96, y: 15 }}
           transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-          className="relative w-[80vw] h-[75vh] pointer-events-auto flex flex-col"
+          className="relative w-[85vw] max-w-md h-[64vh] pointer-events-auto flex flex-col"
         >
           {/* Action Buttons Row - Positioned above the modal */}
-          <div className="absolute top-0 left-0 -translate-y-[calc(100%+16px)] flex items-center w-full min-h-[48px] pointer-events-none">
+          <div className="absolute top-0 left-0 -translate-y-[calc(100%+12px)] flex items-center w-full min-h-[40px] pointer-events-none">
             <div className="flex items-center pointer-events-auto">
               <motion.div
                 initial={{ opacity: 0 }}
@@ -165,11 +165,11 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
                 transition={{ duration: 0.15 }}
                 className="flex items-center gap-2"
               >
-                <div className="flex items-center gap-1 p-1 bg-[#374151] rounded-full shadow-xl border border-white/10">
+                <div className="flex items-center gap-1 p-1 bg-[#0f1116]/90 backdrop-blur-md rounded-[10px] shadow-xl border border-white/10">
                   {[
-                    { id: NodeMode.ALWAYS, icon: Play, activeColor: 'text-emerald-400', label: t('node.allAlways') },
-                    { id: NodeMode.NEVER, icon: VolumeX, activeColor: 'text-[#3b82f6]', label: t('node.allMute') },
-                    { id: NodeMode.BYPASS, icon: Shuffle, activeColor: 'text-[#9333ea]', label: t('node.allBypass') }
+                    { id: NodeMode.ALWAYS, icon: Play, activeColor: 'text-[#4ade80]', label: t('node.allAlways') },
+                    { id: NodeMode.NEVER, icon: VolumeX, activeColor: 'text-[#5b8af5]', label: t('node.allMute') },
+                    { id: NodeMode.BYPASS, icon: Shuffle, activeColor: 'text-[#9a8af0]', label: t('node.allBypass') }
                   ].map((mode) => {
                     const isActive = commonMode === mode.id;
                     return (
@@ -177,13 +177,13 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
                         key={mode.id}
                         onClick={() => setAllNodesMode(mode.id)}
                         title={mode.label}
-                        className={`w-10 h-10 rounded-full flex items-center justify-center transition-all active:scale-90 
+                        className={`w-8 h-8 rounded-[7px] flex items-center justify-center transition-all active:scale-90 
                           ${isActive
                             ? `${mode.activeColor} bg-white/10 ring-1 ring-white/20 shadow-inner`
                             : 'text-white/40 hover:text-white/80 hover:bg-white/5'
                           }`}
                       >
-                        <mode.icon className="w-5 h-5" />
+                        <mode.icon className="w-4 h-4" />
                       </button>
                     );
                   })}
@@ -193,10 +193,10 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
 
                 <button
                   onClick={() => setIsDeleteDialogOpen(true)}
-                  className="w-12 h-12 rounded-full bg-[#374151] shadow-xl border border-white/10 flex items-center justify-center text-red-400 hover:text-red-500 hover:bg-red-500/10 transition-all active:scale-95"
+                  className="w-[38px] h-[38px] rounded-[10px] bg-[#0f1116]/90 backdrop-blur-md shadow-xl border border-white/10 flex items-center justify-center text-[#f87c7c] hover:text-[#f25555] hover:bg-[#f25555]/10 transition-all active:scale-95"
                   title={t('node.deleteGroup')}
                 >
-                  <Trash2 className="w-5 h-5" />
+                  <Trash2 className="w-4 h-4" />
                 </button>
               </motion.div>
             </div>
@@ -204,15 +204,15 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
 
           {/* Main Card */}
           <div
-            style={{ backgroundColor: '#374151' }}
-            className="relative w-full h-full rounded-3xl shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white"
+            style={{ backgroundColor: '#101217' }}
+            className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
             {/* Dynamic Sticky Header */}
             <div
               className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] transition-all duration-300 ease-in-out
                 ${isHeaderCompact
-                  ? 'pt-2 pb-[13px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10'
-                  : 'pt-6 pb-6 pl-6 pr-16 border-transparent bg-black/20 backdrop-blur-0'
+                  ? 'pt-1.5 pb-[11px] pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]'
+                  : 'pt-4 pb-3.5 pl-4 pr-12 border-transparent bg-black/20 backdrop-blur-0'
                 }`}
             >
               {/* Floating Close Button */}
@@ -221,33 +221,33 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
               >
                 <button
                   onClick={onClose}
-                  className="p-2 rounded-full bg-black/20 text-white hover:bg-black/40 transition-all"
+                  className="p-1.5 rounded-lg bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1] transition-all"
                 >
-                  <X className="w-5 h-5" />
+                  <X className="w-4 h-4" />
                 </button>
               </div>
 
               <div className="flex flex-col justify-center flex-1 min-w-0">
                 <div
-                  className={`flex items-center space-x-2 transition-all duration-300 origin-left ${isHeaderCompact ? 'mb-1 scale-90' : 'mb-3 scale-100'}`}
+                  className={`flex items-center space-x-2 transition-all duration-300 origin-left ${isHeaderCompact ? 'mb-0.5 scale-90' : 'mb-2 scale-100'}`}
                 >
-                  <Badge variant="secondary" className="text-[10px] font-mono px-2 py-0.5 rounded-full bg-black/20 text-white/80">
+                  <Badge variant="secondary" className="text-[9px] font-mono px-1.5 py-0.5 rounded-md bg-black/20 text-white/80">
                     ID: {groupInfo.groupId}
                   </Badge>
-                  <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">
+                  <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-white/60">
                     GROUP
                   </span>
                 </div>
 
                 <div
                   className="flex items-center min-w-0 transition-all duration-300"
-                  style={{ height: isHeaderCompact ? '13px' : '2rem' }}
+                  style={{ height: isHeaderCompact ? '12px' : '1.125rem' }}
                 >
                   <h2
                     style={{
-                      fontSize: '1.875rem',
+                      fontSize: '1.125rem',
                       lineHeight: '1',
-                      transform: isHeaderCompact ? `scale(${0.8125 / 1.875})` : 'scale(1)',
+                      transform: isHeaderCompact ? `scale(${0.75 / 1.125})` : 'scale(1)',
                       transformOrigin: 'left center',
                     }}
                     className="font-extrabold tracking-tight leading-tight text-white/95 transition-transform duration-300 will-change-transform truncate pr-4"
@@ -257,10 +257,10 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
                 </div>
 
                 <div
-                  className={`inline-flex self-start items-center text-xs font-medium px-2 rounded-md border m-0 transition-all duration-300 overflow-hidden text-white/80 bg-black/20 border-white/10
+                  className={`inline-flex self-start items-center text-[10px] font-medium px-1.5 rounded-md border m-0 transition-all duration-300 overflow-hidden text-white/80 bg-black/20 border-white/10
                     ${isHeaderCompact
                       ? 'opacity-0 scale-75 h-0 mt-0 py-0 border-transparent'
-                      : 'opacity-100 scale-100 h-6 mt-3 py-1'
+                      : 'opacity-100 scale-100 h-5 mt-2 py-0.5'
                     }`}
                 >
                   {t('node.nodesCount', { count: groupInfo.nodeIds.length })}
@@ -271,18 +271,18 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
             {/* Content Area */}
             <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
               {/* Static Top Bumper */}
-              <div className="h-[150px] relative pointer-events-none">
+              <div className="h-[96px] relative pointer-events-none">
                 <div ref={sentinelRef} className="absolute top-[10px] left-0 h-px w-full" />
               </div>
 
-              <div className="px-5 py-6 sm:px-6">
+              <div className="px-3 py-4">
                 {/* Nodes List Stack */}
-                <div className="space-y-4">
+                <div className="space-y-2.5">
                   <div className="flex items-center gap-2 mb-2 p-1">
-                    <MousePointer2 className="w-4 h-4 text-white/50" />
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-white/50">Nodes in Group</span>
+                    <MousePointer2 className="w-3.5 h-3.5 text-white/50" />
+                    <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-white/50">Nodes in Group</span>
                   </div>
-                  <div className="grid grid-cols-1 gap-3">
+                  <div className="grid grid-cols-1 gap-2">
                     {groupInfo.nodes.map((node: any) => {
                       const nodeMode = getNodeMode(node.id, node.mode || NodeMode.ALWAYS);
                       const modeConfig = getModeConfig(nodeMode);
@@ -290,43 +290,43 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
                       return (
                         <div
                           key={node.id}
-                          className="group relative p-4 rounded-2xl bg-black/10 border border-white/5 hover:bg-black/20 hover:border-white/10 transition-all"
+                          className="group relative px-2.5 py-2 rounded-[10px] bg-white/[0.03] border border-white/[0.07] hover:bg-white/[0.05] hover:border-white/[0.12] transition-all"
                         >
-                          <div className="flex items-center justify-between gap-4">
+                          <div className="flex items-center justify-between gap-2.5">
                             <div className="flex-1 min-w-0">
                               <div
                                 className="flex items-center gap-2 mb-1 cursor-pointer group/title"
                                 onClick={() => onSelectNode(node)}
                               >
-                                <h4 className="font-bold text-base text-white/90 truncate group-hover/title:text-white transition-colors">
+                                <h4 className="font-semibold text-[12px] text-[#e9ebef] truncate group-hover/title:text-white transition-colors">
                                   {node.title || node.type}
                                 </h4>
                               </div>
-                              <div className="flex items-center gap-3 text-[10px] font-medium text-white/40">
+                              <div className="flex items-center gap-2 font-mono text-[9.5px] text-[#565d6b]">
                                 <span>ID: {node.id}</span>
                                 <span className="truncate">Type: {node.type}</span>
                               </div>
                             </div>
 
-                            <div className="flex items-center gap-1 bg-black/20 p-1 rounded-xl">
+                            <div className="flex items-center gap-0.5 bg-black/20 p-0.5 rounded-lg">
                               {/* Discrete mode buttons */}
                               {[
-                                { mode: NodeMode.ALWAYS, icon: Play, color: 'text-emerald-400', bg: 'bg-emerald-400/10', hover: 'hover:bg-emerald-400/20', label: t('node.mode.always') },
-                                { mode: NodeMode.NEVER, icon: VolumeX, color: 'text-[#3b82f6]', bg: 'bg-[#3b82f6]/10', hover: 'hover:bg-[#3b82f6]/20', label: t('node.mode.mute') },
-                                { mode: NodeMode.BYPASS, icon: Shuffle, color: 'text-[#9333ea]', bg: 'bg-[#9333ea]/10', hover: 'hover:bg-[#9333ea]/20', label: t('node.mode.bypass') }
+                                { mode: NodeMode.ALWAYS, icon: Play, color: 'text-[#4ade80]', bg: 'bg-[#34c77b]/[0.12]', hover: 'hover:bg-[#34c77b]/[0.2]', label: t('node.mode.always') },
+                                { mode: NodeMode.NEVER, icon: VolumeX, color: 'text-[#5b8af5]', bg: 'bg-[#3069f0]/[0.12]', hover: 'hover:bg-[#3069f0]/[0.2]', label: t('node.mode.mute') },
+                                { mode: NodeMode.BYPASS, icon: Shuffle, color: 'text-[#9a8af0]', bg: 'bg-[#9a8af0]/[0.12]', hover: 'hover:bg-[#9a8af0]/[0.2]', label: t('node.mode.bypass') }
                               ].map((config) => {
                                 const isActive = nodeMode === config.mode;
                                 return (
                                   <button
                                     key={config.mode}
                                     onClick={() => onNodeModeChange(node.id, config.mode)}
-                                    className={`p-2 rounded-lg transition-all active:scale-90 ${isActive
+                                    className={`p-1.5 rounded-[7px] transition-all active:scale-90 ${isActive
                                       ? `${config.color} ${config.bg}`
                                       : 'text-white/20 hover:text-white/60 hover:bg-white/5'
                                       }`}
                                     title={config.label}
                                   >
-                                    <config.icon className="w-5 h-5" />
+                                    <config.icon className="w-4 h-4" />
                                   </button>
                                 );
                               })}
@@ -337,8 +337,8 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
                     })}
 
                     {groupInfo.nodes.length === 0 && (
-                      <div className="text-center py-12 rounded-3xl bg-black/10 border border-dashed border-white/10">
-                        <p className="text-white/40 text-sm">{t('node.noNodesInGroup')}</p>
+                      <div className="text-center py-12 rounded-xl bg-black/10 border border-dashed border-white/10">
+                        <p className="text-white/40 text-[12px]">{t('node.noNodesInGroup')}</p>
                       </div>
                     )}
                   </div>

--- a/src/components/canvas/NodeDetailModal.tsx
+++ b/src/components/canvas/NodeDetailModal.tsx
@@ -169,7 +169,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
     const isBypassed = currentMode === 4;
     const isAlways = currentMode === 0;
 
-    const baseColor = (selectedNode.bgcolor || selectedNode.color || (selectedNode.properties?.['Node Color'])) || '#374151';
+    const baseColor = (selectedNode.bgcolor || selectedNode.color || (selectedNode.properties?.['Node Color'])) || '#14171e';
     const effectiveBgColor = isMuted ? '#3b82f6' : (isBypassed ? '#9333ea' : baseColor);
     const effectiveOpacity = (isMuted || isBypassed) ? 0.5 : 1;
 
@@ -207,9 +207,9 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
     // Fixed base font size based on title length
     const baseTitleSize = useMemo(() => {
         const len = titleText?.length || 0;
-        if (len < 15) return '1.875rem'; // 30px
-        if (len < 25) return '1.5rem';    // 24px
-        return '1.25rem';                // 20px
+        if (len < 15) return '1.125rem'; // 18px
+        if (len < 25) return '1rem';      // 16px
+        return '0.875rem';               // 14px
     }, [titleText]);
 
     // Use IntersectionObserver to toggle compact mode
@@ -487,11 +487,11 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
     };
 
     const renderSectionHeader = (title: string, count?: number, icon?: React.ReactNode) => (
-        <div className={`flex items-center space-x-2 mb-4 mt-8 pb-2 border-b ${hasCustomColor ? 'border-white/10' : 'border-slate-100 dark:border-slate-800'}`}>
-            {icon && <span className={`${hasCustomColor ? 'text-white/70' : 'text-slate-500 dark:text-slate-400'}`}>{icon}</span>}
-            <h3 className={`text-xs font-bold uppercase tracking-widest ${hasCustomColor ? 'text-white/70' : 'text-slate-500 dark:text-slate-400'}`}>
+        <div className={`flex items-center space-x-2 mb-2.5 mt-5 pb-1.5 border-b ${hasCustomColor ? 'border-white/10' : 'border-white/[0.07]'}`}>
+            {icon && <span className={`${hasCustomColor ? 'text-white/70' : 'text-[#71798a]'}`}>{icon}</span>}
+            <h3 className={`font-mono text-[10px] font-semibold uppercase tracking-[0.12em] ${hasCustomColor ? 'text-white/70' : 'text-[#71798a]'}`}>
                 {title}
-                {count !== undefined && <span className={`ml-2 px-1.5 py-0.5 rounded-md text-[10px] font-bold ${hasCustomColor ? 'bg-black/20 text-white/80' : 'bg-slate-100 dark:bg-slate-800 text-slate-500'}`}>{count}</span>}
+                {count !== undefined && <span className={`ml-2 px-1.5 py-0.5 rounded-md text-[10px] font-bold ${hasCustomColor ? 'bg-black/20 text-white/80' : 'bg-white/[0.06] text-[#71798a]'}`}>{count}</span>}
             </h3>
         </div>
     );
@@ -503,7 +503,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
         const filteredParams = isPointsEditor ? params.filter(param => !readonlyParams.includes(param.name)) : params;
 
         return (
-            <div className="space-y-4">
+            <div className="space-y-2.5">
                 {/* Title is optional for widgets if it's the main section */}
                 {title !== "Node Widgets" && renderSectionHeader(title, filteredParams.length, icon)}
 
@@ -518,14 +518,14 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                     </div>
                 )}
 
-                <div className="grid grid-cols-1 gap-4">
+                <div className="grid grid-cols-1 gap-2">
                     {filteredParams.map((param, index) => (
                         <div key={`${param.name}-${index}`} className="group relative">
                             {isWidgetValues && selectedNode ? (
                                 isInputConnected(param.name) ? (
-                                    <div className={`flex items-center justify-between p-3 rounded-lg border ${hasCustomColor ? 'bg-black/10 border-white/10 text-white' : 'bg-blue-50/50 dark:bg-blue-900/10 border-blue-100 dark:border-blue-900'}`}>
+                                    <div className={`flex items-center justify-between px-2.5 py-2 rounded-lg border ${hasCustomColor ? 'bg-black/10 border-white/10 text-white' : 'bg-blue-50/50 dark:bg-blue-900/10 border-blue-100 dark:border-blue-900'}`}>
                                         <div className="flex items-center space-x-2">
-                                            <span className={`text-sm font-medium ${hasCustomColor ? 'text-white' : 'text-slate-700 dark:text-slate-300'}`}>{getSlotLabel(param)}</span>
+                                            <span className={`text-[12px] font-medium ${hasCustomColor ? 'text-white' : 'text-[#c8ccd4]'}`}>{getSlotLabel(param)}</span>
                                         </div>
                                         <div className={`flex items-center space-x-2 text-xs ${hasCustomColor ? 'text-white/70' : 'text-blue-600 dark:text-blue-400'}`}>
                                             <ExternalLink className="w-3 h-3" />
@@ -608,9 +608,9 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                 )
                             ) : (
                                 // Read-only
-                                <div className={`flex justify-between items-center p-3 rounded-lg ${hasCustomColor ? 'bg-black/10 text-white' : 'bg-slate-50 dark:bg-slate-800/50'}`}>
-                                    <span className={`text-sm font-medium ${hasCustomColor ? 'text-white' : 'text-slate-700 dark:text-slate-300'}`}>{getSlotLabel(param)}</span>
-                                    <span className={`text-sm ${hasCustomColor ? 'text-white/70' : 'text-slate-500'}`}>{String(param.value)}</span>
+                                <div className={`flex justify-between items-center px-2.5 py-2 rounded-lg ${hasCustomColor ? 'bg-black/10 text-white' : 'bg-white/[0.04]'}`}>
+                                    <span className={`text-[12px] font-medium ${hasCustomColor ? 'text-white' : 'text-[#c8ccd4]'}`}>{getSlotLabel(param)}</span>
+                                    <span className={`text-[12px] ${hasCustomColor ? 'text-white/70' : 'text-[#71798a]'}`}>{String(param.value)}</span>
                                 </div>
                             )}
                         </div>
@@ -712,22 +712,22 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                         return (
                             <div key={`input-${index}`} className="group">
                                 {input.link && sourceInfo ? (
-                                    <div className={`flex items-center justify-between p-3 rounded-lg border shadow-sm transition-all ${hasCustomColor ? 'bg-black/10 border-white/5 hover:border-white/30' : 'bg-white border-slate-200 hover:border-blue-300 dark:bg-slate-800 dark:border-slate-700 dark:hover:border-blue-700'}`}>
+                                    <div className={`flex items-center justify-between px-2.5 py-2 rounded-lg border shadow-sm transition-all ${hasCustomColor ? 'bg-black/10 border-white/5 hover:border-white/30' : 'bg-white/[0.03] border-white/[0.08] hover:border-[#3069f0]/40'}`}>
                                         <div className="flex items-center min-w-0 mr-3">
                                             {/* Dot */}
                                             <div className="w-2.5 h-2.5 rounded-full mr-3 flex-shrink-0 shadow-sm" style={{ backgroundColor: getSlotColor(input.type) }} />
                                             <div className="flex flex-col min-w-0">
-                                                <span className={`text-xs font-semibold uppercase tracking-wider mb-0.5 ${hasCustomColor ? 'text-white/50' : 'text-slate-500'}`}>{getSlotLabel(input)}</span>
+                                                <span className={`text-xs font-semibold uppercase tracking-wider mb-0.5 ${hasCustomColor ? 'text-white/50' : 'text-[#71798a]'}`}>{getSlotLabel(input)}</span>
                                                 <div className="flex items-center space-x-1.5 cursor-pointer"
                                                     onClick={() => {
                                                         onNavigateToNode(sourceInfo.sourceNodeId);
                                                         const sourceNode = nodeBounds.get(sourceInfo.sourceNodeId)?.node;
                                                         if (sourceNode) setTimeout(() => onSelectNode(sourceNode), 300);
                                                     }}>
-                                                    <span className={`text-sm font-medium truncate hover:underline ${hasCustomColor ? 'text-white' : 'text-blue-600 dark:text-blue-400'}`}>
+                                                    <span className={`text-[12px] font-medium truncate hover:underline ${hasCustomColor ? 'text-white' : 'text-blue-600 dark:text-blue-400'}`}>
                                                         {sourceInfo.sourceNodeTitle}
                                                     </span>
-                                                    <ExternalLink className={`w-3 h-3 ${hasCustomColor ? 'text-white/40' : 'text-slate-400'}`} />
+                                                    <ExternalLink className={`w-3 h-3 ${hasCustomColor ? 'text-white/40' : 'text-[#565d6b]'}`} />
                                                 </div>
                                             </div>
                                         </div>
@@ -739,19 +739,19 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                     const actualIndex = selectedNode.inputs?.findIndex(i => i.name === input.name && i.type === input.type) ?? -1;
                                                     if (actualIndex >= 0) onDisconnectInput(nodeId, actualIndex);
                                                 }}
-                                                className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                                                className="p-1.5 text-[#565d6b] hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
                                             >
                                                 <X className="w-4 h-4" />
                                             </button>
                                         )}
                                     </div>
                                 ) : (
-                                    <div className={`flex items-center justify-between p-2.5 rounded-lg border ${hasCustomColor ? 'bg-black/5 border-white/5' : 'bg-slate-50/50 border-slate-100 dark:bg-slate-800/30 dark:border-slate-800'}`}>
+                                    <div className={`flex items-center justify-between px-2.5 py-1.5 rounded-lg border ${hasCustomColor ? 'bg-black/5 border-white/5' : 'bg-white/[0.03] border-white/[0.07]'}`}>
                                         <div className="flex items-center space-x-3">
                                             <div className="w-2 h-2 rounded-full ring-2 ring-opacity-50" style={{ backgroundColor: 'transparent', borderColor: getSlotColor(input.type) }} />
-                                            <span className={`text-sm font-medium ${hasCustomColor ? 'text-white/80' : 'text-slate-600 dark:text-slate-400'}`}>{getSlotLabel(input)}</span>
+                                            <span className={`text-[12px] font-medium ${hasCustomColor ? 'text-white/80' : 'text-[#8a919e]'}`}>{getSlotLabel(input)}</span>
                                         </div>
-                                        <Badge variant="secondary" className={`text-[10px] font-normal ${hasCustomColor ? 'bg-black/20 text-white/50' : 'text-slate-400 bg-slate-100 dark:bg-slate-800'}`}>
+                                        <Badge variant="secondary" className={`text-[10px] font-normal ${hasCustomColor ? 'bg-black/20 text-white/50' : 'text-[#565d6b] bg-white/[0.06]'}`}>
                                             {input.type}
                                         </Badge>
                                     </div>
@@ -777,17 +777,17 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                 {/* Output Header / Label */}
                                 <div className="flex items-center px-1">
                                     <div className="w-2.5 h-2.5 rounded-full mr-3 flex-shrink-0 shadow-sm" style={{ backgroundColor: getSlotColor(output.type) }} />
-                                    <span className={`text-sm font-semibold ${hasCustomColor ? 'text-white' : 'text-slate-700 dark:text-slate-300'}`}>{getSlotLabel(output)}</span>
-                                    <span className={`ml-auto text-[10px] uppercase tracking-wider font-medium px-1.5 py-0.5 rounded ${hasCustomColor ? 'bg-black/20 text-white/50' : 'text-slate-400 bg-slate-100 dark:bg-slate-800'}`}>{output.type}</span>
+                                    <span className={`text-[12px] font-semibold ${hasCustomColor ? 'text-white' : 'text-[#c8ccd4]'}`}>{getSlotLabel(output)}</span>
+                                    <span className={`ml-auto text-[10px] uppercase tracking-wider font-medium px-1.5 py-0.5 rounded ${hasCustomColor ? 'bg-black/20 text-white/50' : 'text-[#565d6b] bg-white/[0.06]'}`}>{output.type}</span>
                                 </div>
 
                                 {/* Connections List */}
                                 {hasConnections ? (
-                                    <div className={`ml-3 pl-3 border-l-2 space-y-2 ${hasCustomColor ? 'border-white/10' : 'border-slate-100 dark:border-slate-800'}`}>
+                                    <div className={`ml-3 pl-3 border-l-2 space-y-2 ${hasCustomColor ? 'border-white/10' : 'border-white/[0.07]'}`}>
                                         {output.links.map((linkId: number) => {
                                             const targetInfo = getTargetNodeInfo(linkId);
                                             return targetInfo ? (
-                                                <div key={linkId} className={`flex items-center justify-between p-2.5 rounded-lg border shadow-sm transition-all ${hasCustomColor ? 'bg-black/10 border-white/5 hover:border-white/30' : 'bg-white border-slate-200 hover:border-green-300 dark:bg-slate-800 dark:border-slate-700 dark:hover:border-green-700'}`}>
+                                                <div key={linkId} className={`flex items-center justify-between px-2.5 py-1.5 rounded-lg border shadow-sm transition-all ${hasCustomColor ? 'bg-black/10 border-white/5 hover:border-white/30' : 'bg-white/[0.03] border-white/[0.08] hover:border-[#34c77b]/40'}`}>
                                                     <div className="flex items-center space-x-2 cursor-pointer overflow-hidden flex-1"
                                                         onClick={() => {
                                                             onNavigateToNode(targetInfo.targetNodeId);
@@ -796,10 +796,10 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                         }}
                                                     >
                                                         <ExternalLink className="w-3 h-3 text-green-500 flex-shrink-0" />
-                                                        <span className={`text-sm font-medium truncate hover:underline ${hasCustomColor ? 'text-white' : 'text-slate-900 dark:text-slate-200'}`}>
+                                                        <span className={`text-[12px] font-medium truncate hover:underline ${hasCustomColor ? 'text-white' : 'text-[#e9ebef]'}`}>
                                                             {targetInfo.targetNodeTitle}
                                                         </span>
-                                                        <span className={`hidden sm:inline-block text-xs truncate ${hasCustomColor ? 'text-white/50' : 'text-slate-400'}`}>({targetInfo.targetInputName})</span>
+                                                        <span className={`hidden sm:inline-block text-xs truncate ${hasCustomColor ? 'text-white/50' : 'text-[#565d6b]'}`}>({targetInfo.targetInputName})</span>
                                                     </div>
 
                                                     {onDisconnectOutput && (
@@ -808,7 +808,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                                 e.stopPropagation();
                                                                 onDisconnectOutput(nodeId, index, linkId);
                                                             }}
-                                                            className="flex-shrink-0 p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                                                            className="flex-shrink-0 p-1.5 text-[#565d6b] hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
                                                         >
                                                             <X className="w-4 h-4" />
                                                         </button>
@@ -819,7 +819,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                     </div>
                                 ) : (
                                     <div className="ml-4 pl-3">
-                                        <p className="text-xs text-slate-400 italic">No connections</p>
+                                        <p className="text-xs text-[#565d6b] italic">No connections</p>
                                     </div>
                                 )}
                             </div>
@@ -833,11 +833,11 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
     const renderSingleExecute = () => {
         if (!canSingleExecute || !onSingleExecute) return null;
         return (
-            <div className="mt-10 pt-6 border-t border-slate-100 dark:border-slate-800">
+            <div className="mt-10 pt-6 border-t border-white/[0.07]">
                 <div className="flex items-center justify-between mb-2">
                     <div>
-                        <h4 className="text-sm font-bold text-slate-900 dark:text-slate-100">Single Execution</h4>
-                        <p className="text-xs text-slate-500 mt-0.5">Process only this node.</p>
+                        <h4 className="text-[12px] font-bold text-[#e9ebef]">Single Execution</h4>
+                        <p className="text-xs text-[#71798a] mt-0.5">Process only this node.</p>
                     </div>
                 </div>
                 <Button
@@ -885,10 +885,10 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                     }}
                     exit={{ opacity: 0, scale: 0.96, y: 15 }}
                     transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-                    className="relative w-[80vw] h-[75vh] pointer-events-auto flex flex-col"
+                    className="relative w-[85vw] max-w-md h-[66vh] pointer-events-auto flex flex-col"
                 >
                     {/* Action Buttons Row - Positioned above the modal */}
-                    <div className="absolute top-0 left-0 -translate-y-[calc(100%+16px)] flex items-center w-full min-h-[48px] pointer-events-none">
+                    <div className="absolute top-0 left-0 -translate-y-[calc(100%+12px)] flex items-center w-full min-h-[40px] pointer-events-none">
                         <div className="flex items-center pointer-events-auto">
                             <AnimatePresence mode="wait">
                                 {!showColorPicker ? (
@@ -908,39 +908,39 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                     onEnterSubgraph(selectedNode.type, selectedNode.title || subgraphDefinition.name || 'Subgraph');
                                                     onClose();
                                                 }}
-                                                className="w-12 h-12 rounded-full bg-[#374151] shadow-xl border border-white/10 flex items-center justify-center text-blue-400 hover:text-blue-500 hover:bg-blue-500/10 transition-all active:scale-95"
+                                                className="w-[38px] h-[38px] rounded-[10px] bg-[#0f1116]/90 backdrop-blur-md shadow-xl border border-white/10 flex items-center justify-center text-[#5b8af5] hover:text-[#7ba3f5] hover:bg-[#3069f0]/10 transition-all active:scale-95"
                                                 title="Edit Subgraph"
                                             >
-                                                <Edit3 className="w-5 h-5" />
+                                                <Edit3 className="w-4 h-4" />
                                             </button>
                                         ) : (
                                             <button
                                                 onClick={() => onCopyNode?.(nodeId)}
-                                                className="w-12 h-12 rounded-full bg-[#374151] shadow-xl border border-white/10 flex items-center justify-center text-white/80 hover:text-white transition-colors active:scale-95"
+                                                className="w-[38px] h-[38px] rounded-[10px] bg-[#0f1116]/90 backdrop-blur-md shadow-xl border border-white/10 flex items-center justify-center text-white/80 hover:text-white transition-colors active:scale-95"
                                                 title={t('circularMenu.node.copy')}
                                             >
-                                                <Copy className="w-5 h-5" />
+                                                <Copy className="w-4 h-4" />
                                             </button>
                                         )}
 
                                         <div className="w-[1px] h-6 bg-white/10 mx-1" />
 
-                                        <div className="flex items-center gap-1 p-1 bg-[#374151] rounded-full shadow-xl border border-white/10">
+                                        <div className="flex items-center gap-1 p-1 bg-[#0f1116]/90 backdrop-blur-md rounded-[10px] shadow-xl border border-white/10">
                                             {[
-                                                { id: 0, icon: Play, activeColor: 'text-emerald-400', label: t('node.mode.always') },
-                                                { id: 2, icon: VolumeX, activeColor: 'text-[#3b82f6]', label: t('node.mode.mute') },
-                                                { id: 4, icon: Shuffle, activeColor: 'text-[#9333ea]', label: t('node.mode.bypass') }
+                                                { id: 0, icon: Play, activeColor: 'text-[#4ade80]', label: t('node.mode.always') },
+                                                { id: 2, icon: VolumeX, activeColor: 'text-[#5b8af5]', label: t('node.mode.mute') },
+                                                { id: 4, icon: Shuffle, activeColor: 'text-[#9a8af0]', label: t('node.mode.bypass') }
                                             ].map((mode) => (
                                                 <button
                                                     key={mode.id}
                                                     onClick={() => onNodeModeChange?.(nodeId, mode.id)}
                                                     title={mode.label}
-                                                    className={`w-10 h-10 rounded-full flex items-center justify-center transition-all active:scale-90 ${currentMode === mode.id
+                                                    className={`w-8 h-8 rounded-[7px] flex items-center justify-center transition-all active:scale-90 ${currentMode === mode.id
                                                         ? `${mode.activeColor} bg-white/10 shadow-inner`
                                                         : 'text-white/40 hover:text-white/60 hover:bg-white/5'
                                                         }`}
                                                 >
-                                                    <mode.icon className="w-5 h-5" />
+                                                    <mode.icon className="w-4 h-4" />
                                                 </button>
                                             ))}
                                         </div>
@@ -949,20 +949,20 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
 
                                         <button
                                             onClick={() => setShowColorPicker(true)}
-                                            className="w-12 h-12 rounded-full bg-[#374151] shadow-xl border border-white/10 flex items-center justify-center text-white/80 transition-all active:scale-95"
+                                            className="w-[38px] h-[38px] rounded-[10px] bg-[#0f1116]/90 backdrop-blur-md shadow-xl border border-white/10 flex items-center justify-center text-white/80 transition-all active:scale-95"
                                             title={t('circularMenu.node.color')}
                                         >
-                                            <Palette className="w-5 h-5" />
+                                            <Palette className="w-4 h-4" />
                                         </button>
 
                                         <div className="w-[1px] h-6 bg-white/10 mx-1" />
 
                                         <button
                                             onClick={() => onNodeDelete?.(nodeId)}
-                                            className="w-12 h-12 rounded-full bg-[#374151] shadow-xl border border-white/10 flex items-center justify-center text-red-400 hover:text-red-500 hover:bg-red-500/10 transition-all active:scale-95"
+                                            className="w-[38px] h-[38px] rounded-[10px] bg-[#0f1116]/90 backdrop-blur-md shadow-xl border border-white/10 flex items-center justify-center text-[#f87c7c] hover:text-[#f25555] hover:bg-[#f25555]/10 transition-all active:scale-95"
                                             title={t('circularMenu.node.delete')}
                                         >
-                                            <Trash2 className="w-5 h-5" />
+                                            <Trash2 className="w-4 h-4" />
                                         </button>
 
 
@@ -978,12 +978,12 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                     >
                                         <button
                                             onClick={() => setShowColorPicker(false)}
-                                            className="w-12 h-12 rounded-full bg-[#374151] shadow-xl border border-white/30 flex items-center justify-center text-white transition-all active:scale-95 flex-shrink-0"
+                                            className="w-[38px] h-[38px] rounded-[10px] bg-[#0f1116]/90 backdrop-blur-md shadow-xl border border-white/25 flex items-center justify-center text-white transition-all active:scale-95 flex-shrink-0"
                                         >
                                             <X className="w-5 h-5" />
                                         </button>
 
-                                        <div className="grid grid-cols-5 items-center gap-1.5 p-1.5 bg-[#374151] rounded-2xl shadow-xl border border-white/10 max-w-full overflow-hidden">
+                                        <div className="grid grid-cols-5 items-center gap-1.5 p-1.5 bg-[#0f1116]/90 backdrop-blur-md rounded-[10px] shadow-xl border border-white/10 max-w-full overflow-hidden">
                                             {NODE_COLORS.map((c) => (
                                                 <button
                                                     key={c.name}
@@ -991,8 +991,8 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                         onNodeColorChange?.(nodeId, c.value);
                                                         setShowColorPicker(false);
                                                     }}
-                                                    style={{ backgroundColor: c.value || '#374151' }}
-                                                    className="w-10 h-10 rounded-full border border-white/20 shadow-sm active:scale-90 transition-transform flex-shrink-0"
+                                                    style={{ backgroundColor: c.value || '#14171e' }}
+                                                    className="w-8 h-8 rounded-[7px] border border-white/20 shadow-sm active:scale-90 transition-transform flex-shrink-0"
                                                     title={t(c.key)}
                                                 />
                                             ))}
@@ -1009,14 +1009,14 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                             backgroundColor: effectiveBgColor,
                             opacity: effectiveOpacity
                         }}
-                        className={`relative w-full h-full bg-white dark:bg-slate-950 rounded-3xl shadow-2xl ring-1 ring-slate-900/5 dark:ring-slate-100/10 overflow-hidden flex flex-col ${hasCustomColor ? 'text-white' : ''}`}
+                        className={`relative w-full h-full bg-[#101217] rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col ${hasCustomColor ? 'text-white' : ''}`}
                     >
                         {/* Dynamic Sticky Header - Overlay Architecture */}
                         <div
                             className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] transition-all duration-300 ease-in-out
                                 ${isHeaderCompact
-                                    ? 'pt-2 pb-[13px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10'
-                                    : `pt-6 pb-6 pl-6 pr-16 border-transparent ${hasCustomColor ? 'bg-black/20' : 'bg-transparent'} backdrop-blur-0`
+                                    ? `pt-1.5 pb-[11px] pl-4 pr-[40px] backdrop-blur-xl border-white/[0.08] ${hasCustomColor ? 'bg-black/30' : 'bg-[#0f1116]/90'}`
+                                    : `pt-4 pb-3.5 pl-4 pr-12 border-transparent ${hasCustomColor ? 'bg-black/20' : 'bg-transparent'} backdrop-blur-0`
                                 }`}
                         >
                             {/* Minimalist Floating Close Button */}
@@ -1025,20 +1025,20 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                             >
                                 <button
                                     onClick={onClose}
-                                    className={`p-2 rounded-full transition-all ${hasCustomColor ? 'bg-black/20 text-white hover:bg-black/40' : 'bg-slate-100 dark:bg-slate-800 text-slate-500 hover:text-slate-900 hover:bg-slate-200 dark:hover:text-slate-200 dark:hover:bg-slate-700'}`}
+                                    className={`p-1.5 rounded-lg transition-all ${hasCustomColor ? 'bg-black/20 text-white hover:bg-black/40' : 'bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1]'}`}
                                 >
-                                    <X className="w-5 h-5" />
+                                    <X className="w-4 h-4" />
                                 </button>
                             </div>
 
                             <div className="flex flex-col justify-center flex-1 min-w-0">
                                 <div
-                                    className={`flex items-center space-x-2 transition-all duration-300 origin-left min-w-0 ${isHeaderCompact ? 'mb-1 scale-90' : 'mb-3 scale-100'}`}
+                                    className={`flex items-center space-x-2 transition-all duration-300 origin-left min-w-0 ${isHeaderCompact ? 'mb-0.5 scale-90' : 'mb-2 scale-100'}`}
                                 >
-                                    <Badge variant="secondary" className={`text-[10px] font-mono px-2 py-0.5 rounded-full transition-colors flex-shrink-0 ${hasCustomColor ? 'bg-black/20 text-white/80' : 'text-slate-500 bg-slate-100 dark:bg-slate-900'}`}>
+                                    <Badge variant="secondary" className={`text-[9px] font-mono px-1.5 py-0.5 rounded-md transition-colors flex-shrink-0 ${hasCustomColor ? 'bg-black/20 text-white/80' : 'text-[#8a919e] bg-white/[0.06]'}`}>
                                         ID: {nodeId}
                                     </Badge>
-                                    <span className={`text-[10px] font-bold uppercase tracking-widest transition-colors truncate min-w-0 block ${hasCustomColor ? 'text-white/60' : 'text-slate-400'}`}>
+                                    <span className={`font-mono text-[9px] font-semibold uppercase tracking-[0.12em] transition-colors truncate min-w-0 block ${hasCustomColor ? 'text-white/60' : 'text-[#565d6b]'}`}>
                                         {selectedNode.type}
                                     </span>
                                 </div>
@@ -1046,7 +1046,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                 {isEditingTitle ? (
                                     <div
                                         className="flex items-center min-w-0 transition-all duration-300"
-                                        style={{ height: isHeaderCompact ? '13px' : baseTitleSize }}
+                                        style={{ height: isHeaderCompact ? '12px' : baseTitleSize }}
                                     >
                                         <div className="flex items-center space-x-2 w-full">
                                             <input
@@ -1057,12 +1057,12 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                 style={{
                                                     fontSize: baseTitleSize,
                                                     lineHeight: '1',
-                                                    transform: isHeaderCompact ? `scale(${0.8125 / parseFloat(baseTitleSize)})` : 'scale(1)',
+                                                    transform: isHeaderCompact ? `scale(${0.75 / parseFloat(baseTitleSize)})` : 'scale(1)',
                                                     transformOrigin: 'left center',
                                                     width: '100%',
                                                     maxWidth: '100%'
                                                 }}
-                                                className={`flex-1 font-extrabold bg-transparent border-b-2 focus:outline-none transition-all ${hasCustomColor ? 'text-white border-white/50' : 'text-slate-900 dark:text-white border-primary'}`}
+                                                className={`flex-1 font-extrabold bg-transparent border-b-2 focus:outline-none transition-all ${hasCustomColor ? 'text-white border-white/50' : 'text-[#e9ebef] border-primary'}`}
                                                 autoFocus
                                             />
                                             <Button variant="ghost" size="icon" onClick={handleSaveTitleChange} className={`h-8 w-8 ${hasCustomColor ? 'text-white/80 hover:bg-white/10' : 'text-green-500'}`}>
@@ -1076,27 +1076,27 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                 ) : (
                                     <div
                                         className="flex items-center min-w-0 transition-all duration-300"
-                                        style={{ height: isHeaderCompact ? '13px' : baseTitleSize }}
+                                        style={{ height: isHeaderCompact ? '12px' : baseTitleSize }}
                                     >
                                         <div
                                             style={{
                                                 fontSize: baseTitleSize,
                                                 lineHeight: '1',
-                                                transform: isHeaderCompact ? `scale(${0.8125 / parseFloat(baseTitleSize)})` : 'scale(1)',
+                                                transform: isHeaderCompact ? `scale(${0.75 / parseFloat(baseTitleSize)})` : 'scale(1)',
                                                 transformOrigin: 'left center',
                                                 pointerEvents: isHeaderCompact ? 'none' : 'auto',
                                             }}
                                             className={`flex items-center group/title ${!subgraphDefinition ? 'cursor-pointer' : ''} font-extrabold tracking-tight leading-tight w-full overflow-visible transition-transform duration-300 will-change-transform`}
                                             onClick={!subgraphDefinition ? handleStartEditingTitle : undefined}
                                         >
-                                            <span className={`truncate ${hasCustomColor ? 'text-white/95' : 'text-slate-900 dark:text-white'}`}>
+                                            <span className={`truncate ${hasCustomColor ? 'text-white/95' : 'text-[#e9ebef]'}`}>
                                                 {titleText}
                                             </span>
                                             {!subgraphDefinition && (
                                                 <div
                                                     className={`transition-all duration-300 ${isHeaderCompact ? 'opacity-0 scale-75' : 'opacity-0 group-hover/title:opacity-100 scale-100'}`}
                                                 >
-                                                    <Edit3 className={`w-5 h-5 ${hasCustomColor ? 'text-white/70' : 'text-slate-400'}`} />
+                                                    <Edit3 className={`w-5 h-5 ${hasCustomColor ? 'text-white/70' : 'text-[#565d6b]'}`} />
                                                 </div>
                                             )}
                                         </div>
@@ -1105,10 +1105,10 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
 
                                 {
                                     <div
-                                        className={`inline-flex self-start items-center text-xs font-medium px-2 rounded-md border m-0 transition-all duration-300 overflow-hidden
+                                        className={`inline-flex self-start items-center text-[10px] font-medium px-1.5 rounded-md border m-0 transition-all duration-300 overflow-hidden
                                             ${isHeaderCompact
                                                 ? 'opacity-0 scale-75 h-0 mt-0 py-0 border-transparent'
-                                                : `opacity-100 scale-100 h-6 mt-3 py-1 ${hasCustomColor ? 'text-white/80 bg-black/20 border-white/10' : 'text-slate-500 bg-slate-50 dark:bg-slate-900/50 border-slate-100 dark:border-slate-800'}`
+                                                : `opacity-100 scale-100 h-5 mt-2 py-0.5 ${hasCustomColor ? 'text-white/80 bg-black/20 border-white/10' : 'text-[#71798a] bg-white/[0.04] border-white/[0.07]'}`
                                             }`}
                                     >
                                         {metadata?.category || "No Category"}
@@ -1120,19 +1120,19 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                         {/* Single Scrollable Content Area */}
                         <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
                             {/* Static Top Bumper - Prevents initial jitter */}
-                            <div className="h-[110px] relative pointer-events-none">
+                            <div className="h-[96px] relative pointer-events-none">
                                 {/* Sentinel for IntersectionObserver at exactly 80px scroll depth */}
                                 <div ref={sentinelRef} className="absolute top-[10px] left-0 h-px w-full" />
                             </div>
 
-                            <div className="px-5 py-6">
+                            <div className="px-3 py-4">
                                 {/* Extra top padding when header is NOT compact to avoid overlapping or awkward spacing if needed, 
                                    actually since it's NOT absolute but flex-col, it pushes down naturally. 
                                    We just removed the old identity header from here. */}
 
                                 {/* Image Preview */}
                                 {imagePreview && (
-                                    <div className={`mb-8 rounded-2xl overflow-hidden shadow-sm border ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-white border-slate-200 dark:border-slate-800'}`}>
+                                    <div className={`mb-4 rounded-[10px] overflow-hidden shadow-sm border ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-white/[0.03] border-white/[0.08]'}`}>
                                         <InlineImagePreview
                                             imagePreview={imagePreview}
                                             onClick={() => onFilePreview(imagePreview.filename || imagePreview)}
@@ -1150,7 +1150,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                 {videoPreview && (
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
                                         {(Array.isArray(videoPreview) ? videoPreview : [videoPreview]).map((vp: any, idx: number) => (
-                                            <div key={idx} className={`rounded-2xl overflow-hidden shadow-sm border ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-white border-slate-200 dark:border-slate-800'}`}>
+                                            <div key={idx} className={`rounded-[10px] overflow-hidden shadow-sm border ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-white/[0.03] border-white/[0.08]'}`}>
                                                 <VideoPreviewSection
                                                     videoPreview={vp}
                                                     nodeId={nodeId}
@@ -1174,20 +1174,20 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                         renderParameterSection(t('node.parameters'), widgets, <SlidersHorizontal className="w-4 h-4" />, true)
                                     ) : (
                                         selectedNode.widgets_values && (
-                                            <div className={`p-4 rounded-xl border mt-8 ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-slate-50 dark:bg-slate-900 border-slate-100 dark:border-slate-800'}`}>
-                                                <p className={`text-[10px] font-bold uppercase tracking-widest mb-3 ${hasCustomColor ? 'text-white/50' : 'text-slate-400'}`}>Raw Widget Values</p>
-                                                <code className={`text-xs break-all font-mono leading-relaxed ${hasCustomColor ? 'text-white/80' : 'text-slate-600 dark:text-slate-400'}`}>
+                                            <div className={`p-4 rounded-xl border mt-8 ${hasCustomColor ? 'bg-black/10 border-white/10' : 'bg-white/[0.04] border-white/[0.07]'}`}>
+                                                <p className={`text-[10px] font-bold uppercase tracking-widest mb-3 ${hasCustomColor ? 'text-white/50' : 'text-[#565d6b]'}`}>Raw Widget Values</p>
+                                                <code className={`text-xs break-all font-mono leading-relaxed ${hasCustomColor ? 'text-white/80' : 'text-[#8a919e]'}`}>
                                                     {JSON.stringify(selectedNode.widgets_values)}
                                                 </code>
 
                                                 {/* Refresh Button for Raw Values Mode */}
                                                 {onNodeRefresh && (
-                                                    <div className={`mt-4 pt-4 border-t ${hasCustomColor ? 'border-white/10' : 'border-slate-200 dark:border-slate-700'}`}>
+                                                    <div className={`mt-4 pt-4 border-t ${hasCustomColor ? 'border-white/10' : 'border-white/[0.08]'}`}>
                                                         <Button
                                                             variant="outline"
                                                             size="sm"
                                                             onClick={() => onNodeRefresh(nodeId)}
-                                                            className={`w-full text-xs h-9 ${hasCustomColor ? 'bg-white/5 border-white/10 text-white/80 hover:bg-white/10 hover:text-white' : 'text-slate-600 dark:text-slate-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 dark:hover:text-blue-400'}`}
+                                                            className={`w-full text-xs h-9 ${hasCustomColor ? 'bg-white/5 border-white/10 text-white/80 hover:bg-white/10 hover:text-white' : 'text-[#8a919e] hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 dark:hover:text-blue-400'}`}
                                                         >
                                                             <RefreshCw className="w-3.5 h-3.5 mr-2" />
                                                             Refresh Node
@@ -1218,7 +1218,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                 {/* File Gallery Portal */}
                 {
                     fileSelectionState.isOpen && fileSelectionState.paramType && createPortal(
-                        <div className="fixed inset-0 z-[9999] bg-white dark:bg-slate-900 overflow-auto">
+                        <div className="fixed inset-0 z-[9999] bg-[#0b0c0f] overflow-auto">
                             <OutputsGallery
                                 isFileSelectionMode={true}
                                 allowImages={true}

--- a/src/components/canvas/NodeSettingsEditor.tsx
+++ b/src/components/canvas/NodeSettingsEditor.tsx
@@ -127,13 +127,13 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 10 }}
       transition={{ duration: 0.2 }}
-      className="absolute inset-0 bg-white dark:bg-slate-900"
+ className="absolute inset-0 bg-white"
     >
       <ScrollArea className="h-full">
         <div className="p-6 space-y-6">
           {/* Node Mode Section */}
           <div className="space-y-4">
-            <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wide">
+            <h3 className="text-sm font-semibold text-[#c8ccd4] uppercase tracking-wide">
               {t('node.executionMode')}
             </h3>
             <SegmentedControl
@@ -157,9 +157,9 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
                 }
               ]}
               size="md"
-              className="w-full"
+ className="w-full"
             />
-            <p className="text-xs text-slate-500 dark:text-slate-400">
+            <p className="text-xs text-[#71798a]">
               {nodeMode === NodeMode.ALWAYS && t('node.modeAlwaysDesc')}
               {nodeMode === NodeMode.NEVER && t('node.modeMuteDesc')}
               {nodeMode === NodeMode.BYPASS && t('node.modeBypassDesc')}
@@ -172,20 +172,20 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
           {onNodeColorChange && (
             <>
               <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wide">
+                <h3 className="text-sm font-semibold text-[#c8ccd4] uppercase tracking-wide">
                   {t('node.color')}
                 </h3>
                 <div className="flex flex-wrap gap-2">
                   {/* Clear/None option */}
                   <button
                     onClick={() => handleColorChange('')}
-                    className={`w-12 h-12 rounded-lg border-2 transition-all flex items-center justify-center ${isNoneSelected
-                      ? 'border-blue-500 scale-105 shadow-lg bg-slate-100 dark:bg-slate-800'
-                      : 'border-gray-300 dark:border-gray-600 hover:scale-105 bg-slate-50 dark:bg-slate-900'
+ className={`w-12 h-12 rounded-lg border-2 transition-all flex items-center justify-center ${isNoneSelected
+                      ? 'border-blue-500 scale-105 shadow-lg bg-white/[0.06] '
+                      : 'border-gray-300 dark:border-gray-600 hover:scale-105 bg-white/[0.04] '
                       }`}
                     title={t('node.clearColor')}
                   >
-                    <span className="text-xl font-bold text-slate-600 dark:text-slate-400">×</span>
+                    <span className="text-xl font-bold text-[#8a919e]">×</span>
                   </button>
 
                   {/* Color options */}
@@ -193,7 +193,7 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
                     <button
                       key={color.value}
                       onClick={() => handleColorChange(color.value)}
-                      className={`w-12 h-12 rounded-lg border-2 transition-all shadow-sm ${selectedColor === color.value
+ className={`w-12 h-12 rounded-lg border-2 transition-all shadow-sm ${selectedColor === color.value
                         ? 'border-blue-500 scale-105 shadow-lg ring-2 ring-blue-200 dark:ring-blue-800'
                         : 'border-gray-300 dark:border-gray-600 hover:scale-105 hover:shadow-md'
                         }`}
@@ -205,7 +205,7 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
                   {/* Show custom color indicator if selected color is not in predefined list */}
                   {selectedColor && !isColorInPredefined && (
                     <div
-                      className="w-12 h-12 rounded-lg border-2 border-orange-500 scale-105 shadow-lg ring-2 ring-orange-200 dark:ring-orange-800 relative"
+ className="w-12 h-12 rounded-lg border-2 border-orange-500 scale-105 shadow-lg ring-2 ring-orange-200 dark:ring-orange-800 relative"
                       style={{ backgroundColor: selectedColor }}
                       title={`Custom color: ${selectedColor}`}
                     >
@@ -223,13 +223,13 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
           {/* Node Size Section */}
           {(onNodeSizeChange || onNodeCollapseChange) && (
             <div className="space-y-6">
-              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wide">
+              <h3 className="text-sm font-semibold text-[#c8ccd4] uppercase tracking-wide">
                 {t('node.sizeLayout')}
               </h3>
 
               {/* Collapse Toggle */}
               <div className="flex items-center justify-between py-2">
-                <label className="text-sm font-medium text-slate-600 dark:text-slate-400">{t('node.collapsed')}</label>
+                <label className="text-sm font-medium text-[#8a919e]">{t('node.collapsed')}</label>
                 <Switch
                   checked={previewCollapsed}
                   onCheckedChange={handleCollapseChange}
@@ -239,9 +239,9 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
               {/* Width Slider */}
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
-                  <label className="text-sm font-medium text-slate-600 dark:text-slate-400">{t('node.width')}</label>
+                  <label className="text-sm font-medium text-[#8a919e]">{t('node.width')}</label>
                   <div className="flex items-center space-x-2">
-                    <span className="text-sm font-mono text-slate-700 dark:text-slate-300 min-w-[60px] text-right">
+                    <span className="text-sm font-mono text-[#c8ccd4] min-w-[60px] text-right">
                       {Math.round(previewWidth)}px
                     </span>
                     {Math.abs(Number(widthChange)) > 0 && (
@@ -260,7 +260,7 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
                   min={80}
                   max={1600}
                   step={10}
-                  className="w-full"
+ className="w-full"
                   disabled={previewCollapsed}
                 />
               </div>
@@ -268,9 +268,9 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
               {/* Height Slider */}
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
-                  <label className="text-sm font-medium text-slate-600 dark:text-slate-400">{t('node.height')}</label>
+                  <label className="text-sm font-medium text-[#8a919e]">{t('node.height')}</label>
                   <div className="flex items-center space-x-2">
-                    <span className="text-sm font-mono text-slate-700 dark:text-slate-300 min-w-[60px] text-right">
+                    <span className="text-sm font-mono text-[#c8ccd4] min-w-[60px] text-right">
                       {Math.round(previewHeight)}px
                     </span>
                     {Math.abs(Number(heightChange)) > 0 && (
@@ -289,16 +289,16 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
                   min={30}
                   max={1600}
                   step={10}
-                  className="w-full"
+ className="w-full"
                   disabled={previewCollapsed}
                 />
               </div>
 
               {/* Visual Preview */}
               <div className="space-y-3">
-                <label className="text-sm font-medium text-slate-600 dark:text-slate-400">{t('node.preview')}</label>
+                <label className="text-sm font-medium text-[#8a919e]">{t('node.preview')}</label>
                 <div
-                  className="relative bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700"
+ className="relative bg-white/[0.04] rounded-lg border border-white/[0.08]"
                   style={{ height: '180px' }}  // Fixed height container
                 >
                   <div className="absolute inset-0 flex justify-center items-center p-4">
@@ -332,7 +332,7 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
                         <div className="relative" style={{ width: '100%', height: '100%' }}>
                           {/* Original size (ghost) */}
                           <div
-                            className="absolute border-2 border-slate-300 dark:border-slate-600 rounded opacity-40"
+ className="absolute border-2 border-white/[0.1] rounded opacity-40"
                             style={{
                               width: `${scaledOrigWidth}px`,
                               height: `${scaledOrigHeight}px`,
@@ -344,13 +344,13 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
                           >
                             {originalCollapsed && (
                               <div className="absolute inset-0 flex items-center justify-center">
-                                <span className="text-[10px] text-slate-500 dark:text-slate-400 font-medium opacity-75">{t('node.original')}</span>
+                                <span className="text-[10px] text-[#71798a] font-medium opacity-75">{t('node.original')}</span>
                               </div>
                             )}
                           </div>
                           {/* New size */}
                           <div
-                            className="absolute border-2 border-blue-500 dark:border-blue-400 rounded bg-blue-100/50 dark:bg-blue-900/30"
+ className="absolute border-2 border-blue-500 dark:border-blue-400 rounded bg-blue-100/50 dark:bg-blue-900/30"
                             style={{
                               width: `${scaledNewWidth}px`,
                               height: `${scaledNewHeight}px`,
@@ -369,7 +369,7 @@ export const NodeSettingsEditor: React.FC<NodeSettingsEditorProps> = ({
 
                           {/* Size labels */}
                           <div className="absolute bottom-2 left-2 right-2 flex justify-between text-[10px]">
-                            <span className="text-slate-500 dark:text-slate-400">
+                            <span className="text-[#71798a]">
                               {t('node.original')}: {origWidth}×{origHeight}
                             </span>
                             <span className="text-blue-600 dark:text-blue-400 font-medium">

--- a/src/components/controls/FloatingControlsPanel.tsx
+++ b/src/components/controls/FloatingControlsPanel.tsx
@@ -567,9 +567,12 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
         transform: 'translateY(-50%)'
       }}
     >
-      <div className="bg-slate-600/40 backdrop-blur-3xl rounded-2xl shadow-[0_20px_50px_rgba(0,0,0,0.3)] border border-white/30 p-1 relative overflow-hidden">
+      <div
+        className="rounded-[10px] border border-white/[0.09] p-1 relative overflow-hidden"
+        style={{ background: 'rgba(15,17,22,0.88)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}
+      >
         {/* Workflow Controls Container */}
-        <div className="flex flex-col items-center space-y-1 relative z-10">
+        <div className="flex flex-col items-center gap-[2px] relative z-10">
 
           {/* Search Node Button */}
           <div className="relative" ref={searchRef}>
@@ -577,7 +580,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               onClick={handleSearchToggle}
               variant="ghost"
               size="sm"
-              className={`h-8 w-8 p-0 rounded-lg hover:bg-white/20 transition-all ${isSearchOpen ? 'bg-white/20 text-white' : 'text-slate-100 hover:text-white'
+              className={`h-[30px] w-[30px] p-0 rounded-[7px] transition-all ${isSearchOpen ? 'bg-[#3069f0]/[0.18] text-[#7ba3f5]' : 'text-[#9aa3b2] hover:text-[#c8ccd4] hover:bg-white/[0.06]'
                 }`}
               title={t('workflow.searchNode')}
             >
@@ -587,7 +590,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
           </div>
 
           {/* Divider */}
-          <div className="h-px w-6 bg-white/10 mx-1" />
+          <div className="h-px w-4 bg-white/[0.07]" />
 
           {/* Refresh Workflow Button */}
           {onRefreshWorkflow && (
@@ -595,7 +598,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               onClick={onRefreshWorkflow}
               variant="ghost"
               size="sm"
-              className="h-8 w-8 p-0 text-slate-100 hover:text-white hover:bg-white/20 rounded-lg transition-all"
+              className="h-[30px] w-[30px] p-0 rounded-[7px] text-[#9aa3b2] hover:text-[#c8ccd4] hover:bg-white/[0.06] transition-all"
               title={t('workflow.refreshSlots')}
             >
               <RefreshCw className="h-4 w-4" />
@@ -603,7 +606,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
           )}
 
           {/* Divider */}
-          <div className="h-px w-6 bg-white/10 mx-1" />
+          <div className="h-px w-4 bg-white/[0.07]" />
 
           {/* Fit to Screen Button */}
           {onZoomFit && (
@@ -612,7 +615,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
                 onClick={onZoomFit}
                 variant="ghost"
                 size="sm"
-                className="h-8 w-8 p-0 text-slate-100 hover:text-white hover:bg-white/20 rounded-lg transition-all"
+                className="h-[30px] w-[30px] p-0 rounded-[7px] text-[#9aa3b2] hover:text-[#c8ccd4] hover:bg-white/[0.06] transition-all"
                 title={t('workflow.fitToScreen')}
               >
                 <Maximize2 className="h-4 w-4" />
@@ -621,7 +624,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
           )}
 
           {/* Divider */}
-          <div className="h-px w-6 bg-white/10 mx-1" />
+          <div className="h-px w-4 bg-white/[0.07]" />
 
           {/* Queue Button */}
           <div className="relative" ref={historyRef}>
@@ -629,19 +632,19 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               onClick={handleShowPromptHistory}
               variant="ghost"
               size="sm"
-              className={`h-8 w-8 p-0 transition-all rounded-lg ${isHistoryOpen ? 'bg-white/20 text-white' : 'text-slate-100 hover:text-white hover:bg-white/20'
+              className={`h-[34px] w-[34px] p-0 transition-all rounded-lg ${isHistoryOpen ? 'bg-[#3069f0]/[0.18] text-[#7ba3f5]' : 'text-[#9aa3b2] hover:text-[#c8ccd4] hover:bg-white/[0.06]'
                 }`}
               title={t('workflow.queue')}
             >
               <Clock className="h-4 w-4" />
             </Button>
             {hasUnseenCompletion && !isHistoryOpen && (
-              <span className="pointer-events-none absolute top-1 right-1 h-2.5 w-2.5 rounded-full bg-red-500 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9)] dark:shadow-[0_0_0_1.5px_rgba(15,23,42,0.8)] animate-pulse" />
+              <span className="pointer-events-none absolute top-[3px] right-[3px] h-[7px] w-[7px] rounded-full bg-[#f25555] shadow-[0_0_0_2px_#0f1116] animate-pulse" />
             )}
           </div>
 
           {/* Divider */}
-          <div className="h-px w-6 bg-white/10 mx-1" />
+          <div className="h-px w-4 bg-white/[0.07]" />
 
           {/* Console Button */}
           <div className="relative" ref={consoleRef}>
@@ -649,7 +652,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               onClick={handleConsoleToggle}
               variant="ghost"
               size="sm"
-              className={`h-8 w-8 p-0 transition-all rounded-lg ${isConsoleOpen ? 'bg-white/20 text-white' : 'text-slate-100 hover:text-white hover:bg-white/20'
+              className={`h-[34px] w-[34px] p-0 transition-all rounded-lg ${isConsoleOpen ? 'bg-[#3069f0]/[0.18] text-[#7ba3f5]' : 'text-[#9aa3b2] hover:text-[#c8ccd4] hover:bg-white/[0.06]'
                 }`}
               title={t('workflow.console')}
             >
@@ -658,7 +661,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
           </div>
 
           {/* Divider */}
-          <div className="h-px w-6 bg-white/10 mx-1" />
+          <div className="h-px w-4 bg-white/[0.07]" />
 
           {/* Stack View Button */}
           <div className="relative">
@@ -666,7 +669,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               onClick={handleStackViewClick}
               variant="ghost"
               size="sm"
-              className="h-8 w-8 p-0 transition-all rounded-lg text-slate-100 hover:text-white hover:bg-white/20"
+              className="h-[30px] w-[30px] p-0 rounded-[7px] text-[#9aa3b2] hover:text-[#c8ccd4] hover:bg-white/[0.06] transition-all"
               title={t('menu.stackView')}
             >
               <Layers className="h-4 w-4" />
@@ -674,7 +677,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
           </div>
 
           {/* Divider */}
-          <div className="h-px w-6 bg-white/10 mx-1" />
+          <div className="h-px w-4 bg-white/[0.07]" />
 
           {/* Settings Button with Dropdown */}
           <div className="relative" ref={settingsRef}>
@@ -688,7 +691,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               }}
               variant="ghost"
               size="sm"
-              className="relative h-8 w-8 p-0 text-slate-100 hover:text-white hover:bg-white/20 rounded-lg transition-all"
+              className="relative h-[30px] w-[30px] p-0 rounded-[7px] text-[#9aa3b2] hover:text-[#c8ccd4] hover:bg-white/[0.06] transition-all"
               title={t('common.settings')}
             >
               <Settings
@@ -697,9 +700,9 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               />
               {/* Priority: Red for missing nodes, Yellow for missing models only */}
               {missingNodesCount > 0 ? (
-                <span className="pointer-events-none absolute top-1 right-1 h-2.5 w-2.5 rounded-full bg-red-500 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9)] dark:shadow-[0_0_0_1.5px_rgba(15,23,42,0.8)] animate-pulse" />
+                <span className="pointer-events-none absolute top-[3px] right-[3px] h-[7px] w-[7px] rounded-full bg-[#f25555] shadow-[0_0_0_2px_#0f1116] animate-pulse" />
               ) : missingModels.length > 0 ? (
-                <span className="pointer-events-none absolute top-1 right-1 h-2.5 w-2.5 rounded-full bg-yellow-500 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9)] dark:shadow-[0_0_0_1.5px_rgba(15,23,42,0.8)] animate-pulse" />
+                <span className="pointer-events-none absolute top-[3px] right-[3px] h-[7px] w-[7px] rounded-full bg-[#ffa348] shadow-[0_0_0_2px_#0f1116] animate-pulse" />
               ) : null}
             </Button>
           </div>
@@ -716,11 +719,9 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
             animate={{ opacity: 1, x: 0, scale: 1, y: panelYOffsets.settings }}
             exit={{ opacity: 0, x: 20, scale: 0.95 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="absolute right-full top-0 mr-3 w-64 max-w-[calc(100vw-100px)] bg-slate-800/60 backdrop-blur-3xl rounded-2xl shadow-2xl border border-white/20 overflow-hidden z-50"
+            className="absolute right-full top-0 mr-2.5 w-56 max-w-[calc(100vw-90px)] rounded-[10px] border border-white/10 overflow-hidden z-50"
+            style={{ background: 'rgba(15,17,22,0.94)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', boxShadow: '0 20px 48px rgba(0,0,0,0.55)' }}
           >
-            {/* Subtle Inner Glow */}
-            <div className="absolute inset-0 bg-white/5 pointer-events-none" />
-
             <div className="relative z-10 max-h-[80vh] overflow-y-auto custom-scrollbar">
               <SettingsDropdownContent
                 isClearingVRAM={isClearingVRAM}
@@ -757,9 +758,10 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
             animate={{ opacity: 1, x: 0, scale: 1, y: panelYOffsets.search }}
             exit={{ opacity: 0, x: 20, scale: 0.95 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="absolute right-full top-0 mr-3 w-80 max-w-[calc(100vw-100px)] bg-slate-800/60 backdrop-blur-3xl rounded-2xl shadow-2xl border border-white/20 p-4 z-50 overflow-hidden"
+            className="absolute right-full top-0 mr-2.5 w-72 max-w-[calc(100vw-90px)] rounded-[10px] border border-white/10 p-3 z-50 overflow-hidden"
             data-search-panel
             style={{
+              background: 'rgba(15,17,22,0.94)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', boxShadow: '0 20px 48px rgba(0,0,0,0.55)',
               touchAction: 'pan-y pinch-zoom',
               overscrollBehaviorY: 'contain'
             } as React.CSSProperties}
@@ -773,9 +775,6 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               e.stopPropagation();
             }}
           >
-            {/* Subtle Inner Glow */}
-            <div className="absolute inset-0 bg-white/5 pointer-events-none rounded-xl" />
-
             <div className="relative z-10">
               {/* Search Input */}
               <form onSubmit={handleSearchSubmit} className="mb-3">
@@ -786,14 +785,15 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
                   onChange={(e) => setSearchValue(e.target.value)}
                   onKeyDown={handleSearchKeyDown}
                   placeholder={t('workflow.searchNodesPlaceholder')}
-                  className="w-full px-3 py-2 text-sm bg-white/90 dark:bg-slate-800/90 border border-slate-200/60 dark:border-slate-600/60 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500/50 text-slate-700 dark:text-slate-300 placeholder-slate-400 dark:placeholder-slate-500"
+                  className="w-full h-8 px-2.5 text-[12px] rounded-lg border border-white/[0.08] focus:outline-none focus:border-[#3069f0]/50 text-[#e9ebef] placeholder-[#71798a] transition-colors"
+                  style={{ background: 'rgba(255,255,255,0.045)' }}
                 />
               </form>
 
               {/* Search Results */}
               {searchValue.trim() && searchResults.length > 0 && (
                 <div className="space-y-1">
-                  <div className="text-xs text-slate-500 dark:text-slate-400 mb-2 px-1">
+                  <div className="font-mono text-[10px] text-[#565d6b] tracking-[0.1em] uppercase mb-2 px-1">
                     {searchResults.length === 1
                       ? t('workflow.resultFound')
                       : t('workflow.resultsFound', { count: searchResults.length })}
@@ -818,21 +818,21 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
                       <button
                         key={node.id}
                         onClick={() => handleResultSelect(node)}
-                        className={`w-full text-left p-2 rounded-md transition-colors ${index === selectedResultIndex
-                          ? 'bg-blue-100 dark:bg-blue-900/30 border border-blue-300 dark:border-blue-700'
-                          : 'hover:bg-white/40 dark:hover:bg-slate-700/50 bg-white/20 dark:bg-slate-800/20'
+                        className={`w-full text-left px-2.5 py-2 rounded-lg border transition-colors ${index === selectedResultIndex
+                          ? 'bg-[#3069f0]/[0.15] border-[#3069f0]/40'
+                          : 'bg-white/[0.03] border-transparent hover:bg-white/[0.06]'
                           }`}
                       >
                         <div className="flex items-center justify-between">
                           <div className="flex-1 min-w-0">
-                            <div className="font-medium text-slate-900 dark:text-slate-100 truncate">
+                            <div className="text-[12.5px] font-semibold text-[#e9ebef] truncate">
                               {node.title || node.type}
                             </div>
-                            <div className="text-sm text-slate-600 dark:text-slate-400 truncate">
-                              ID: {node.id} • Type: {node.type}
+                            <div className="font-mono text-[10px] text-[#565d6b] truncate mt-0.5">
+                              {node.type}
                             </div>
                           </div>
-                          <div className="text-xs text-slate-400 dark:text-slate-500 ml-2">
+                          <div className="font-mono text-[10px] text-[#5b8af5] ml-2">
                             #{node.id}
                           </div>
                         </div>
@@ -844,7 +844,7 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
 
               {/* No Results Message */}
               {searchValue.trim() && searchResults.length === 0 && (
-                <div className="text-sm text-slate-500 dark:text-slate-400 text-center py-3">
+                <div className="text-[12px] text-[#66758a] text-center py-3">
                   {t('workflow.noNodesFound', { query: searchValue })}
                 </div>
               )}
@@ -869,9 +869,10 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
             animate={{ opacity: 1, x: 0, scale: 1, y: panelYOffsets.console }}
             exit={{ opacity: 0, x: 20, scale: 0.95 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="absolute right-full top-0 mr-3 w-96 max-w-[calc(100vw-100px)] bg-slate-800/60 backdrop-blur-3xl rounded-2xl shadow-2xl border border-white/20 p-4 z-50 overflow-hidden"
+            className="absolute right-full top-0 mr-2.5 w-80 max-w-[calc(100vw-90px)] rounded-[10px] border border-white/10 p-3 z-50 overflow-hidden"
             data-console-panel
             style={{
+              background: 'rgba(15,17,22,0.94)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', boxShadow: '0 20px 48px rgba(0,0,0,0.55)',
               touchAction: 'pan-y pinch-zoom',
               overscrollBehaviorY: 'contain'
             } as React.CSSProperties}
@@ -885,20 +886,17 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               e.stopPropagation();
             }}
           >
-            {/* Subtle Inner Glow */}
-            <div className="absolute inset-0 bg-white/5 pointer-events-none rounded-xl" />
-
             <div className="relative z-10">
               {/* Console Header */}
               <div className="flex items-center justify-between mb-3">
-                <div className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                <div className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] uppercase">
                   {t('workflow.serverConsole')}
                 </div>
                 <Button
                   onClick={() => setConsoleLogs([])}
                   variant="ghost"
                   size="sm"
-                  className="h-6 px-2 text-xs hover:bg-white/60 dark:hover:bg-slate-700/60"
+                  className="h-6 px-2 text-[11px] text-[#8a919e] hover:text-[#c8ccd4] hover:bg-white/[0.06]"
                 >
                   {t('common.clear')}
                 </Button>
@@ -907,8 +905,9 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
               {/* Console Logs */}
               <div
                 ref={consoleContainerRef}
-                className="h-96 overflow-y-auto space-y-1 px-3 py-2 bg-slate-900/90 dark:bg-slate-950/90 rounded-lg font-mono text-xs"
+                className="h-72 overflow-y-auto space-y-1 px-2.5 py-2 rounded-lg border border-white/[0.06] font-mono text-[10.5px]"
                 style={{
+                  background: '#08090c',
                   touchAction: 'pan-y pinch-zoom',
                   overscrollBehaviorY: 'contain'
                 } as React.CSSProperties}
@@ -923,14 +922,14 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
                 }}
               >
                 {consoleLogs.length === 0 ? (
-                  <div className="flex items-center justify-center h-full text-slate-500 dark:text-slate-400">
+                  <div className="flex items-center justify-center h-full text-[#565d6b]">
                     {t('workflow.noLogs')}
                   </div>
                 ) : (
                   consoleLogs.map((log, index) => (
                     <div
                       key={index}
-                      className="py-0.5 text-slate-100 dark:text-slate-200 leading-relaxed break-all whitespace-pre-wrap"
+                      className="py-0.5 text-[#9aa3b2] leading-relaxed break-all whitespace-pre-wrap"
                     >
                       {log.m}
                     </div>
@@ -951,16 +950,14 @@ export const FloatingControlsPanel: React.FC<FloatingControlsPanelProps> = ({
             animate={{ opacity: 1, x: 0, scale: 1, y: panelYOffsets.history }}
             exit={{ opacity: 0, x: 20, scale: 0.95 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="absolute right-full top-0 mr-3 w-96 max-w-[calc(100vw-100px)] h-[480px] bg-slate-800/60 backdrop-blur-3xl rounded-2xl shadow-2xl border border-white/20 p-4 z-50 overflow-hidden flex flex-col"
+            className="absolute right-full top-0 mr-2.5 w-72 max-w-[calc(100vw-90px)] h-[400px] rounded-[10px] border border-white/10 p-3 z-50 overflow-hidden flex flex-col"
             data-history-panel
             style={{
+              background: 'rgba(15,17,22,0.94)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', boxShadow: '0 20px 48px rgba(0,0,0,0.55)',
               touchAction: 'pan-y pinch-zoom',
               overscrollBehaviorY: 'contain'
             } as React.CSSProperties}
           >
-            {/* Subtle Inner Glow */}
-            <div className="absolute inset-0 bg-white/5 pointer-events-none rounded-2xl" />
-
             <div className="relative z-10 flex flex-col h-full">
               <PromptHistoryContent
                 isEmbedded={true}

--- a/src/components/controls/QuickActionPanel.tsx
+++ b/src/components/controls/QuickActionPanel.tsx
@@ -105,20 +105,23 @@ export function QuickActionPanel({
   }, [onClearQueue]);
 
   return (
-    <div className="fixed right-6 bottom-4 z-40">
-      <div className="bg-slate-600/40 backdrop-blur-3xl rounded-[28px] shadow-[0_20px_50px_rgba(0,0,0,0.3)] border border-white/30 p-1.5 relative">
-        {/* Button Group - Separated with gaps */}
-        <div className="flex items-center gap-2 relative z-10">
+    <div className="fixed right-3.5 bottom-4 z-40">
+      <div
+        className="rounded-[14px] border border-white/[0.09] p-1.5 relative"
+        style={{ background: 'rgba(15,17,22,0.88)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}
+      >
+        {/* Button Group */}
+        <div className="flex items-center gap-1.5 relative z-10">
           <AnimatePresence>
             {imageUrl && (
               <motion.div
                 initial={{ opacity: 0, x: -20, scale: 0.8 }}
                 animate={{ opacity: 1, x: 0, scale: 1 }}
                 exit={{ opacity: 0, x: -20, scale: 0.8 }}
-                className="flex items-center"
+                className="flex items-center gap-1.5"
               >
                 <div className="relative">
-                  {/* Floating Preview (Bubble) - Localized */}
+                  {/* Floating Preview (Bubble) */}
                   <AnimatePresence>
                     {isVisible && (
                       <motion.div
@@ -129,8 +132,8 @@ export function QuickActionPanel({
                         onClick={() => setLatentPreviewFullscreen(true)}
                       >
                         <div
-                          className="bg-slate-800/60 backdrop-blur-2xl rounded-2xl shadow-2xl border border-white/20 overflow-hidden cursor-pointer group relative"
-                          style={{ width: '100px', height: '100px' }}
+                          className="rounded-[14px] border border-white/[0.12] overflow-hidden cursor-pointer group relative"
+                          style={{ width: '104px', height: '104px', background: '#14171e', boxShadow: '0 16px 40px rgba(0,0,0,0.55)' }}
                         >
                           <img
                             src={imageUrl}
@@ -140,11 +143,13 @@ export function QuickActionPanel({
                           <div className="absolute inset-0 bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                             <Maximize2 className="text-white w-5 h-5" />
                           </div>
-                          {/* Floating preview badge/info - Localized */}
                           {nodeId && nodeId !== 'unknown' && (
-                            <div className="absolute top-2 left-2 z-20">
-                              <div className="bg-black/60 backdrop-blur-md px-2 py-0.5 rounded-full border border-white/20">
-                                <span className="text-[10px] font-bold text-white tracking-tighter">
+                            <div className="absolute top-1.5 left-1.5 z-20">
+                              <div
+                                className="px-1.5 py-[3px] rounded-full border border-white/[0.12]"
+                                style={{ background: 'rgba(10,14,22,0.7)' }}
+                              >
+                                <span className="font-mono text-[8.5px] font-bold text-[#cfe0ff]">
                                   {t('latentPreview.fullScreen.node', { id: nodeId })}
                                 </span>
                               </div>
@@ -155,86 +160,73 @@ export function QuickActionPanel({
                     )}
                   </AnimatePresence>
 
-                  <Button
-                    size="lg"
-                    variant="outline"
-                    className={`h-11 w-11 rounded-[22px] border transition-all duration-150 p-0 active:scale-95 active:translate-y-px ${isVisible
-                      ? 'bg-violet-500/20 border-violet-400 text-violet-600 dark:text-violet-400 shadow-[0_0_15px_rgba(139,92,246,0.3)]'
-                      : 'bg-white/10 dark:bg-white/10 border-white/20 text-slate-300 hover:text-white hover:bg-white/20'
-                      }`}
+                  <button
+                    className={`w-10 h-10 rounded-[10px] border flex items-center justify-center transition-all duration-150 active:scale-95 ${isVisible ? '' : 'border-white/[0.08] text-[#9aa3b2] hover:text-[#c8ccd4]'}`}
+                    style={isVisible
+                      ? { background: 'rgba(139,92,246,0.14)', borderColor: 'rgba(139,92,246,0.35)', color: '#a78bfa' }
+                      : { background: 'rgba(255,255,255,0.05)' }}
                     onClick={() => setVisible(!isVisible)}
                     title="Toggle Latent Preview"
                   >
                     <div className="relative">
-                      <Image className="w-5 h-5" />
+                      <Image className="w-[15px] h-[15px]" strokeWidth={1.8} />
                       {!isVisible && (
                         <span className="absolute -top-1 -right-1 flex h-2 w-2">
-                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-violet-400 opacity-75"></span>
-                          <span className="relative inline-flex rounded-full h-2 w-2 bg-violet-500"></span>
+                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[#a78bfa] opacity-75"></span>
+                          <span className="relative inline-flex rounded-full h-2 w-2 bg-[#8b5cf6]"></span>
                         </span>
                       )}
                     </div>
-                  </Button>
+                  </button>
                 </div>
 
-                <div className="w-px h-6 bg-white/10 mx-2" />
+                <div className="w-px h-[22px] bg-white/[0.08]" />
               </motion.div>
             )}
           </AnimatePresence>
 
           {/* Execute Workflow Button - ALWAYS ENABLED */}
-          <Button
-            size="lg"
-            variant="outline"
-            disabled={false}
-            className="h-11 px-5 rounded-[22px] bg-white/10 dark:bg-white/10 border transition-all duration-150 font-medium active:translate-y-px border-green-200 dark:border-green-800 hover:bg-green-500/10 dark:hover:bg-green-500/20 hover:border-green-300 dark:hover:border-green-700 text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 active:text-green-800 dark:active:text-green-200 active:border-green-400 dark:active:border-green-600 shadow-none hover:shadow-sm active:shadow-none active:scale-95"
+          <button
+            className="h-10 px-4 rounded-[10px] border flex items-center gap-2 text-[13px] font-semibold whitespace-nowrap transition-all duration-150 active:scale-95"
+            style={{ background: 'rgba(52,199,123,0.13)', borderColor: 'rgba(52,199,123,0.3)', color: '#4ade80' }}
             onClick={handleExecuteClick}
             title={t('workflow.executeWorkflow')}
           >
-            <Play className="w-4 h-4 mr-2" />
+            <Play className="w-[13px] h-[13px] fill-current" strokeWidth={0} />
             {t('workflow.execute')}
-          </Button>
+          </button>
 
           {/* Interrupt Execution Button */}
-          <Button
-            size="lg"
-            variant="outline"
-            disabled={false}
-            className="h-11 w-11 rounded-[22px] bg-white/10 dark:bg-white/10 border transition-all duration-150 p-0 active:scale-95 active:translate-y-px border-orange-200 dark:border-orange-800 hover:bg-orange-500/10 dark:hover:bg-orange-500/20 hover:border-orange-300 dark:hover:border-orange-700 text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300 active:text-orange-800 dark:active:text-orange-200 active:border-orange-400 dark:active:border-orange-600 shadow-none hover:shadow-sm active:shadow-none"
+          <button
+            className="w-10 h-10 rounded-[10px] border flex items-center justify-center transition-all duration-150 active:scale-95"
+            style={{ background: 'rgba(255,163,72,0.09)', borderColor: 'rgba(255,163,72,0.28)' }}
             onClick={handleInterruptClick}
             title={t('workflow.interruptExecution')}
           >
-            <Square className="w-4 h-4" />
-            {/* {t('workflow.interrupt')} */}
-          </Button>
+            <Square className="w-3 h-3 fill-[#ffa348] text-[#ffa348]" strokeWidth={0} />
+          </button>
 
           {/* Clear Queue Button with Badge */}
           <div className="relative">
-            <Button
-              size="lg"
-              variant="outline"
-              disabled={false}
-              className="h-11 w-11 rounded-[22px] bg-white/10 dark:bg-white/10 border transition-all duration-150 p-0 active:scale-95 active:translate-y-px border-red-200 dark:border-red-800 hover:bg-red-500/10 dark:hover:bg-red-500/20 hover:border-red-300 dark:hover:border-red-700 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 active:text-red-800 dark:active:text-red-200 active:border-red-400 dark:active:border-red-600 shadow-none hover:shadow-sm active:shadow-none"
+            <button
+              className="w-10 h-10 rounded-[10px] border flex items-center justify-center transition-all duration-150 active:scale-95"
+              style={{ background: 'rgba(242,85,85,0.09)', borderColor: 'rgba(242,85,85,0.28)' }}
               onClick={handleClearQueueClick}
               title={t('workflow.clearQueuePending', { count: queueCount })}
             >
-              <X className="w-4 h-4" />
-            </Button>
+              <X className="w-3.5 h-3.5 text-[#f25555]" strokeWidth={2} />
+            </button>
 
             {/* Queue Counter Badge */}
             {queueCount > 0 && (
-              <Badge
-                variant="destructive"
-                className="absolute -top-2 -right-2 h-6 w-6 p-0 rounded-full flex items-center justify-center font-bold bg-red-200 dark:bg-red-600 text-white shadow-sm border-0"
-                style={{ fontSize: '13px' }}
-              >
+              <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] px-1 rounded-full bg-[#f25555] flex items-center justify-center font-mono text-[10px] font-bold text-white">
                 {queueCount > 99 ? '99+' : queueCount}
-              </Badge>
+              </span>
             )}
 
             {/* Loading indicator (small dot) */}
             {isLoadingQueue && (
-              <div className="absolute -top-1 -right-1 h-2 w-2 bg-blue-500 rounded-full animate-pulse"></div>
+              <div className="absolute -top-1 -right-1 h-2 w-2 bg-[#3069f0] rounded-full animate-pulse"></div>
             )}
           </div>
         </div>

--- a/src/components/controls/RepositionActionBar.tsx
+++ b/src/components/controls/RepositionActionBar.tsx
@@ -31,58 +31,43 @@ export const RepositionActionBar: React.FC<RepositionActionBarProps> = ({
         transition={{ duration: 0.3, ease: "easeOut" }}
         className="fixed right-4 sm:right-6 bottom-4 z-40 max-w-[calc(100vw-2rem)]"
       >
-        <div className="bg-slate-600/40 backdrop-blur-3xl rounded-[28px] shadow-[0_20px_50px_rgba(0,0,0,0.3)] border border-white/30 p-4 relative">
-          <div className="relative z-10">
-            {/* Title */}
-            <div className="text-sm font-bold text-white/90 text-left mb-3 tracking-tight">
-              {t('node.repositioning')}
-            </div>
+        <div className="rounded-[14px] border border-white/[0.09] p-1.5 relative flex items-center gap-1.5"
+          style={{ background: 'rgba(15,17,22,0.9)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}>
+          {/* Grid Snap toggle (icon tile) */}
+          <button
+            onClick={onToggleGridSnap}
+            className={`w-10 h-10 rounded-[10px] border flex items-center justify-center transition-all duration-150 active:scale-95 ${gridSnapEnabled
+              ? 'border-[#34c77b]/30 text-[#4ade80]'
+              : 'border-white/[0.08] text-[#8a919e] hover:text-[#c8ccd4]'
+              }`}
+            style={{ background: gridSnapEnabled ? 'rgba(52,199,123,0.13)' : 'rgba(255,255,255,0.05)' }}
+            title={t('node.toggleGridSnap')}
+          >
+            <Grid3X3 className="w-[15px] h-[15px]" strokeWidth={1.8} />
+          </button>
 
-            {/* Button Group - Reorganized rows */}
-            <div className="flex flex-col gap-2">
-              {/* Top row: Grid Snap Toggle */}
-              <Button
-                onClick={onToggleGridSnap}
-                size="lg"
-                variant="outline"
-                className={`w-full h-11 px-5 rounded-[22px] bg-white/10 dark:bg-white/10 border transition-all duration-150 font-bold active:scale-95 ${gridSnapEnabled
-                  ? 'border-green-500/40 text-green-400 bg-green-500/20 hover:bg-green-500/30 hover:text-green-300'
-                  : 'border-white/10 text-white/50 hover:bg-white/20 hover:text-white'
-                  } shadow-none`}
-                title={t('node.toggleGridSnap')}
-              >
-                <Grid3X3 className="w-4 h-4 mr-2" />
-                {t('node.gridSnap')}
-              </Button>
+          <span className="w-px h-[22px] bg-white/[0.08]" />
 
-              {/* Bottom row: Cancel & Apply */}
-              <div className="flex items-center gap-2">
-                {/* Cancel Button */}
-                <Button
-                  onClick={onCancel}
-                  size="lg"
-                  variant="outline"
-                  className="flex-1 h-11 px-5 rounded-[22px] bg-white/10 dark:bg-white/10 border transition-all duration-150 font-bold active:scale-95 border-red-500/40 text-red-400 hover:bg-red-500/30 hover:text-red-300 shadow-none"
-                  title={t('node.cancelRepositioning')}
-                >
-                  <X className="w-4 h-4 mr-2" />
-                  {t('common.cancel')}
-                </Button>
+          {/* Cancel */}
+          <button
+            onClick={onCancel}
+            className="h-10 px-3.5 rounded-[10px] border flex items-center gap-1.5 text-[12px] font-semibold whitespace-nowrap transition-all duration-150 active:scale-95"
+            style={{ background: 'rgba(242,85,85,0.1)', borderColor: 'rgba(242,85,85,0.3)', color: '#f87c7c' }}
+            title={t('node.cancelRepositioning')}
+          >
+            <X className="w-3.5 h-3.5" strokeWidth={1.9} />
+            {t('common.cancel')}
+          </button>
 
-                {/* Apply Button */}
-                <Button
-                  onClick={onApply}
-                  size="lg"
-                  variant="outline"
-                  className="flex-1 h-11 px-6 rounded-[22px] bg-blue-500/20 border-blue-500/40 transition-all duration-150 font-bold active:scale-95 text-blue-400 hover:bg-blue-500/30 hover:text-blue-300 shadow-none"
-                  title={t('node.applyChanges')}
-                >
-                  <Check className="w-4 h-4 mr-2" />
-                  {t('common.confirm')}
-                </Button>
-              </div>
-            </div>
-          </div>
+          {/* Apply */}
+          <button
+            onClick={onApply}
+            className="h-10 px-3.5 rounded-[10px] bg-[#3069f0] hover:bg-[#3f78f5] flex items-center gap-1.5 text-[12px] font-semibold text-white whitespace-nowrap transition-all duration-150 active:scale-95"
+            title={t('node.applyChanges')}
+          >
+            <Check className="w-3.5 h-3.5" strokeWidth={2} />
+            {t('common.confirm')}
+          </button>
         </div>
       </motion.div>
     </AnimatePresence>

--- a/src/components/controls/SettingsDropdown.tsx
+++ b/src/components/controls/SettingsDropdown.tsx
@@ -56,41 +56,43 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
   const { t } = useTranslation();
 
   return (
-    <div className="relative z-10 py-1">
+    <div className="relative z-10 pb-2">
       {/* Group 1: Workflow Tools */}
       {(onShowGroupModer || onRandomizeSeeds || onToggleRepositionMode || onToggleConnectionMode || (missingNodesCount ?? 0) > 0 || missingModels.length > 0) && (
         <>
           {missingNodesCount > 0 && onShowMissingNodeInstaller && (
             <button
               onClick={onShowMissingNodeInstaller}
-              className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-red-500/10 transition-colors border-b border-white/5 active:bg-red-500/20"
+              className="w-full px-3 py-2 flex items-center gap-2.5 transition-colors border-b border-white/[0.06] active:bg-[#f25555]/[0.12]"
+              style={{ background: 'rgba(242,85,85,0.07)' }}
             >
-              <AlertTriangle className="h-4 w-4 text-red-500 flex-shrink-0" />
-              <span className="text-sm font-medium text-red-100 text-left flex-1">
+              <AlertTriangle className="h-3.5 w-3.5 text-[#f25555] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#f8b3b3] text-left flex-1">
                 {t('menu.installMissingNodes')}
               </span>
               {installablePackageCount > 0 && (
-                <Badge variant="destructive" className="ml-auto text-xs h-5 px-1.5 min-w-[20px] justify-center">{installablePackageCount}</Badge>
+                <span className="ml-auto min-w-[18px] h-[18px] px-1 rounded-full bg-[#f25555] flex items-center justify-center font-mono text-[9.5px] font-bold text-white">{installablePackageCount}</span>
               )}
             </button>
           )}
           {missingModels.length > 0 && onOpenMissingModelDetector && (
             <button
               onClick={onOpenMissingModelDetector}
-              className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-yellow-500/10 transition-colors border-b border-white/5 active:bg-yellow-500/20"
+              className="w-full px-3 py-2 flex items-center gap-2.5 transition-colors border-b border-white/[0.06] active:bg-[#ffa348]/[0.12]"
+              style={{ background: 'rgba(255,163,72,0.07)' }}
             >
-              <Package className="h-4 w-4 text-yellow-500 flex-shrink-0" />
-              <span className="text-sm font-medium text-yellow-100 text-left flex-1">
+              <Package className="h-3.5 w-3.5 text-[#ffa348] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#ffd9ae] text-left flex-1">
                 {t('menu.missingModelDetector')}
               </span>
-              <Badge variant="outline" className="ml-auto text-xs border-yellow-500/50 text-yellow-400">
+              <span className="ml-auto min-w-[18px] h-[18px] px-1 rounded-full flex items-center justify-center font-mono text-[9.5px] font-bold text-[#ffa348] border border-[#ffa348]/40">
                 {missingModels.length}
-              </Badge>
+              </span>
             </button>
           )}
           {/* Group Title */}
-          <div className="px-4 py-2 bg-white/5 border-b border-white/5">
-            <h3 className="text-[10px] font-bold text-white/40 uppercase tracking-widest">
+          <div className="px-3 pt-2 pb-1">
+            <h3 className="font-mono text-[9px] font-semibold text-[#565d6b] uppercase tracking-[0.14em]">
               {t('menu.workflowTools')}
             </h3>
           </div>
@@ -99,10 +101,10 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {onShowGroupModer && (
             <button
               onClick={onShowGroupModer}
-              className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10"
+              className="w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07]"
             >
-              <Users className="h-4 w-4 text-white/60 flex-shrink-0" />
-              <span className="text-sm font-medium text-white/90 text-left flex-1">
+              <Users className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
                 {t('menu.fastGroupModer')}
               </span>
             </button>
@@ -111,10 +113,10 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {/* Trigger Word Selector */}
           <button
             onClick={onShowTriggerWordSelector}
-            className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10"
+            className="w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07]"
           >
-            <Hash className="h-4 w-4 text-white/60 flex-shrink-0" />
-            <span className="text-sm font-medium text-white/90 text-left flex-1">
+            <Hash className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+            <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
               {t('menu.triggerWords')}
             </span>
           </button>
@@ -123,10 +125,10 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {onRandomizeSeeds && (
             <button
               onClick={() => onRandomizeSeeds(true)}
-              className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10"
+              className="w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07]"
             >
-              <Dices className="h-4 w-4 text-white/60 flex-shrink-0" />
-              <span className="text-sm font-medium text-white/90 text-left flex-1">
+              <Dices className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
                 {t('menu.randomizeSeeds')}
               </span>
             </button>
@@ -136,13 +138,13 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {onToggleRepositionMode && (
             <button
               onClick={onToggleRepositionMode}
-              className={`w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10 ${repositionMode?.isActive
-                ? 'bg-blue-500/20 text-blue-400'
+              className={`w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07] ${repositionMode?.isActive
+                ? 'bg-[#3069f0]/[0.18]'
                 : ''
                 }`}
             >
-              <Move className="h-4 w-4 text-white/60 flex-shrink-0" />
-              <span className="text-sm font-medium text-white/90 text-left flex-1">
+              <Move className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
                 {t('menu.nodeRepositioning')}
               </span>
             </button>
@@ -152,13 +154,13 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {onToggleConnectionMode && (
             <button
               onClick={onToggleConnectionMode}
-              className={`w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10 ${connectionMode?.isActive
-                ? 'bg-green-500/20 text-green-400'
+              className={`w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07] ${connectionMode?.isActive
+                ? 'bg-[#34c77b]/[0.13]'
                 : ''
                 }`}
             >
-              <Link className="h-4 w-4 text-white/60 flex-shrink-0" />
-              <span className="text-sm font-medium text-white/90 text-left flex-1">
+              <Link className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
                 {t('menu.nodeConnection')}
               </span>
             </button>
@@ -168,10 +170,10 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {hasSubgraphs && onExtractSubgraphs && (
             <button
               onClick={onExtractSubgraphs}
-              className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-orange-500/10 transition-colors border-b border-orange-500/10 active:bg-orange-500/20"
+              className="w-full h-8 px-3 flex items-center gap-2 hover:bg-[#ffa348]/[0.07] transition-colors active:bg-[#ffa348]/[0.12]"
             >
-              <Ungroup className="h-4 w-4 text-orange-500 flex-shrink-0" />
-              <span className="text-sm font-medium text-orange-100 text-left flex-1">
+              <Ungroup className="h-3.5 w-3.5 text-[#ffa348] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#ffd9ae] text-left flex-1">
                 {t('menu.extractSubgraphs')}
               </span>
             </button>
@@ -183,8 +185,9 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
       {(onShowWorkflowJson || onShowObjectInfo) && (
         <>
           {/* Group Title */}
-          <div className="px-4 py-2 bg-white/5 border-b border-white/5">
-            <h3 className="text-[10px] font-bold text-white/40 uppercase tracking-widest">
+          <div className="h-px bg-white/[0.06] my-1" />
+          <div className="px-3 pt-1 pb-1">
+            <h3 className="font-mono text-[9px] font-semibold text-[#565d6b] uppercase tracking-[0.14em]">
               {t('menu.workflowInfo')}
             </h3>
           </div>
@@ -193,10 +196,10 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {onShowWorkflowJson && (
             <button
               onClick={onShowWorkflowJson}
-              className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10"
+              className="w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07]"
             >
-              <FileJson className="h-4 w-4 text-white/60 flex-shrink-0" />
-              <span className="text-sm font-medium text-white/90 text-left flex-1">
+              <FileJson className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
                 {t('menu.viewWorkflowJson')}
               </span>
             </button>
@@ -206,10 +209,10 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
           {onShowObjectInfo && (
             <button
               onClick={onShowObjectInfo}
-              className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10"
+              className="w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07]"
             >
-              <Database className="h-4 w-4 text-white/60 flex-shrink-0" />
-              <span className="text-sm font-medium text-white/90 text-left flex-1">
+              <Database className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+              <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
                 {t('menu.viewObjectInfo')}
               </span>
             </button>
@@ -220,8 +223,9 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
       {/* Group 3: System Controls */}
       <>
         {/* Group Title */}
-        <div className="px-4 py-2 bg-white/5 border-b border-white/5">
-          <h3 className="text-[10px] font-bold text-white/40 uppercase tracking-widest">
+        <div className="h-px bg-white/[0.06] my-1" />
+        <div className="px-3 pt-1 pb-1">
+          <h3 className="font-mono text-[9px] font-semibold text-[#565d6b] uppercase tracking-[0.14em]">
             {t('menu.system')}
           </h3>
         </div>
@@ -230,10 +234,10 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
         {onShowWorkflowSnapshots && (
           <button
             onClick={onShowWorkflowSnapshots}
-            className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-white/5 transition-colors border-b border-white/5 active:bg-white/10"
+            className="w-full h-8 px-3 flex items-center gap-2 hover:bg-white/[0.04] transition-colors active:bg-white/[0.07]"
           >
-            <Camera className="h-4 w-4 text-white/60 flex-shrink-0" />
-            <span className="text-sm font-medium text-white/90 text-left flex-1">
+            <Camera className="h-3.5 w-3.5 text-[#8a919e] flex-shrink-0" strokeWidth={1.8} />
+            <span className="text-[11.5px] font-medium text-[#d5d9e0] text-left flex-1">
               {t('menu.workflowSnapshots')}
             </span>
           </button>
@@ -242,14 +246,14 @@ export const SettingsDropdownContent: React.FC<SettingsDropdownProps> = ({
         <button
           onClick={onClearVRAM}
           disabled={isClearingVRAM}
-          className="w-full px-4 py-3 flex items-center space-x-3 hover:bg-red-500/10 transition-colors disabled:opacity-50 active:bg-red-500/20"
+          className="w-full h-8 px-3 flex items-center gap-2 hover:bg-[#f25555]/[0.07] transition-colors disabled:opacity-50 active:bg-[#f25555]/[0.12]"
         >
           {isClearingVRAM ? (
-            <Loader2 className="h-4 w-4 animate-spin text-red-500 flex-shrink-0" />
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-[#f25555] flex-shrink-0" />
           ) : (
-            <Brush className="h-4 w-4 text-red-500 flex-shrink-0" />
+            <Brush className="h-3.5 w-3.5 text-[#f25555] flex-shrink-0" strokeWidth={1.8} />
           )}
-          <span className="text-sm font-medium text-red-400 text-left flex-1">
+          <span className="text-[11.5px] font-medium text-[#f87c7c] text-left flex-1">
             {isClearingVRAM ? t('menu.clearing') : t('menu.clearVram')}
           </span>
         </button>

--- a/src/components/controls/SideMenu.tsx
+++ b/src/components/controls/SideMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactDOM from 'react-dom';
-import { X, Settings, Server, Download, Upload, RotateCcw, Package, Trash2, FolderOpen, Database, Layers, Video, Link as LinkIcon, Image, ChevronRight, Check } from 'lucide-react';
+import { X, Settings, Server, Download, Upload, RotateCcw, Package, Trash2, FolderOpen, Database, Layers, Video, Link as LinkIcon, Image, ChevronRight, ChevronDown, Check } from 'lucide-react';
 import { useConnectionStore } from '@/ui/store/connectionStore';
 import { CacheService, CacheClearResult, BrowserCapabilities } from '@/services/cacheService';
 import { useNavigate } from 'react-router-dom';
@@ -37,6 +37,7 @@ const TINT = {
   sync: { bg: 'rgba(79,184,186,.12)', fg: '#56bfc1' },
   models: { bg: 'rgba(240,171,82,.1)', fg: '#e0a860' },
   tools: { bg: 'rgba(122,167,232,.09)', fg: '#8fa8d8' },
+  old: { bg: 'rgba(255,255,255,.05)', fg: '#8a919e' },
 } as const;
 
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -106,6 +107,7 @@ const SideMenu: React.FC<SideMenuProps> = ({
   const [isClearing, setIsClearing] = useState<boolean>(false);
   const [clearResult, setClearResult] = useState<CacheClearResult | null>(null);
   const [, setBrowserCapabilities] = useState<BrowserCapabilities | null>(null);
+  const [isOldOpen, setIsOldOpen] = useState(true);
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { previewMethod, setPreviewMethod } = useLatentPreviewStore();
@@ -234,13 +236,6 @@ const SideMenu: React.FC<SideMenuProps> = ({
               <SectionLabel>{t('menu.navigation')}</SectionLabel>
               <GroupCard>
                 <MenuRow
-                  icon={<LinkIcon className="w-4 h-4" strokeWidth={1.8} />}
-                  tint={TINT.nav}
-                  label={t('menu.chains')}
-                  sub={t('menu.chainsSub')}
-                  onClick={onChainsClick}
-                />
-                <MenuRow
                   icon={<Image className="w-4 h-4" strokeWidth={1.8} />}
                   tint={TINT.nav}
                   label={t('menu.gallery')}
@@ -354,13 +349,6 @@ const SideMenu: React.FC<SideMenuProps> = ({
                   onClick={onVideoDownloadClick}
                 />
                 <MenuRow
-                  icon={<Layers className="w-4 h-4" strokeWidth={1.8} />}
-                  tint={TINT.tools}
-                  label={t('menu.nodePatches')}
-                  sub={t('menu.nodePatchesSub')}
-                  onClick={onWidgetTypeSettingsClick}
-                />
-                <MenuRow
                   icon={<Database className="w-4 h-4" strokeWidth={1.8} />}
                   tint={TINT.tools}
                   label={t('menu.backup')}
@@ -369,6 +357,40 @@ const SideMenu: React.FC<SideMenuProps> = ({
                   divider={false}
                 />
               </GroupCard>
+            </div>
+
+            {/* OLD (legacy features, collapsed by default) */}
+            <div>
+              <button
+                onClick={() => setIsOldOpen((v) => !v)}
+                className="w-full flex items-center gap-2 mb-[9px]"
+              >
+                <span className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] uppercase">OLD</span>
+                <span className="flex-1 h-px bg-white/[0.06]" />
+                <ChevronDown
+                  className={`w-3.5 h-3.5 text-[#565d6b] transition-transform duration-200 ${isOldOpen ? 'rotate-180' : ''}`}
+                  strokeWidth={2}
+                />
+              </button>
+              {isOldOpen && (
+                <GroupCard>
+                  <MenuRow
+                    icon={<LinkIcon className="w-4 h-4" strokeWidth={1.8} />}
+                    tint={TINT.old}
+                    label={t('menu.chains')}
+                    sub={t('menu.chainsSub')}
+                    onClick={onChainsClick}
+                  />
+                  <MenuRow
+                    icon={<Layers className="w-4 h-4" strokeWidth={1.8} />}
+                    tint={TINT.old}
+                    label={t('menu.nodePatches')}
+                    sub={t('menu.nodePatchesSub')}
+                    onClick={onWidgetTypeSettingsClick}
+                    divider={false}
+                  />
+                </GroupCard>
+              )}
             </div>
 
             {/* LANGUAGE */}

--- a/src/components/controls/SideMenu.tsx
+++ b/src/components/controls/SideMenu.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactDOM from 'react-dom';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { X, Settings, Wifi, WifiOff, Server, Download, Upload, RotateCcw, Package, Trash2, HardDrive, FolderOpen, Database, Layers, Video, Link as LinkIcon, Image, Globe, Info } from 'lucide-react';
+import { X, Settings, Server, Download, Upload, RotateCcw, Package, Trash2, FolderOpen, Database, Layers, Video, Link as LinkIcon, Image, ChevronRight, Check } from 'lucide-react';
 import { useConnectionStore } from '@/ui/store/connectionStore';
 import { CacheService, CacheClearResult, BrowserCapabilities } from '@/services/cacheService';
 import { useNavigate } from 'react-router-dom';
@@ -32,6 +30,62 @@ interface SideMenuProps {
   onGalleryClick: () => void;
 }
 
+// Design-spec section tints (icon tile bg + icon color per section)
+const TINT = {
+  nav: { bg: 'rgba(61,123,253,.1)', fg: '#5b8af5' },
+  mgmt: { bg: 'rgba(154,123,240,.1)', fg: '#9a8af0' },
+  sync: { bg: 'rgba(79,184,186,.12)', fg: '#56bfc1' },
+  models: { bg: 'rgba(240,171,82,.1)', fg: '#e0a860' },
+  tools: { bg: 'rgba(122,167,232,.09)', fg: '#8fa8d8' },
+} as const;
+
+const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] mb-[9px] uppercase whitespace-nowrap">
+    {children}
+  </div>
+);
+
+const GroupCard: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className = '' }) => (
+  <div
+    className={`border border-white/[0.08] rounded-xl overflow-hidden ${className}`}
+    style={{ background: 'rgba(255,255,255,0.025)' }}
+  >
+    {children}
+  </div>
+);
+
+const MenuRow: React.FC<{
+  icon: React.ReactNode;
+  tint: { bg: string; fg: string };
+  label: string;
+  sub?: string;
+  onClick?: () => void;
+  trailing?: React.ReactNode;
+  divider?: boolean;
+}> = ({ icon, tint, label, sub, onClick, trailing, divider = true }) => {
+  const content = (
+    <>
+      <span
+        className="w-9 h-9 shrink-0 rounded-[10px] flex items-center justify-center"
+        style={{ background: tint.bg, color: tint.fg }}
+      >
+        {icon}
+      </span>
+      <span className="flex-1 min-w-0 text-left">
+        <span className="block text-[13.5px] font-semibold leading-[1.3] text-[#e9ebef] truncate">{label}</span>
+        {sub && <span className="block text-[11px] leading-[1.3] text-[#66758a] mt-0.5 truncate">{sub}</span>}
+      </span>
+      {trailing ?? <ChevronRight className="w-3.5 h-3.5 shrink-0 text-[#4a5261]" strokeWidth={2} />}
+    </>
+  );
+  const cls = `w-full h-[58px] flex items-center gap-3 px-3.5 ${divider ? 'border-b border-white/[0.05]' : ''} ${onClick ? 'active:bg-white/[0.03] transition-colors' : ''}`;
+  return onClick ? (
+    <button onClick={onClick} className={cls}>{content}</button>
+  ) : (
+    <div className={cls}>{content}</div>
+  );
+};
+
 const SideMenu: React.FC<SideMenuProps> = ({
   isOpen,
   onClose,
@@ -51,7 +105,7 @@ const SideMenu: React.FC<SideMenuProps> = ({
   const [cacheSize, setCacheSize] = useState<number>(0);
   const [isClearing, setIsClearing] = useState<boolean>(false);
   const [clearResult, setClearResult] = useState<CacheClearResult | null>(null);
-  const [browserCapabilities, setBrowserCapabilities] = useState<BrowserCapabilities | null>(null);
+  const [, setBrowserCapabilities] = useState<BrowserCapabilities | null>(null);
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { previewMethod, setPreviewMethod } = useLatentPreviewStore();
@@ -109,411 +163,322 @@ const SideMenu: React.FC<SideMenuProps> = ({
     }
   };
 
+  const updatesDisabled = remoteVersion === 'dev' || remoteVersion === '0.0.0';
+
   return typeof document !== 'undefined' ? ReactDOM.createPortal(
     <>
       {/* Side Menu - Full Screen Overlay */}
-      <div className={`fixed inset-0 bg-slate-50/95 dark:bg-slate-950/95 backdrop-blur-xl z-[9999] transition-all duration-300 ease-out flex flex-col ${isOpen ? 'translate-x-0 opacity-100' : '-translate-x-full opacity-0'
-        }`}>
-        {/* Header */}
-        <div className="flex-none flex items-center justify-between p-6 border-b border-slate-200/50 dark:border-slate-800/50">
-          <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
-            {t('menu.title')}
-          </h2>
-          <Button
+      <div
+        className={`fixed inset-0 z-[9999] transition-all duration-300 ease-out flex flex-col text-[#e9ebef] ${isOpen ? 'translate-x-0 opacity-100' : '-translate-x-full opacity-0'}`}
+        style={{ background: '#0b0c0f' }}
+      >
+        {/* Header (56px) */}
+        <div className="flex-none h-14 flex items-center justify-between px-[18px] border-b border-white/[0.08]">
+          <h2 className="text-[17px] font-bold leading-none">{t('menu.title')}</h2>
+          <button
             onClick={onClose}
-            variant="ghost"
-            size="icon"
-            className="h-10 w-10 rounded-full hover:bg-slate-200/50 dark:hover:bg-slate-800/50"
+            className="w-[34px] h-[34px] rounded-[10px] border border-white/[0.08] flex items-center justify-center text-[#c8ccd4] hover:text-white transition-colors"
+            style={{ background: 'rgba(255,255,255,0.045)' }}
           >
-            <X className="h-6 w-6" />
-          </Button>
+            <X className="w-[15px] h-[15px]" strokeWidth={1.9} />
+          </button>
         </div>
 
         {/* Content - Scrollable */}
-        <div className="flex-1 overflow-y-auto p-6">
-          <div className="max-w-2xl mx-auto space-y-8">
-            {/* Server Connection Status */}
-            <section className="space-y-4">
-              <div className="flex items-center space-x-3 text-blue-600 dark:text-blue-400">
-                <Server className="h-6 w-6" />
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-                  {t('menu.serverConnection')}
-                </h3>
-              </div>
-
-              <div className="p-5 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-sm space-y-4">
-                <div className="flex items-center justify-between">
-                  <span className="font-medium text-slate-700 dark:text-slate-300">
-                    {t('common.status')}
-                  </span>
-                  <div className="flex items-center space-x-2">
-                    {isConnected ? (
-                      <>
-                        <Wifi className="h-4 w-4 text-green-600 dark:text-green-400" />
-                        <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100 px-3 py-1">
-                          {t('common.connected')}
-                        </Badge>
-                      </>
-                    ) : (
-                      <>
-                        <WifiOff className="h-4 w-4 text-red-600 dark:text-red-400" />
-                        <Badge variant="destructive" className="px-3 py-1">
-                          {t('common.disconnected')}
-                        </Badge>
-                      </>
-                    )}
-                  </div>
+        <div className="flex-1 overflow-y-auto px-[18px] pt-4 pb-6">
+          <div className="max-w-2xl mx-auto flex flex-col gap-[18px]">
+            {/* SERVER */}
+            <div>
+              <SectionLabel>{t('menu.serverConnection')}</SectionLabel>
+              <GroupCard className="px-3.5">
+                <div className="h-[42px] flex items-center justify-between">
+                  <span className="text-[13px] font-medium text-[#c8ccd4]">{t('common.status')}</span>
+                  {isConnected ? (
+                    <span
+                      className="flex items-center gap-[7px] px-2.5 py-[5px] rounded-lg border text-[11.5px] font-semibold"
+                      style={{ background: 'rgba(52,199,123,.12)', borderColor: 'rgba(52,199,123,.28)', color: '#4ade80' }}
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full bg-[#4ade80]" />
+                      {t('common.connected')}
+                    </span>
+                  ) : (
+                    <span
+                      className="flex items-center gap-[7px] px-2.5 py-[5px] rounded-lg border text-[11.5px] font-semibold"
+                      style={{ background: 'rgba(242,85,85,.12)', borderColor: 'rgba(242,85,85,.3)', color: '#f87c7c' }}
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full bg-[#f25555]" />
+                      {t('common.disconnected')}
+                    </span>
+                  )}
                 </div>
-
-                <div className="flex items-center justify-between">
-                  <span className="font-medium text-slate-700 dark:text-slate-300">
-                    {t('workflow.server')} URL
-                  </span>
-                  <span className="text-sm text-slate-500 dark:text-slate-400 font-mono bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
+                <div className="h-px bg-white/[0.06]" />
+                <div className="h-[42px] flex items-center justify-between gap-3">
+                  <span className="text-[13px] font-medium text-[#c8ccd4] shrink-0">{t('workflow.server')} URL</span>
+                  <span
+                    className="font-mono text-[11.5px] text-[#8a919e] px-[9px] py-[5px] rounded-[7px] border border-white/[0.07] truncate"
+                    style={{ background: 'rgba(255,255,255,0.05)' }}
+                  >
                     {formatUrl(url)}
                   </span>
                 </div>
-
                 {error && (
-                  <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-sm text-red-600 dark:text-red-400">
+                  <div className="mb-2.5 rounded-[10px] border border-[#f25555]/30 bg-[#f25555]/10 px-3 py-2 text-[11.5px] text-[#f87c7c]">
                     {error}
                   </div>
                 )}
-              </div>
-            </section>
+              </GroupCard>
+            </div>
 
-            {/* Menu Grid */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {/* Navigation */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider ml-1">
-                  {t('menu.navigation')}
-                </h4>
-                <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden">
-                  <button
-                    onClick={onChainsClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left border-b border-slate-100 dark:border-slate-800 last:border-0"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center text-indigo-600 dark:text-indigo-400 mr-4">
-                      <LinkIcon className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.chains')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.chainsSub')}</div>
-                    </div>
-                  </button>
-                  <button
-                    onClick={onGalleryClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-pink-100 dark:bg-pink-900/30 flex items-center justify-center text-pink-600 dark:text-pink-400 mr-4">
-                      <Image className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.gallery')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.gallerySub')}</div>
-                    </div>
-                  </button>
-                </div>
-              </div>
+            {/* NAVIGATION */}
+            <div>
+              <SectionLabel>{t('menu.navigation')}</SectionLabel>
+              <GroupCard>
+                <MenuRow
+                  icon={<LinkIcon className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.nav}
+                  label={t('menu.chains')}
+                  sub={t('menu.chainsSub')}
+                  onClick={onChainsClick}
+                />
+                <MenuRow
+                  icon={<Image className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.nav}
+                  label={t('menu.gallery')}
+                  sub={t('menu.gallerySub')}
+                  onClick={onGalleryClick}
+                  divider={false}
+                />
+              </GroupCard>
+            </div>
 
-              {/* Server Management */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider ml-1">
-                  {t('menu.serverMgmt')}
-                </h4>
-                <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden">
-                  <button
-                    onClick={onServerSettingsClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left border-b border-slate-100 dark:border-slate-800 last:border-0"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 mr-4">
-                      <Settings className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.settings')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.settingsSub')}</div>
-                    </div>
-                  </button>
-                  <button
-                    onClick={onServerRebootClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-orange-100 dark:bg-orange-900/30 flex items-center justify-center text-orange-600 dark:text-orange-400 mr-4">
-                      <RotateCcw className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.reboot')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.rebootSub')}</div>
-                    </div>
-                  </button>
-
-                  <div className="flex items-center p-4 border-t border-slate-100 dark:border-slate-800">
-                    <div className="h-10 w-10 rounded-xl bg-violet-100 dark:bg-violet-900/30 flex items-center justify-center text-violet-600 dark:text-violet-400 mr-4">
-                      <Image className="h-5 w-5" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="font-medium text-slate-900 dark:text-slate-100 truncate">{t('latentPreview.title')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400 truncate">{t('latentPreview.mode')}</div>
-                    </div>
-                    <div className="ml-2">
-                      <Select
-                        value={previewMethod}
-                        onValueChange={(value) => setPreviewMethod(value as PreviewMethod)}
+            {/* SERVER MANAGEMENT */}
+            <div>
+              <SectionLabel>{t('menu.serverMgmt')}</SectionLabel>
+              <GroupCard>
+                <MenuRow
+                  icon={<Settings className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.mgmt}
+                  label={t('menu.settings')}
+                  sub={t('menu.settingsSub')}
+                  onClick={onServerSettingsClick}
+                />
+                <MenuRow
+                  icon={<RotateCcw className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.mgmt}
+                  label={t('menu.reboot')}
+                  sub={t('menu.rebootSub')}
+                  onClick={onServerRebootClick}
+                />
+                <MenuRow
+                  icon={<Image className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.mgmt}
+                  label={t('latentPreview.title')}
+                  sub={t('latentPreview.mode')}
+                  divider={false}
+                  trailing={
+                    <Select
+                      value={previewMethod}
+                      onValueChange={(value) => setPreviewMethod(value as PreviewMethod)}
+                    >
+                      <SelectTrigger
+                        className="h-8 w-[110px] rounded-lg border-white/[0.08] text-[11.5px] text-[#c8ccd4] shadow-none dark:bg-transparent"
+                        style={{ background: 'rgba(255,255,255,0.05)' }}
                       >
-                        <SelectTrigger className="h-9 w-[110px] bg-slate-50 dark:bg-slate-800/50">
-                          <SelectValue placeholder="Select" />
-                        </SelectTrigger>
-                        <SelectContent className="z-[10001]">
-                          <SelectItem value="none">{t('latentPreview.methods.none')}</SelectItem>
-                          <SelectItem value="auto">{t('latentPreview.methods.auto')}</SelectItem>
-                          <SelectItem value="latent2rgb">{t('latentPreview.methods.fast')}</SelectItem>
-                          <SelectItem value="taesd">{t('latentPreview.methods.slow')}</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-                </div>
-              </div>
+                        <SelectValue placeholder="Select" />
+                      </SelectTrigger>
+                      <SelectContent className="z-[10001]">
+                        <SelectItem value="none">{t('latentPreview.methods.none')}</SelectItem>
+                        <SelectItem value="auto">{t('latentPreview.methods.auto')}</SelectItem>
+                        <SelectItem value="latent2rgb">{t('latentPreview.methods.fast')}</SelectItem>
+                        <SelectItem value="taesd">{t('latentPreview.methods.slow')}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  }
+                />
+              </GroupCard>
+            </div>
 
-              {/* Workflow Sync */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider ml-1">
-                  {t('menu.workflowSync')}
-                </h4>
-                <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden">
-                  <button
-                    onClick={onImportWorkflowsClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left border-b border-slate-100 dark:border-slate-800 last:border-0"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-purple-100 dark:bg-purple-900/30 flex items-center justify-center text-purple-600 dark:text-purple-400 mr-4">
-                      <Download className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.import')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.importSub')}</div>
-                    </div>
-                  </button>
-                  <button
-                    onClick={onUploadWorkflowsClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center text-indigo-600 dark:text-indigo-400 mr-4">
-                      <Upload className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.upload')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.uploadSub')}</div>
-                    </div>
-                  </button>
-                </div>
-              </div>
+            {/* WORKFLOW SYNC */}
+            <div>
+              <SectionLabel>{t('menu.workflowSync')}</SectionLabel>
+              <GroupCard>
+                <MenuRow
+                  icon={<Download className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.sync}
+                  label={t('menu.import')}
+                  sub={t('menu.importSub')}
+                  onClick={onImportWorkflowsClick}
+                />
+                <MenuRow
+                  icon={<Upload className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.sync}
+                  label={t('menu.upload')}
+                  sub={t('menu.uploadSub')}
+                  onClick={onUploadWorkflowsClick}
+                  divider={false}
+                />
+              </GroupCard>
+            </div>
 
-              {/* Model Management */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider ml-1">
-                  {t('menu.models')}
-                </h4>
-                <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden">
-                  <button
-                    onClick={onModelDownloadClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left border-b border-slate-100 dark:border-slate-800 last:border-0"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-pink-100 dark:bg-pink-900/30 flex items-center justify-center text-pink-600 dark:text-pink-400 mr-4">
-                      <Package className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.modelDownload')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.modelDownloadSub')}</div>
-                    </div>
-                  </button>
-                  <button
-                    onClick={onModelBrowserClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-rose-100 dark:bg-rose-900/30 flex items-center justify-center text-rose-600 dark:text-rose-400 mr-4">
-                      <FolderOpen className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.modelBrowser')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.modelBrowserSub')}</div>
-                    </div>
-                  </button>
-                </div>
-              </div>
+            {/* MODELS */}
+            <div>
+              <SectionLabel>{t('menu.models')}</SectionLabel>
+              <GroupCard>
+                <MenuRow
+                  icon={<Package className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.models}
+                  label={t('menu.modelDownload')}
+                  sub={t('menu.modelDownloadSub')}
+                  onClick={onModelDownloadClick}
+                />
+                <MenuRow
+                  icon={<FolderOpen className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.models}
+                  label={t('menu.modelBrowser')}
+                  sub={t('menu.modelBrowserSub')}
+                  onClick={onModelBrowserClick}
+                  divider={false}
+                />
+              </GroupCard>
+            </div>
 
-              {/* Tools */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider ml-1">
-                  {t('menu.tools')}
-                </h4>
-                <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden">
-                  <button
-                    onClick={onVideoDownloadClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left border-b border-slate-100 dark:border-slate-800 last:border-0"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-teal-100 dark:bg-teal-900/30 flex items-center justify-center text-teal-600 dark:text-teal-400 mr-4">
-                      <Video className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.videoDownloader')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.videoDownloaderSub')}</div>
-                    </div>
-                  </button>
-                  <button
-                    onClick={onWidgetTypeSettingsClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left border-b border-slate-100 dark:border-slate-800 last:border-0"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-cyan-100 dark:bg-cyan-900/30 flex items-center justify-center text-cyan-600 dark:text-cyan-400 mr-4">
-                      <Layers className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.nodePatches')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.nodePatchesSub')}</div>
-                    </div>
-                  </button>
-                  <button
-                    onClick={onBrowserDataBackupClick}
-                    className="w-full flex items-center p-4 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors text-left"
-                  >
-                    <div className="h-10 w-10 rounded-xl bg-sky-100 dark:bg-sky-900/30 flex items-center justify-center text-sky-600 dark:text-sky-400 mr-4">
-                      <Database className="h-5 w-5" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{t('menu.backup')}</div>
-                      <div className="text-xs text-slate-500 dark:text-slate-400">{t('menu.backupSub')}</div>
-                    </div>
-                  </button>
-                </div>
+            {/* TOOLS */}
+            <div>
+              <SectionLabel>{t('menu.tools')}</SectionLabel>
+              <GroupCard>
+                <MenuRow
+                  icon={<Video className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.tools}
+                  label={t('menu.videoDownloader')}
+                  sub={t('menu.videoDownloaderSub')}
+                  onClick={onVideoDownloadClick}
+                />
+                <MenuRow
+                  icon={<Layers className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.tools}
+                  label={t('menu.nodePatches')}
+                  sub={t('menu.nodePatchesSub')}
+                  onClick={onWidgetTypeSettingsClick}
+                />
+                <MenuRow
+                  icon={<Database className="w-4 h-4" strokeWidth={1.8} />}
+                  tint={TINT.tools}
+                  label={t('menu.backup')}
+                  sub={t('menu.backupSub')}
+                  onClick={onBrowserDataBackupClick}
+                  divider={false}
+                />
+              </GroupCard>
+            </div>
+
+            {/* LANGUAGE */}
+            <div>
+              <SectionLabel>{t('menu.language')}</SectionLabel>
+              <div className="grid grid-cols-2 gap-1.5">
+                {[
+                  { code: 'en', label: 'English' },
+                  { code: 'ko', label: '한국어' },
+                  { code: 'zh', label: '简体中文' },
+                  { code: 'ja', label: '日本語' }
+                ].map((lang) => {
+                  const active = i18n.language === lang.code;
+                  return (
+                    <button
+                      key={lang.code}
+                      onClick={() => i18n.changeLanguage(lang.code)}
+                      className={`h-10 flex items-center justify-between px-3.5 rounded-[10px] border text-[12.5px] font-medium transition-colors ${active
+                        ? 'border-[#3069f0]/40 text-[#7ba3f5]'
+                        : 'border-white/[0.08] text-[#9aa3b2] hover:text-[#c8ccd4]'
+                        }`}
+                      style={{ background: active ? 'rgba(61,123,253,.1)' : 'rgba(255,255,255,0.025)' }}
+                    >
+                      {lang.label}
+                      {active && <Check className="w-[13px] h-[13px]" strokeWidth={2.2} />}
+                    </button>
+                  );
+                })}
               </div>
             </div>
 
-            {/* Language Selection */}
-            <section className="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-800">
-              <div className="flex items-center space-x-3 text-slate-600 dark:text-slate-400">
-                <Globe className="h-6 w-6" />
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-                  {t('menu.language')}
-                </h3>
-              </div>
-
-              <div className="grid grid-cols-2 gap-2">
-                {[
-                  { code: 'en', label: 'English', flag: '🇺🇸' },
-                  { code: 'ko', label: '한국어', flag: '🇰🇷' },
-                  { code: 'zh', label: '简体中文', flag: '🇨🇳' },
-                  { code: 'ja', label: '日本語', flag: '🇯🇵' }
-                ].map((lang) => (
-                  <Button
-                    key={lang.code}
-                    variant={i18n.language === lang.code ? "default" : "outline"}
-                    className={`justify-start ${i18n.language === lang.code ? 'bg-primary text-primary-foreground' : 'bg-white dark:bg-slate-900'}`}
-                    onClick={() => i18n.changeLanguage(lang.code)}
-                  >
-                    <span className="mr-2 text-base">{lang.flag}</span>
-                    {lang.label}
-                  </Button>
-                ))}
-              </div>
-            </section>
-
-            {/* App Info & Update Section */}
-            <section className="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-800">
-              <div className="flex items-center space-x-3 text-slate-600 dark:text-slate-400">
-                <Info className="h-6 w-6" />
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-                  {t('menu.appInfo')}
-                </h3>
-              </div>
-
-              <Button
-                onClick={() => {
-                  if (remoteVersion === 'dev' || remoteVersion === '0.0.0') {
-                    // In development mode, checking for updates is disabled
-                    import('sonner').then(({ toast }) => {
-                      toast.info('Update check is disabled in development mode');
-                    });
-                    return;
-                  }
-                  onClose();
-                  navigate('/update');
-                }}
-                variant="outline"
-                className={`w-full justify-start text-left h-auto py-3 px-4 bg-slate-50 dark:bg-slate-900 border-slate-200 dark:border-slate-800 transition-all group ${(remoteVersion === 'dev' || remoteVersion === '0.0.0')
-                  ? 'opacity-50 cursor-not-allowed'
-                  : 'hover:bg-purple-50 dark:hover:bg-purple-900/10 hover:border-purple-200 dark:hover:border-purple-800'
-                  }`}
-              >
-                <div className="flex items-center justify-between w-full">
-                  <div className="flex flex-col items-start gap-1">
-                    <div className={`font-medium text-slate-900 dark:text-slate-100 ${(remoteVersion === 'dev' || remoteVersion === '0.0.0') ? '' : 'group-hover:text-purple-600 dark:group-hover:text-purple-400'
-                      }`}>
-                      {t('menu.checkForUpdates')}
-                    </div>
-                    <div className="text-xs text-slate-500 dark:text-slate-400">
-                      {remoteVersion === 'dev' ? 'dev' : `v${remoteVersion || 'Unknown'}`}
-                    </div>
-                  </div>
-                  <Download className={`h-4 w-4 text-slate-400 ${(remoteVersion === 'dev' || remoteVersion === '0.0.0') ? '' : 'group-hover:text-purple-500'
-                    }`} />
-                </div>
-              </Button>
-            </section>
-
-            {/* App Cache Section */}
-            <section className="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-800">
-              <div className="flex items-center space-x-3 text-slate-600 dark:text-slate-400">
-                <HardDrive className="h-6 w-6" />
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-                  {t('menu.cache')}
-                </h3>
-              </div>
-
-              <div className="p-5 bg-slate-100 dark:bg-slate-900/50 rounded-2xl space-y-4">
-                <div className="flex items-center justify-between">
-                  <span className="font-medium text-slate-700 dark:text-slate-300">
-                    {t('menu.cacheUsed')}
+            {/* APP INFO */}
+            <div>
+              <SectionLabel>{t('menu.appInfo')}</SectionLabel>
+              <GroupCard>
+                <button
+                  onClick={() => {
+                    if (updatesDisabled) {
+                      import('sonner').then(({ toast }) => {
+                        toast.info('Update check is disabled in development mode');
+                      });
+                      return;
+                    }
+                    onClose();
+                    navigate('/update');
+                  }}
+                  className={`w-full h-[58px] flex items-center gap-3 px-3.5 transition-colors ${updatesDisabled ? 'opacity-50' : 'active:bg-white/[0.03]'}`}
+                >
+                  <span className="w-9 h-9 shrink-0 rounded-[10px] flex items-center justify-center" style={{ background: TINT.tools.bg, color: TINT.tools.fg }}>
+                    <Download className="w-4 h-4" strokeWidth={1.8} />
                   </span>
-                  <span className="text-slate-600 dark:text-slate-400 font-mono">
+                  <span className="flex-1 min-w-0 text-left">
+                    <span className="block text-[13.5px] font-semibold leading-[1.3] text-[#e9ebef]">{t('menu.checkForUpdates')}</span>
+                    <span className="block font-mono text-[10px] text-[#565d6b] mt-0.5">
+                      {remoteVersion === 'dev' ? 'dev' : `v${remoteVersion || 'Unknown'}`}
+                    </span>
+                  </span>
+                  <ChevronRight className="w-3.5 h-3.5 shrink-0 text-[#4a5261]" strokeWidth={2} />
+                </button>
+              </GroupCard>
+            </div>
+
+            {/* CACHE */}
+            <div>
+              <SectionLabel>{t('menu.cache')}</SectionLabel>
+              <GroupCard className="px-3.5 py-1">
+                <div className="h-[42px] flex items-center justify-between">
+                  <span className="text-[13px] font-medium text-[#c8ccd4]">{t('menu.cacheUsed')}</span>
+                  <span className="font-mono text-[11.5px] text-[#8a919e]">
                     {CacheService.formatCacheSize(cacheSize)}
                   </span>
                 </div>
-
-                <Button
-                  onClick={handleClearCache}
-                  disabled={isClearing}
-                  variant="outline"
-                  className="w-full bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600 dark:hover:text-red-400 transition-colors"
-                >
-                  {isClearing ? (
-                    <>
-                      <div className="h-4 w-4 mr-2 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                      {t('menu.cacheClearing')}
-                    </>
-                  ) : (
-                    <>
-                      <Trash2 className="h-4 w-4 mr-2" />
-                      {t('menu.cacheClear')}
-                    </>
+                <div className="h-px bg-white/[0.06]" />
+                <div className="py-2.5">
+                  <button
+                    onClick={handleClearCache}
+                    disabled={isClearing}
+                    className="w-full h-10 flex items-center justify-center gap-2 rounded-[10px] border text-[12.5px] font-semibold transition-colors disabled:opacity-50"
+                    style={{ background: 'rgba(242,85,85,.1)', borderColor: 'rgba(242,85,85,.3)', color: '#f87c7c' }}
+                  >
+                    {isClearing ? (
+                      <>
+                        <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                        {t('menu.cacheClearing')}
+                      </>
+                    ) : (
+                      <>
+                        <Trash2 className="w-3.5 h-3.5" strokeWidth={1.8} />
+                        {t('menu.cacheClear')}
+                      </>
+                    )}
+                  </button>
+                  {clearResult && (
+                    <div className={`mt-2 text-[11px] px-2.5 py-1.5 rounded-lg ${clearResult.success
+                      ? 'text-[#4ade80] bg-[#34c77b]/10 border border-[#34c77b]/25'
+                      : 'text-[#f87c7c] bg-[#f25555]/10 border border-[#f25555]/25'
+                      }`}>
+                      {clearResult.success ? t('menu.cacheSuccess') : t('menu.cacheFailed')}
+                    </div>
                   )}
-                </Button>
-
-                {clearResult && (
-                  <div className={`text-xs p-2 rounded ${clearResult.success ? 'text-green-600 bg-green-50 dark:bg-green-900/20' : 'text-red-600 bg-red-50 dark:bg-red-900/20'}`}>
-                    {clearResult.success ? t('menu.cacheSuccess') : t('menu.cacheFailed')}
-                  </div>
-                )}
-              </div>
-            </section>
+                </div>
+              </GroupCard>
+            </div>
 
             {/* Footer */}
-            <div className="pt-8 text-center space-y-2">
-              <h3 className="font-bold text-slate-900 dark:text-slate-100">
-                {t('menu.appTitle')}
-              </h3>
-              <p className="text-sm text-slate-500 dark:text-slate-400">
+            <div className="pt-4 pb-2 text-center">
+              <div className="text-[13px] font-bold text-[#c8ccd4]">{t('menu.appTitle')}</div>
+              <div className="font-mono text-[10px] text-[#565d6b] mt-1">
                 {remoteVersion === 'dev' ? 'dev' : t('menu.version', { version: remoteVersion || '0.0.0' })}
-              </p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/controls/TriggerWordSelector.tsx
+++ b/src/components/controls/TriggerWordSelector.tsx
@@ -229,7 +229,6 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
 
   if (!isOpen) return null;
 
-  const baseTitleSize = '1.875rem';
 
   return createPortal(
     <AnimatePresence>
@@ -247,66 +246,50 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.96, y: 15 }}
           transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-          className="relative w-[90vw] h-[85vh] pointer-events-auto flex flex-col"
+          className="relative w-[92vw] max-w-md h-[72vh] pointer-events-auto flex flex-col"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Main Card */}
           <div
-            style={{ backgroundColor: '#374151' }}
-            className="relative w-full h-full rounded-[40px] shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white"
+            style={{ backgroundColor: '#101217' }}
+            className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
             {/* Always Compact Sticky Header */}
             <div
-              className="absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] pt-2 pb-[13px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10"
+              className="absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b h-11 pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]"
             >
               {/* Floating Close Button */}
-              <div className="absolute right-4 top-1/2 -translate-y-1/2 flex-shrink-0 scale-75">
+              <div className="absolute right-3 top-1/2 -translate-y-1/2 flex-shrink-0">
                 <button
                   onClick={onClose}
-                  className="p-2 rounded-full bg-black/20 text-white hover:bg-black/40 transition-all pointer-events-auto"
+                  className="p-1.5 rounded-lg bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1] transition-all pointer-events-auto"
                 >
-                  <X className="w-5 h-5" />
+                  <X className="w-4 h-4" />
                 </button>
               </div>
 
-              <div className="flex flex-col justify-center flex-1 min-w-0 pointer-events-none">
-                <div className="flex items-center space-x-2 mb-1 scale-90 origin-left">
-                  <Badge variant="secondary" className="text-[10px] font-mono px-2 py-0.5 rounded-full bg-black/20 text-white/80 border-transparent">
-                    LORAS
-                  </Badge>
-                  <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">
-                    {t('menu.triggerWords')}
-                  </span>
-                </div>
-
-                <div className="flex items-center min-w-0 h-[13px]">
-                  <h2
-                    style={{
-                      fontSize: baseTitleSize,
-                      lineHeight: '1',
-                      transform: `scale(${0.8125 / 1.875})`,
-                      transformOrigin: 'left center',
-                    }}
-                    className="font-extrabold tracking-tight leading-tight text-white/95 transition-transform duration-300 will-change-transform truncate pr-4"
-                  >
-                    {t('menu.triggerWords')}
-                  </h2>
-                </div>
+              <div className="flex items-center gap-2 flex-1 min-w-0 pointer-events-none">
+                <h2 className="text-[14px] font-bold text-[#e9ebef] truncate">
+                  {t('menu.triggerWords')}
+                </h2>
+                <span className="font-mono text-[9px] font-semibold text-[#565d6b] tracking-[0.12em] px-1.5 py-0.5 rounded-md bg-black/20 shrink-0">
+                  LORAS
+                </span>
               </div>
             </div>
 
             {/* Persistent Search & Controls Bar - Slightly detached from header */}
             <div
-              className="absolute left-0 w-full z-20 px-4 sm:px-8 top-[68px]"
+              className="absolute left-0 w-full z-20 px-3 sm:px-6 top-[52px]"
             >
-              <div className="flex flex-col gap-3 bg-[#374151]/80 backdrop-blur-md p-3 rounded-2xl border border-white/5 shadow-lg">
+              <div className="flex flex-col gap-2 bg-[#101217]/90 backdrop-blur-md p-2 rounded-[10px] border border-white/[0.08]">
                 <div className="relative w-full">
                   <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
                   <Input
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     placeholder={t('menu.triggerWordsSearchPlaceholder')}
-                    className="w-full bg-black/20 border-white/10 text-xs text-white/90 placeholder:text-white/20 h-9 pl-9 pr-8 rounded-xl focus-visible:ring-1 focus-visible:ring-white/20 focus-visible:border-white/20 transition-all duration-300 border shadow-inner"
+                    className="w-full bg-white/[0.045] border-white/[0.08] text-[12px] text-[#e9ebef] placeholder:text-[#565d6b] h-8 pl-9 pr-8 rounded-lg focus-visible:ring-0 focus-visible:border-[#3069f0]/50 transition-all border"
                   />
                   {searchQuery && (
                     <button
@@ -322,7 +305,7 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                     onClick={expandAll}
                     variant="ghost"
                     size="sm"
-                    className="flex-1 h-8 text-[9px] font-bold uppercase tracking-wider bg-white/5 text-white/60 hover:bg-white/10 hover:text-white border border-white/5 rounded-lg transition-all"
+                    className="flex-1 h-7 font-mono text-[9px] font-semibold uppercase tracking-[0.12em] bg-white/[0.04] text-[#8a919e] hover:bg-white/[0.07] hover:text-[#c8ccd4] border border-white/[0.07] rounded-[7px] transition-all"
                   >
                     {t('menu.expandAll')}
                   </Button>
@@ -330,7 +313,7 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                     onClick={collapseAll}
                     variant="ghost"
                     size="sm"
-                    className="flex-1 h-8 text-[9px] font-bold uppercase tracking-wider bg-white/5 text-white/60 hover:bg-white/10 hover:text-white border border-white/5 rounded-lg transition-all"
+                    className="flex-1 h-7 font-mono text-[9px] font-semibold uppercase tracking-[0.12em] bg-white/[0.04] text-[#8a919e] hover:bg-white/[0.07] hover:text-[#c8ccd4] border border-white/[0.07] rounded-[7px] transition-all"
                   >
                     {t('menu.collapseAll')}
                   </Button>
@@ -341,21 +324,21 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
             {/* Content Area */}
             <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
               {/* Static Top Bumper - Adjusted for fixed header + search bar + gap */}
-              <div className="h-[185px] relative pointer-events-none">
+              <div className="h-[150px] relative pointer-events-none">
                 <div ref={sentinelRef} className="absolute top-[10px] left-0 h-px w-full" />
               </div>
 
-              <div className="px-5 pb-6 sm:px-6">
+              <div className="px-3 pb-4 sm:px-4">
                 {isLoading ? (
                   <div className="flex flex-col items-center justify-center py-20 space-y-4">
                     <div className="relative">
-                      <Loader2 className="h-10 w-10 animate-spin text-white/20" />
-                      <Sparkles className="absolute -top-1 -right-1 h-4 w-4 text-violet-400/50 animate-pulse" />
+                      <Loader2 className="h-7 w-7 animate-spin text-white/20" />
+                      <Sparkles className="absolute -top-1 -right-1 h-4 w-4 text-[#5b8af5]/50 animate-pulse" />
                     </div>
                     <p className="text-xs font-medium tracking-wide text-white/40 uppercase">{t('menu.loadingTriggerWords')}</p>
                   </div>
                 ) : filteredGroups.length === 0 ? (
-                  <div className="text-center py-12 rounded-3xl bg-black/20 border border-dashed border-white/10">
+                  <div className="text-center py-12 rounded-xl bg-black/20 border border-dashed border-white/10">
                     <Hash className="h-10 w-10 text-white/10 mx-auto mb-3" />
                     <p className="text-white/40 text-sm font-medium">
                       {searchQuery ? t('menu.noTriggerWordsFound') : t('menu.noTriggerWordsAvailable')}
@@ -372,12 +355,12 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                     )}
                   </div>
                 ) : (
-                  <div className="space-y-6">
+                  <div className="space-y-2.5">
                     {/* Category Header */}
                     <div className="flex items-center justify-between mb-2 p-1">
                       <div className="flex items-center gap-2">
-                        <Layers className="w-4 h-4 text-white/50" />
-                        <span className="text-[10px] font-bold uppercase tracking-widest text-white/50">
+                        <Layers className="w-3.5 h-3.5 text-white/50" />
+                        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-white/50">
                           {t('menu.lorasCount', { count: filteredGroups.length })}
                         </span>
                       </div>
@@ -386,23 +369,23 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                       </Badge>
                     </div>
 
-                    <div className="grid grid-cols-1 gap-4">
+                    <div className="grid grid-cols-1 gap-2">
                       {filteredGroups.map((group) => (
                         <div
                           key={group.loraName}
-                          className="group relative rounded-3xl bg-black/10 border border-white/5 hover:bg-black/20 hover:border-white/10 transition-all overflow-hidden"
+                          className="group relative rounded-[10px] bg-white/[0.03] border border-white/[0.07] hover:bg-white/[0.05] hover:border-white/[0.12] transition-all overflow-hidden"
                         >
                           {/* LoRA Header Card */}
                           <button
                             onClick={() => toggleLoraExpansion(group.loraName)}
-                            className="w-full px-5 py-3.5 flex items-center justify-between text-left transition-all"
+                            className="w-full px-3 py-2 flex items-center justify-between text-left transition-all"
                           >
-                            <div className="flex items-center space-x-4 min-w-0">
-                              <div className={`p-1.5 rounded-2xl bg-black/20 border border-white/5 transition-transform duration-300 ${group.isExpanded ? 'rotate-180 bg-violet-500/10 border-violet-500/20' : ''}`}>
-                                <ChevronDown className={`w-3.5 h-3.5 ${group.isExpanded ? 'text-violet-400' : 'text-white/40'}`} />
+                            <div className="flex items-center space-x-2.5 min-w-0">
+                              <div className={`p-1 rounded-lg bg-black/20 border border-white/[0.07] transition-transform duration-300 ${group.isExpanded ? 'rotate-180 bg-[#3069f0]/[0.12] border-[#3069f0]/25' : ''}`}>
+                                <ChevronDown className={`w-3.5 h-3.5 ${group.isExpanded ? 'text-[#7ba3f5]' : 'text-white/40'}`} />
                               </div>
                               <div className="flex flex-col min-w-0">
-                                <span className="font-bold text-white/90 text-[12px] tracking-tight line-clamp-2 leading-snug" title={cleanLoraName(group.loraName)}>
+                                <span className="font-bold text-white/90 text-[11.5px] tracking-tight line-clamp-2 leading-snug" title={cleanLoraName(group.loraName)}>
                                   {cleanLoraName(group.loraName)}
                                 </span>
                                 <span className="text-[9px] font-medium text-white/30 uppercase tracking-wider mt-0.5">
@@ -410,8 +393,8 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                                 </span>
                               </div>
                             </div>
-                            <div className="flex-shrink-0 ml-4 opacity-0 group-hover:opacity-100 transition-opacity">
-                              <div className="w-7 h-7 rounded-full bg-black/20 flex items-center justify-center border border-white/10">
+                            <div className="flex-shrink-0 ml-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                              <div className="w-6 h-6 rounded-md bg-black/20 flex items-center justify-center border border-white/10">
                                 <ChevronRight className="h-3.5 w-3.5 text-white/40" />
                               </div>
                             </div>
@@ -426,20 +409,20 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                                 exit={{ height: 0, opacity: 0 }}
                                 transition={{ duration: 0.3, ease: [0.23, 1, 0.32, 1] }}
                               >
-                                <div className="px-5 pb-5 pt-1 space-y-2">
+                                <div className="px-3 pb-3 pt-1 space-y-2">
                                   <div className="grid grid-cols-1 gap-2">
                                     {group.triggerWords.map((word, index) => {
                                       const isCopied = copiedWord === word;
                                       return (
                                         <motion.div
                                           key={`${group.loraName}-${index}`}
-                                          className={`w-full p-4 rounded-2xl transition-all duration-300 relative overflow-hidden group/word flex items-center justify-between border ${isCopied
-                                            ? 'bg-green-500/10 border-green-500/30 text-green-300 shadow-[0_0_20px_rgba(34,197,94,0.1)]'
-                                            : 'bg-black/20 border-white/5 hover:border-white/10 text-white/60 hover:text-white/90'
+                                          className={`w-full px-2.5 py-2 rounded-lg transition-all duration-300 relative overflow-hidden group/word flex items-center justify-between border ${isCopied
+                                            ? 'bg-[#34c77b]/[0.12] border-[#34c77b]/30 text-[#4ade80]'
+                                            : 'bg-black/20 border-white/[0.06] hover:border-white/[0.12] text-[#9aa3b2] hover:text-[#e9ebef]'
                                             }`}
                                         >
                                           <div className="flex flex-col items-start min-w-0 select-text cursor-text">
-                                            <span className="text-xs font-mono break-all leading-normal text-left pr-4">
+                                            <span className="font-mono text-[10.5px] break-all leading-normal text-left pr-3">
                                               {word}
                                             </span>
                                           </div>
@@ -456,14 +439,14 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                                             }}
                                             className={`flex-shrink-0 p-2 rounded-xl transition-all duration-300 relative z-10 
                                             ${isCopied
-                                                ? 'bg-green-500/20 scale-110'
+                                                ? 'bg-[#34c77b]/20 scale-110'
                                                 : 'bg-white/5 hover:bg-white/10 opacity-40 group-hover/word:opacity-100 hover:scale-110 active:scale-90'
                                               }`}
                                           >
                                             {isCopied ? (
-                                              <Sparkles className="h-4 w-4 text-green-400" />
+                                              <Sparkles className="h-3.5 w-3.5 text-[#4ade80]" />
                                             ) : (
-                                              <Copy className="h-4 w-4" />
+                                              <Copy className="h-3.5 w-3.5" />
                                             )}
                                           </button>
 
@@ -474,7 +457,7 @@ const TriggerWordSelector: React.FC<TriggerWordSelectorProps> = ({
                                                 initial={{ opacity: 0, scale: 0.8 }}
                                                 animate={{ opacity: 1, scale: 1.5 }}
                                                 exit={{ opacity: 0 }}
-                                                className="absolute inset-0 bg-green-500/10 pointer-events-none blur-xl"
+                                                className="absolute inset-0 bg-[#34c77b]/10 pointer-events-none blur-xl"
                                               />
                                             )}
                                           </AnimatePresence>

--- a/src/components/controls/WidgetValueEditor.tsx
+++ b/src/components/controls/WidgetValueEditor.tsx
@@ -175,7 +175,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
 
   if (isEditing) {
     return (
-      <div className={`p-4 rounded-lg border transition-all duration-200 ${themeOverride?.container || 'bg-blue-50 dark:bg-blue-950/20 border-blue-200 dark:border-blue-800'}`}>
+      <div className={`p-2.5 rounded-lg border transition-all duration-200 ${themeOverride?.container || 'bg-[#3069f0]/[0.06] border-[#3069f0]/25'}`}>
         {/* Value Input Area */}
         <div className="space-y-4">
           {/* Widget Control Components */}
@@ -266,7 +266,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
                         }}
                         // Prevent actual selection since we're using the modal
                         onChange={() => { }}
-                        className="w-full p-3 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-lg text-lg cursor-pointer"
+ className="w-full p-2 bg-[#14171e] border border-white/[0.1] rounded-lg text-[13px] cursor-pointer"
                       >
                         <option value="">
                           {currentValue && currentValue !== '' ? currentValue : t('node.selectFileTyped', { type: (param.type === 'IMAGE' || isImageParam) ? t('node.image') : t('node.video') })}
@@ -283,9 +283,9 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
                       {/* Visual indicator for IMAGE/VIDEO type */}
                       <div className="absolute right-3 top-1/2 transform -translate-y-1/2 pointer-events-none flex items-center space-x-1">
                         {(param.type === 'IMAGE' || isImageParam) ? (
-                          <ImageIcon className="h-4 w-4 text-slate-400" />
+                          <ImageIcon className="h-4 w-4 text-[#565d6b]" />
                         ) : (
-                          <Video className="h-4 w-4 text-slate-400" />
+                          <Video className="h-4 w-4 text-[#565d6b]" />
                         )}
                       </div>
                     </div>
@@ -338,7 +338,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
               e.preventDefault();
               onCancelEditing();
             }}
-            className="text-red-600 border-red-200 hover:bg-red-50 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-950/20"
+ className="text-red-600 border-red-200 hover:bg-red-50 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-950/20"
           >
             <X className="w-4 h-4 mr-1" />
             {t('common.cancel')}
@@ -350,7 +350,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
               e.preventDefault();
               onSaveEditing();
             }}
-            className="bg-green-600 hover:bg-green-700 text-white"
+ className="bg-green-600 hover:bg-green-700 text-white"
           >
             <Check className="w-4 h-4 mr-1" />
             {t('common.save')}
@@ -362,31 +362,31 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
 
   // Normal display mode
   return (
-    <div className={`px-2.5 py-3 rounded-lg ${themeOverride?.container || 'bg-slate-50 dark:bg-slate-800/50'}`}>
-      <div className="flex items-start justify-between mb-2 gap-2">
+    <div className={`px-2.5 py-2 rounded-lg border ${themeOverride?.container || 'bg-white/[0.03] border-white/[0.07]'}`}>
+      <div className="flex items-start justify-between mb-1.5 gap-2">
         <div className="flex flex-wrap items-center gap-2 min-w-0">
-          <span className={`font-medium break-words leading-tight ${themeOverride?.label || 'text-slate-900 dark:text-slate-100'}`}>
+          <span className={`text-[12px] font-semibold break-words leading-tight ${themeOverride?.label || 'text-[#e9ebef]'}`}>
             {param.label || param.name}
           </span>
           {param.required && (
-            <Badge variant="destructive" className="text-[10px] px-1.5 py-0.5 flex-shrink-0">
+            <Badge variant="destructive" className="text-[9px] px-1 py-0 h-[16px] rounded flex-shrink-0">
               {t('node.required')}
             </Badge>
           )}
         </div>
         <Badge
           variant={hasCustomWidgetDefinition ? "secondary" : "outline"}
-          className={`text-[10px] flex-shrink-0 ${hasCustomWidgetDefinition ? 'bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-700' : ''}`}
+ className={`font-mono text-[9px] h-[16px] px-1 rounded flex-shrink-0 ${hasCustomWidgetDefinition ? 'bg-[#3069f0]/[0.12] text-[#7ba3f5] border-[#3069f0]/30' : ''}`}
         >
           {param.type}
           {hasCustomWidgetDefinition && (
-            <span className="ml-1 text-purple-600 dark:text-purple-400">●</span>
+            <span className="ml-1 text-[#7ba3f5]">●</span>
           )}
         </Badge>
       </div>
 
-      <div className="mb-2">
-        <span className={`text-sm ${themeOverride?.secondaryText || 'text-slate-600 dark:text-slate-400'}`}>{t('node.value')}: </span>
+      <div className="mb-1.5">
+        <span className={`text-[10.5px] ${themeOverride?.secondaryText || 'text-[#71798a]'}`}>{t('node.value')}: </span>
         <div className="inline-flex items-center space-x-2">
           {isEditable ? (
             <button
@@ -395,16 +395,16 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
                 e.preventDefault();
                 onStartEditing(nodeId, param.name, currentValue);
               }}
-              className={`text-sm px-2 py-1 rounded inline-flex items-center max-w-[250px] md:max-w-[350px] align-bottom transition-all duration-200 hover:shadow-sm active:scale-95 cursor-pointer border ${isModified
+ className={`text-[11.5px] font-mono px-1.5 py-0.5 rounded inline-flex items-center max-w-[250px] md:max-w-[350px] align-bottom transition-all duration-200 hover:shadow-sm active:scale-95 cursor-pointer border ${isModified
                 ? 'bg-[#10b981] dark:bg-[#10b981] text-white dark:text-white border-[#10b981] dark:border-[#10b981] hover:bg-[#059669] dark:hover:bg-[#059669]'
                 : (themeOverride
                   ? 'bg-transparent border-white/20 text-white/90 hover:bg-white/10'
-                  : 'bg-slate-200 dark:bg-slate-700 border-slate-300 dark:border-slate-600 hover:bg-slate-300 dark:hover:bg-slate-600')
+                  : 'bg-white/[0.06] border-white/[0.1] hover:bg-white/[0.1]')
                 } ${modifiedHighlightClasses}`}
             >
               {param.type === 'BOOLEAN' ? (
                 <div className="flex items-center mr-2">
-                  <div className={`w-3 h-3 rounded-full mr-2 ${Boolean(currentValue) ? 'bg-green-500' : 'bg-slate-400'
+                  <div className={`w-3 h-3 rounded-full mr-2 ${Boolean(currentValue) ? 'bg-green-500' : 'bg-[#565d6b]'
                     }`} />
                   <span className="font-mono">{Boolean(currentValue) ? t('node.true') : t('node.false')}</span>
                 </div>
@@ -428,10 +428,10 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
               <Edit className="w-3 h-3 opacity-60 flex-shrink-0" />
             </button>
           ) : (
-            <div className={`text-sm px-2 py-1 rounded inline-block max-w-[250px] md:max-w-[350px] truncate align-bottom border ${themeOverride ? 'bg-transparent border-white/20 text-white/80' : 'bg-slate-100 dark:bg-slate-800 border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400'}`}>
+            <div className={`text-[11.5px] font-mono px-1.5 py-0.5 rounded inline-block max-w-[250px] md:max-w-[350px] truncate align-bottom border ${themeOverride ? 'bg-transparent border-white/20 text-white/80' : 'bg-white/[0.05] border-white/[0.08] text-[#9aa3b2]'}`}>
               {param.type === 'BOOLEAN' ? (
                 <div className="flex items-center">
-                  <div className={`w-3 h-3 rounded-full mr-2 ${Boolean(currentValue) ? 'bg-green-500' : 'bg-slate-400'
+                  <div className={`w-3 h-3 rounded-full mr-2 ${Boolean(currentValue) ? 'bg-green-500' : 'bg-[#565d6b]'
                     }`} />
                   <span className="font-mono">{Boolean(currentValue) ? t('node.true') : t('node.false')}</span>
                 </div>
@@ -467,7 +467,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
                 onFileUpload(nodeId, param.name);
               }}
               disabled={uploadState.isUploading && uploadState.nodeId === nodeId && uploadState.paramName === param.name}
-              className={`w-full flex items-center justify-center space-x-2 py-2.5 px-4 rounded-lg font-bold transition-all duration-200 active:scale-[0.98] border shadow-sm ${uploadState.isUploading && uploadState.nodeId === nodeId && uploadState.paramName === param.name
+ className={`w-full flex items-center justify-center space-x-2 py-2 px-3 rounded-lg text-[11.5px] font-semibold transition-all duration-200 active:scale-[0.98] border shadow-sm ${uploadState.isUploading && uploadState.nodeId === nodeId && uploadState.paramName === param.name
                 ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 dark:text-zinc-600 border-zinc-200 dark:border-zinc-700 cursor-not-allowed'
                 : 'bg-emerald-50 hover:bg-emerald-100 dark:bg-emerald-900/20 dark:hover:bg-emerald-900/40 text-emerald-600 dark:text-emerald-400 border-emerald-200/50 dark:border-emerald-800/50'
                 }`}
@@ -475,12 +475,12 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
               {uploadState.isUploading && uploadState.nodeId === nodeId && uploadState.paramName === param.name ? (
                 <>
                   <div className="w-4 h-4 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
-                  <span className="text-sm">{t('gallery.uploading')}</span>
+                  <span className="text-[11.5px]">{t('gallery.uploading')}</span>
                 </>
               ) : (
                 <>
                   <Upload className="w-4 h-4" />
-                  <span className="text-sm">
+                  <span className="text-[11.5px]">
                     {t('node.uploadNewFile', { type: isImageFile(currentValue) ? t('node.image') : t('node.video') })}
                   </span>
                 </>
@@ -535,7 +535,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
       {/* Parameter Description */}
       {
         param.description && (
-          <p className="text-xs text-slate-500 dark:text-slate-400 mb-2">
+          <p className="text-[10.5px] text-[#66758a] mb-1.5 leading-snug">
             {param.description}
           </p>
         )
@@ -544,7 +544,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
       {/* Possible Values for COMBO type */}
       {
         param.possibleValues && param.possibleValues.length > 0 && (
-          <div className="text-xs text-slate-500 dark:text-slate-400">
+          <div className="text-[10.5px] text-[#66758a]">
             <span className="font-medium">{t('node.options')}: </span>
             <span>
               {(() => {
@@ -576,7 +576,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
       {/* Validation Info for INT/FLOAT types */}
       {
         param.validation && (
-          <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          <div className="font-mono text-[10px] text-[#565d6b] mt-1">
             {param.validation.min !== undefined && (
               <span>{t('node.min')}: {param.validation.min} </span>
             )}
@@ -594,7 +594,7 @@ export const WidgetValueEditor: React.FC<WidgetValueEditorProps> = ({
       {
         showAlbumModal && createPortal(
           <div
-            className="fixed inset-0 z-[9999] bg-white dark:bg-slate-900 overflow-auto overscroll-contain"
+ className="fixed inset-0 z-[9999] bg-white overflow-auto overscroll-contain"
             style={{
               position: 'fixed',
               top: 0,

--- a/src/components/controls/widgets/BooleanWidget.tsx
+++ b/src/components/controls/widgets/BooleanWidget.tsx
@@ -39,16 +39,16 @@ export const BooleanWidget: React.FC<BooleanWidgetProps> = ({
 
   return (
     <div className="flex items-center justify-center space-x-4 py-4">
-      <span className={`text-lg font-medium transition-colors ${!editingValue ? 'text-slate-900 dark:text-slate-100' : 'text-slate-500 dark:text-slate-400'
+      <span className={`text-[14px] font-medium transition-colors ${!editingValue ? 'text-[#e9ebef]' : 'text-[#71798a]'
         }`}>
         {t('node.false')}
       </span>
       <Switch
         checked={Boolean(editingValue)}
         onCheckedChange={handleValueChange}
-        className="data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-slate-200 dark:data-[state=unchecked]:bg-slate-700"
+ className="data-[state=checked]:bg-[#34c77b] data-[state=unchecked]:bg-white/[0.1]"
       />
-      <span className={`text-lg font-medium transition-colors ${editingValue ? 'text-slate-900 dark:text-slate-100' : 'text-slate-500 dark:text-slate-400'
+      <span className={`text-[14px] font-medium transition-colors ${editingValue ? 'text-[#e9ebef]' : 'text-[#71798a]'
         }`}>
         {t('node.true')}
       </span>

--- a/src/components/controls/widgets/ComboWidget.tsx
+++ b/src/components/controls/widgets/ComboWidget.tsx
@@ -228,7 +228,7 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
       parts.push(
         <mark
           key={index}
-          className="bg-yellow-200 dark:bg-yellow-600/30 text-slate-900 dark:text-slate-100 font-semibold rounded px-0.5"
+ className="bg-yellow-200 dark:bg-yellow-600/30 text-[#e9ebef] font-semibold rounded px-0.5"
         >
           {text.slice(match.start, match.end)}
         </mark>
@@ -257,7 +257,7 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
 
   return (
     <div className="space-y-2">
-      <label className="text-sm text-slate-600 dark:text-slate-400">
+      <label className="text-[12px] text-[#8a919e]">
         {param.label || param.name}
       </label>
       <div className="relative" ref={inputContainerRef}>
@@ -267,7 +267,7 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
             value={String(editingValue || '')}
             readOnly
             placeholder={t('node.clickDropdownToSelect')}
-            className="text-lg pr-16 cursor-pointer"
+ className="text-[14px] pr-16 cursor-pointer"
             onClick={() => setIsDropdownOpen(true)}
           />
           <div className="absolute right-1 top-1/2 -translate-y-1/2 flex">
@@ -275,7 +275,7 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-8 w-8 p-0 hover:bg-slate-200 dark:hover:bg-slate-700"
+ className="h-8 w-8 p-0 hover:bg-white/[0.08]"
                 onClick={clearSelection}
                 title={t('node.clearSelection')}
               >
@@ -285,7 +285,7 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 w-8 p-0 hover:bg-slate-200 dark:hover:bg-slate-700"
+ className="h-8 w-8 p-0 hover:bg-white/[0.08]"
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
               title={t('node.browseOptions')}
             >
@@ -298,7 +298,7 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
         {isDropdownOpen && ReactDOM.createPortal(
           <div
             ref={dropdownRef}
-            className="z-[9999] bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md shadow-lg max-h-60 overflow-hidden"
+ className="z-[9999] bg-[#14171e] border border-white/[0.08] rounded-md shadow-lg max-h-60 overflow-hidden"
             style={{
               position: 'fixed',
               top: `${dropdownPosition.top}px`,
@@ -307,19 +307,19 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
             }}
           >
             {/* Search input */}
-            <div className="p-2 border-b border-slate-200 dark:border-slate-700">
+            <div className="p-2 border-b border-white/[0.08]">
               <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-slate-400" />
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-[#565d6b]" />
                 <input
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder={t('node.searchOptionsPlaceholder')}
-                  className="w-full pl-7 pr-2 py-1 text-sm bg-transparent border-none outline-none text-slate-700 dark:text-slate-300 placeholder-slate-400"
+ className="w-full pl-7 pr-2 py-1 text-[12px] bg-transparent border-none outline-none text-[#c8ccd4] placeholder-[#565d6b]"
                 />
               </div>
               {searchQuery && (
-                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                <div className="mt-1 text-xs text-[#71798a]">
                   {t('node.matchesFound', { count: filteredOptions.length })}
                 </div>
               )}
@@ -332,15 +332,15 @@ export const ComboWidget: React.FC<ComboWidgetProps> = ({
                   <button
                     key={String(option)}
                     onClick={() => handleOptionSelection(option)}
-                    className="w-full px-3 py-2 text-left hover:bg-slate-100 dark:hover:bg-slate-700 border-none outline-none text-sm transition-colors"
+ className="w-full px-3 py-2 text-left hover:bg-white/[0.06] border-none outline-none text-[12px] transition-colors"
                   >
-                    <div className="font-medium text-slate-700 dark:text-slate-300">
+                    <div className="font-medium text-[#c8ccd4]">
                       {highlightMatches(String(option), searchQuery)}
                     </div>
                   </button>
                 ))
               ) : (
-                <div className="px-3 py-2 text-sm text-slate-500 dark:text-slate-400">
+                <div className="px-3 py-2 text-[12px] text-[#71798a]">
                   {searchQuery ? t('node.noOptionsMatch', { query: searchQuery }) : t('node.noOptionsAvailable')}
                 </div>
               )}

--- a/src/components/controls/widgets/CustomDynamicWidget.tsx
+++ b/src/components/controls/widgets/CustomDynamicWidget.tsx
@@ -45,13 +45,13 @@ const BooleanFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldCo
   const { t } = useTranslation();
   return (
     <div className="flex items-center justify-between">
-      <label className="text-sm text-slate-600 dark:text-slate-400">
+      <label className="text-[12px] text-[#8a919e]">
         {fieldConfig.label || fieldName}
       </label>
       <Switch
         checked={Boolean(value)}
         onCheckedChange={onChange}
-        className="data-[state=checked]:bg-green-600"
+ className="data-[state=checked]:bg-[#34c77b]"
       />
     </div>
   );
@@ -68,10 +68,10 @@ const IntFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfig
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <label className="text-sm text-slate-600 dark:text-slate-400">
+        <label className="text-[12px] text-[#8a919e]">
           {fieldConfig.label || fieldName}
         </label>
-        <span className="text-xs text-slate-500 dark:text-slate-400">
+        <span className="text-xs text-[#71798a]">
           {currentValue}
         </span>
       </div>
@@ -80,7 +80,7 @@ const IntFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfig
         <>
           {/* Slider mode - when min/max are defined */}
           <div
-            className="px-2"
+ className="px-2"
             style={{
               touchAction: 'pan-x pinch-zoom',
               WebkitTouchCallout: 'none',
@@ -97,7 +97,7 @@ const IntFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfig
               min={min}
               max={max}
               step={step}
-              className="w-full"
+ className="w-full"
               data-slider="true"
               onTouchStart={(e) => {
                 e.stopPropagation();
@@ -116,7 +116,7 @@ const IntFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfig
             min={min}
             max={max}
             step={step}
-            className="text-center text-lg font-medium"
+ className="text-center text-[14px] font-medium"
           />
         </>
       ) : (
@@ -127,10 +127,10 @@ const IntFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfig
             value={String(currentValue)}
             onChange={(e) => onChange(parseInt(e.target.value) || 0)}
             step={step}
-            className="text-center text-lg font-medium"
+ className="text-center text-[14px] font-medium"
             placeholder={t('node.enterIntegerValue')}
           />
-          <p className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded">
+          <p className="text-xs text-amber-600 dark:text-[#ffa348] bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded">
             {t('node.defineMinMaxForSlider')}
           </p>
         </>
@@ -150,10 +150,10 @@ const FloatFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConf
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <label className="text-sm text-slate-600 dark:text-slate-400">
+        <label className="text-[12px] text-[#8a919e]">
           {fieldConfig.label || fieldName}
         </label>
-        <span className="text-xs text-slate-500 dark:text-slate-400">
+        <span className="text-xs text-[#71798a]">
           {currentValue.toFixed(2)}
         </span>
       </div>
@@ -162,7 +162,7 @@ const FloatFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConf
         <>
           {/* Slider mode - when min/max are defined */}
           <div
-            className="px-2"
+ className="px-2"
             style={{
               touchAction: 'pan-x pinch-zoom',
               WebkitTouchCallout: 'none',
@@ -179,7 +179,7 @@ const FloatFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConf
               min={min}
               max={max}
               step={step}
-              className="w-full"
+ className="w-full"
               data-slider="true"
               onTouchStart={(e) => {
                 e.stopPropagation();
@@ -198,7 +198,7 @@ const FloatFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConf
             min={min}
             max={max}
             step={step}
-            className="text-center text-lg font-medium"
+ className="text-center text-[14px] font-medium"
           />
         </>
       ) : (
@@ -209,10 +209,10 @@ const FloatFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConf
             value={String(currentValue)}
             onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
             step={step}
-            className="text-center text-lg font-medium"
+ className="text-center text-[14px] font-medium"
             placeholder={t('node.enterFloatValue')}
           />
-          <p className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded">
+          <p className="text-xs text-amber-600 dark:text-[#ffa348] bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded">
             {t('node.defineMinMaxForSlider')}
           </p>
         </>
@@ -431,7 +431,7 @@ const LoraFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfi
       parts.push(
         <mark
           key={index}
-          className="bg-yellow-200 dark:bg-yellow-600/30 text-slate-900 dark:text-slate-100 font-semibold rounded px-0.5"
+ className="bg-yellow-200 dark:bg-yellow-600/30 text-[#e9ebef] font-semibold rounded px-0.5"
         >
           {text.slice(match.start, match.end)}
         </mark>
@@ -460,7 +460,7 @@ const LoraFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfi
 
   return (
     <div className="space-y-2">
-      <label className="text-sm text-slate-600 dark:text-slate-400">
+      <label className="text-[12px] text-[#8a919e]">
         {fieldConfig.label || fieldName}
       </label>
       <div className="relative" ref={dropdownRef}>
@@ -470,7 +470,7 @@ const LoraFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfi
             value={value || ''}
             readOnly
             placeholder={isLoading ? t('node.loadingLoras') : t('node.clickToSelectLora')}
-            className="text-sm pr-16 cursor-pointer"
+ className="text-[12px] pr-16 cursor-pointer"
             disabled={isLoading}
             onClick={() => setIsDropdownOpen(true)}
           />
@@ -479,7 +479,7 @@ const LoraFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfi
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-6 w-6 p-0 hover:bg-slate-200 dark:hover:bg-slate-700"
+ className="h-6 w-6 p-0 hover:bg-white/[0.08]"
                 onClick={clearLoraSelection}
                 title={t('node.clearSelection')}
               >
@@ -489,7 +489,7 @@ const LoraFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfi
             <Button
               variant="ghost"
               size="sm"
-              className="h-6 w-6 p-0 hover:bg-slate-200 dark:hover:bg-slate-700"
+ className="h-6 w-6 p-0 hover:bg-white/[0.08]"
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
               disabled={isLoading}
               title={t('node.browseLoras')}
@@ -501,17 +501,17 @@ const LoraFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfi
 
         {/* Dropdown */}
         {isDropdownOpen && (
-          <div className="absolute z-50 w-full mt-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md shadow-lg max-h-60 overflow-hidden">
+          <div className="absolute z-50 w-full mt-1 bg-[#14171e] border border-white/[0.08] rounded-md shadow-lg max-h-60 overflow-hidden">
             {/* Search input */}
-            <div className="p-2 border-b border-slate-200 dark:border-slate-700">
+            <div className="p-2 border-b border-white/[0.08]">
               <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-slate-400" />
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-[#565d6b]" />
                 <input
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder={t('node.searchLorasPlaceholder')}
-                  className="w-full pl-7 pr-2 py-1 text-xs bg-transparent border-none outline-none text-slate-700 dark:text-slate-300 placeholder-slate-400"
+ className="w-full pl-7 pr-2 py-1 text-xs bg-transparent border-none outline-none text-[#c8ccd4] placeholder-[#565d6b]"
                 />
               </div>
             </div>
@@ -523,23 +523,23 @@ const LoraFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldConfi
                   <button
                     key={lora.path}
                     onClick={() => handleLoraSelection(lora.name)}
-                    className="w-full px-3 py-2 text-left hover:bg-slate-100 dark:hover:bg-slate-700 border-none outline-none text-sm"
+ className="w-full px-3 py-2 text-left hover:bg-white/[0.06] border-none outline-none text-[12px]"
                   >
-                    <div className="font-medium text-slate-700 dark:text-slate-300 truncate">
+                    <div className="font-medium text-[#c8ccd4] truncate">
                       {highlightLoraMatches(lora.name, searchQuery)}
                     </div>
                     {lora.subfolder && (
-                      <div className="text-xs text-slate-500 dark:text-slate-400 truncate">
+                      <div className="text-xs text-[#71798a] truncate">
                         {lora.subfolder}
                       </div>
                     )}
-                    <div className="text-xs text-slate-400 dark:text-slate-500">
+                    <div className="text-xs text-[#565d6b]">
                       {lora.size_mb.toFixed(1)} MB
                     </div>
                   </button>
                 ))
               ) : (
-                <div className="px-3 py-2 text-sm text-slate-500 dark:text-slate-400">
+                <div className="px-3 py-2 text-[12px] text-[#71798a]">
                   {searchQuery ? t('node.noLorasMatch', { query: searchQuery }) : t('node.noLorasFound')}
                 </div>
               )}
@@ -555,7 +555,7 @@ const StringFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldCon
   const { t } = useTranslation();
   return (
     <div className="space-y-2">
-      <label className="text-sm text-slate-600 dark:text-slate-400">
+      <label className="text-[12px] text-[#8a919e]">
         {fieldConfig.label || fieldName}
       </label>
       <Input
@@ -563,7 +563,7 @@ const StringFieldRenderer: React.FC<FieldRendererProps> = ({ fieldName, fieldCon
         value={value || ''}
         onChange={(e) => onChange(e.target.value)}
         placeholder={fieldConfig.placeholder || t('node.enterValueFor', { name: fieldName })}
-        className="text-sm"
+ className="text-[12px]"
       />
     </div>
   );
@@ -652,9 +652,9 @@ export const CustomDynamicWidget: React.FC<CustomDynamicWidgetProps> = ({
   };
 
   return (
-    <div className="space-y-4 p-4 border border-slate-200 dark:border-slate-700 rounded-lg bg-slate-50 dark:bg-slate-800/50">
+    <div className="space-y-4 p-4 border border-white/[0.08] rounded-lg bg-white/[0.04]">
       <div className="flex items-center justify-between">
-        <h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
+        <h4 className="text-[12px] font-medium text-[#c8ccd4]">
           {param.name}
         </h4>
         <Badge variant="outline" className="text-xs">
@@ -676,7 +676,7 @@ export const CustomDynamicWidget: React.FC<CustomDynamicWidgetProps> = ({
               onChange={(value) => updateField(fieldName, value)}
             />
             {fieldConfig.description && (
-              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              <p className="text-xs text-[#71798a] mt-1">
                 {fieldConfig.description}
               </p>
             )}

--- a/src/components/controls/widgets/NumberWidget.tsx
+++ b/src/components/controls/widgets/NumberWidget.tsx
@@ -57,7 +57,7 @@ export const NumberWidget: React.FC<NumberWidgetProps> = ({
     <div className="space-y-3">
       {/* Slider */}
       <div 
-        className="px-2"
+ className="px-2"
         style={{ 
           touchAction: 'pan-x pinch-zoom', // Allow horizontal panning for slider
           WebkitTouchCallout: 'none',
@@ -74,7 +74,7 @@ export const NumberWidget: React.FC<NumberWidgetProps> = ({
           min={min}
           max={max}
           step={step}
-          className="w-full"
+ className="w-full"
           data-slider="true"
           onTouchStart={(e) => {
             e.stopPropagation();
@@ -93,7 +93,7 @@ export const NumberWidget: React.FC<NumberWidgetProps> = ({
         min={min}
         max={max}
         step={step}
-        className="text-center text-lg font-medium"
+ className="text-center text-[14px] font-medium"
       />
     </div>
   );

--- a/src/components/controls/widgets/SeedWithControlWidget.tsx
+++ b/src/components/controls/widgets/SeedWithControlWidget.tsx
@@ -31,7 +31,7 @@ export const SeedWithControlWidget: React.FC<SeedWithControlWidgetProps> = ({
       {/* Seed value input */}
       <div className="space-y-3">
         <div className="flex items-center justify-between">
-          <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+          <label className="text-[12px] font-medium text-[#c8ccd4]">
             {t('node.seedValue')}
           </label>
           <Badge variant="outline" className="text-xs">
@@ -52,7 +52,7 @@ export const SeedWithControlWidget: React.FC<SeedWithControlWidgetProps> = ({
       {controlWidget && (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            <label className="text-[12px] font-medium text-[#c8ccd4]">
               {t('node.controlAfterGenerate')}
             </label>
             <Badge variant="outline" className="text-xs">
@@ -83,7 +83,7 @@ export const SeedWithControlWidget: React.FC<SeedWithControlWidgetProps> = ({
               }
 
             }}
-            className="w-full p-3 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+ className="w-full p-3 border border-white/[0.1] rounded-lg bg-[#14171e] text-[#e9ebef] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           >
             <option value="fixed">{t('node.seedModes.fixed')}</option>
             <option value="increment">{t('node.seedModes.increment')}</option>

--- a/src/components/controls/widgets/StringWidget.tsx
+++ b/src/components/controls/widgets/StringWidget.tsx
@@ -114,7 +114,7 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+        <label className="text-[12px] font-medium text-[#c8ccd4]">
           {param.label || param.name}
         </label>
         <div className="flex space-x-2">
@@ -123,7 +123,7 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
             variant="outline"
             size="sm"
             onClick={handleCopy}
-            className="h-8 px-2 text-xs hover:bg-blue-50 dark:hover:bg-blue-950/50"
+ className="h-8 px-2 text-xs hover:bg-blue-50 dark:hover:bg-blue-950/50"
             title={t('node.copyToClipboard')}
           >
             <Copy className="h-3 w-3 mr-1" />
@@ -135,7 +135,7 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
               variant="outline"
               size="sm"
               onClick={handlePaste}
-              className="h-8 px-2 text-xs hover:bg-green-50 dark:hover:bg-green-950/50"
+ className="h-8 px-2 text-xs hover:bg-green-50 dark:hover:bg-green-950/50"
               title={t('node.pasteFromClipboard')}
             >
               <ClipboardPaste className="h-3 w-3 mr-1" />
@@ -147,7 +147,7 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
       <Textarea
         value={String(editingValue)}
         onChange={(e) => handleValueChange(e.target.value)}
-        className="text-lg resize-y"
+ className="text-[14px] resize-y"
         rows={6}
         placeholder={t('node.enterText')}
       />

--- a/src/components/controls/widgets/custom_node_widget/PointEditor.tsx
+++ b/src/components/controls/widgets/custom_node_widget/PointEditor.tsx
@@ -342,18 +342,18 @@ export const PointEditor: React.FC<PointEditorProps> = ({
       {/* Always show the button - matching other widget styles */}
       <div className={`p-3 rounded-lg cursor-pointer transition-all duration-200 ${isModified && modifiedHighlightClasses
           ? modifiedHighlightClasses
-          : 'bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700/50'
+          : 'bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.06] '
         }`}>
         <div
           onClick={() => setIsOpen(true)}
-          className="w-full flex items-center justify-between"
+ className="w-full flex items-center justify-between"
         >
           <div className="flex items-center space-x-2">
-            <span className="font-medium text-slate-900 dark:text-slate-100">
+            <span className="font-medium text-[#e9ebef]">
               Points Editor
             </span>
           </div>
-          <div className="text-sm text-slate-600 dark:text-slate-400">
+          <div className="text-[12px] text-[#8a919e]">
             {points.positive.length} positive, {points.negative.length} negative
           </div>
         </div>
@@ -361,43 +361,43 @@ export const PointEditor: React.FC<PointEditorProps> = ({
 
       {/* Modal - rendered with createPortal to document.body */}
       {isOpen && createPortal(
-        <div className="fixed inset-0 z-[9999] bg-gradient-to-br from-slate-900/40 via-blue-900/20 to-purple-900/40 backdrop-blur-md">
+        <div className="fixed inset-0 z-[9999] bg-gradient-to-br from-black/40 via-blue-900/20 to-purple-900/40 backdrop-blur-md">
           <div className="fixed inset-4 z-[9999] max-h-screen overflow-y-auto">
-            <div className="bg-white/20 dark:bg-slate-800/20 backdrop-blur-xl rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 w-full h-full flex flex-col overflow-hidden">
+            <div className="bg-white/20 dark:bg-[#14171e]/20 backdrop-blur-xl rounded-xl shadow-2xl border border-white/20 dark:border-white/[0.1]/20 w-full h-full flex flex-col overflow-hidden">
 
               {/* Header */}
-              <div className="relative flex items-center justify-between p-6 bg-white/10 dark:bg-slate-700/10 backdrop-blur-sm border-b border-white/10 dark:border-slate-600/10">
-                <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100">
+              <div className="relative flex items-center justify-between p-3 bg-white/[0.04] border-b border-white/[0.08]">
+                <h2 className="text-[15px] font-semibold text-[#e9ebef]">
                   Points Editor - {width}x{height}
                 </h2>
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => setIsOpen(false)}
-                  className="h-8 w-8 p-0 hover:bg-white/20 dark:hover:bg-slate-700/30 text-slate-700 dark:text-slate-200 backdrop-blur-sm border border-white/10 dark:border-slate-600/10 rounded-full"
+ className="h-8 w-8 p-0 hover:bg-white/20 /30 text-[#c8ccd4] dark:text-[#d5d9e0] backdrop-blur-sm border border-white/10 dark:border-white/[0.1]/10 rounded-full"
                 >
                   <X className="h-4 w-4" />
                 </Button>
               </div>
 
               {/* Content */}
-              <div className="flex-1 overflow-y-auto p-6 space-y-6">
+              <div className="flex-1 overflow-y-auto p-4 space-y-6">
                 {/* Background Image Controls */}
                 <div className="space-y-3">
-                  <h3 className="text-lg font-medium text-slate-800 dark:text-slate-100">Background Image</h3>
+                  <h3 className="text-[14px] font-medium text-[#e9ebef]">Background Image</h3>
                   <div className="flex gap-2 flex-wrap">
                     <input
                       type="file"
                       accept="image/*"
                       onChange={handleImageUpload}
-                      className="hidden"
+ className="hidden"
                       id="bg-image-upload"
                     />
                     <Button
                       variant="outline"
                       size="sm"
                       onClick={() => document.getElementById('bg-image-upload')?.click()}
-                      className="bg-white/30 dark:bg-slate-800/30 backdrop-blur border border-slate-200/40 dark:border-slate-700/40 hover:bg-white/50 dark:hover:bg-slate-800/50"
+ className="bg-white/30 dark:bg-[#14171e]/30 backdrop-blur border border-white/[0.08] dark:border-white/[0.08]/40 hover:bg-white/50 dark:hover:bg-[#14171e]/50"
                     >
                       <Upload className="h-4 w-4 mr-2" />
                       Upload from Device
@@ -407,7 +407,7 @@ export const PointEditor: React.FC<PointEditorProps> = ({
                       variant="outline"
                       size="sm"
                       onClick={() => setShowOutputsGallery(true)}
-                      className="bg-white/30 dark:bg-slate-800/30 backdrop-blur border border-slate-200/40 dark:border-slate-700/40 hover:bg-white/50 dark:hover:bg-slate-800/50"
+ className="bg-white/30 dark:bg-[#14171e]/30 backdrop-blur border border-white/[0.08] dark:border-white/[0.08]/40 hover:bg-white/50 dark:hover:bg-[#14171e]/50"
                     >
                       <Image className="h-4 w-4 mr-2" />
                       Select from Gallery
@@ -430,7 +430,7 @@ export const PointEditor: React.FC<PointEditorProps> = ({
                           setPoints({ positive: [], negative: [] });
                           setPointHistory([]);
                         }}
-                        className="bg-red-50/80 dark:bg-red-950/40 backdrop-blur border border-red-200/40 dark:border-red-800/40 hover:bg-red-100/80 dark:hover:bg-red-900/50 text-red-700 dark:text-red-300"
+ className="bg-red-50/80 dark:bg-red-950/40 backdrop-blur border border-red-200/40 dark:border-red-800/40 hover:bg-red-100/80 dark:hover:bg-red-900/50 text-red-700 dark:text-red-300"
                       >
                         <X className="h-4 w-4 mr-2" />
                         Clear Image
@@ -446,8 +446,8 @@ export const PointEditor: React.FC<PointEditorProps> = ({
 
                 {/* Point Mode Selection */}
                 <div className="space-y-3">
-                  <h3 className="text-lg font-medium text-slate-800 dark:text-slate-100">Point Mode</h3>
-                  <div className="bg-white/30 dark:bg-slate-800/30 backdrop-blur rounded-xl border border-slate-200/40 dark:border-slate-700/40 p-4">
+                  <h3 className="text-[14px] font-medium text-[#e9ebef]">Point Mode</h3>
+                  <div className="bg-white/30 dark:bg-[#14171e]/30 backdrop-blur rounded-xl border border-white/[0.08] dark:border-white/[0.08]/40 p-4">
                     <SegmentedControl
                       items={[
                         { value: 'positive', label: 'Positive', color: 'green' },
@@ -461,11 +461,11 @@ export const PointEditor: React.FC<PointEditorProps> = ({
 
                 {/* Canvas */}
                 <div className="space-y-3">
-                  <h3 className="text-lg font-medium text-slate-800 dark:text-slate-100">Canvas</h3>
-                  <div className="bg-white/30 dark:bg-slate-800/30 backdrop-blur rounded-xl border border-slate-200/40 dark:border-slate-700/40 p-4 flex items-center justify-center">
+                  <h3 className="text-[14px] font-medium text-[#e9ebef]">Canvas</h3>
+                  <div className="bg-white/30 dark:bg-[#14171e]/30 backdrop-blur rounded-xl border border-white/[0.08] dark:border-white/[0.08]/40 p-4 flex items-center justify-center">
                     <canvas
                       ref={canvasRef}
-                      className="max-w-full max-h-96 cursor-crosshair block rounded-lg"
+ className="max-w-full max-h-96 cursor-crosshair block rounded-lg"
                       style={{ aspectRatio: `${width}/${height}` }}
                       onClick={handleCanvasClick}
                     />
@@ -480,7 +480,7 @@ export const PointEditor: React.FC<PointEditorProps> = ({
                       size="sm"
                       onClick={handleUndo}
                       disabled={pointHistory.length === 0}
-                      className="bg-white/30 dark:bg-slate-800/30 backdrop-blur border border-slate-200/40 dark:border-slate-700/40 hover:bg-white/50 dark:hover:bg-slate-800/50 disabled:opacity-50"
+ className="bg-white/30 dark:bg-[#14171e]/30 backdrop-blur border border-white/[0.08] dark:border-white/[0.08]/40 hover:bg-white/50 dark:hover:bg-[#14171e]/50 disabled:opacity-50"
                     >
                       <Undo className="h-4 w-4 mr-2" />
                       Undo
@@ -491,7 +491,7 @@ export const PointEditor: React.FC<PointEditorProps> = ({
                       size="sm"
                       onClick={handleClearAll}
                       disabled={points.positive.length === 0 && points.negative.length === 0}
-                      className="bg-orange-50/80 dark:bg-orange-950/40 backdrop-blur border border-orange-200/40 dark:border-orange-800/40 hover:bg-orange-100/80 dark:hover:bg-orange-900/50 text-orange-700 dark:text-orange-300 disabled:opacity-50"
+ className="bg-orange-50/80 dark:bg-orange-950/40 backdrop-blur border border-orange-200/40 dark:border-orange-800/40 hover:bg-orange-100/80 dark:hover:bg-orange-900/50 text-orange-700 dark:text-orange-300 disabled:opacity-50"
                     >
                       <Trash2 className="h-4 w-4 mr-2" />
                       Clear All
@@ -502,22 +502,22 @@ export const PointEditor: React.FC<PointEditorProps> = ({
                     <Button
                       variant="outline"
                       onClick={() => setIsOpen(false)}
-                      className="bg-white/30 dark:bg-slate-800/30 backdrop-blur border border-slate-200/40 dark:border-slate-700/40 hover:bg-white/50 dark:hover:bg-slate-800/50"
+ className="bg-white/30 dark:bg-[#14171e]/30 backdrop-blur border border-white/[0.08] dark:border-white/[0.08]/40 hover:bg-white/50 dark:hover:bg-[#14171e]/50"
                     >
                       Cancel
                     </Button>
 
                     <Button
                       onClick={handleApply}
-                      className="bg-blue-500/80 dark:bg-blue-600/80 backdrop-blur border border-blue-300/40 dark:border-blue-500/40 hover:bg-blue-600/80 dark:hover:bg-blue-500/80 text-white"
+ className="bg-[#3069f0] dark:bg-[#3069f0]/80 backdrop-blur border border-blue-300/40 dark:border-[#3069f0]/40 hover:bg-[#3069f0]/80 dark:hover:bg-[#3f78f5]/80 text-white"
                     >
                       Apply
                     </Button>
                   </div>
 
                   {/* Status */}
-                  <div className="bg-white/20 dark:bg-slate-800/20 backdrop-blur rounded-lg border border-slate-200/30 dark:border-slate-700/30 p-3">
-                    <div className="text-sm text-slate-700 dark:text-slate-300">
+                  <div className="bg-white/20 dark:bg-[#14171e]/20 backdrop-blur rounded-lg border border-white/[0.07] dark:border-white/[0.08]/30 p-3">
+                    <div className="text-[12px] text-[#c8ccd4]">
                       Positive: {points.positive.length} points, Negative: {points.negative.length} points
                     </div>
                   </div>
@@ -531,7 +531,7 @@ export const PointEditor: React.FC<PointEditorProps> = ({
 
       {/* OutputsGallery Modal */}
       {showOutputsGallery && createPortal(
-        <div className="fixed inset-0 z-[9999] bg-white dark:bg-slate-900 overflow-auto overscroll-contain">
+        <div className="fixed inset-0 z-[9999] bg-[#101217] overflow-auto overscroll-contain">
           <OutputsGallery
             isFileSelectionMode={true}
             allowImages={true}

--- a/src/components/etc/BrowserDataBackup.tsx
+++ b/src/components/etc/BrowserDataBackup.tsx
@@ -466,7 +466,7 @@ export const BrowserDataBackup: React.FC = () => {
           touchAction: 'none'
         }}
       >
-        <div className="absolute inset-0 bg-gradient-to-br from-slate-50 via-blue-50/30 to-cyan-50/30 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900" />
+        <div className="absolute inset-0 bg-[#0b0c0f]" />
         <div className="absolute inset-0 bg-black/5 dark:bg-black/10 pointer-events-none" />
 
         <div
@@ -479,26 +479,26 @@ export const BrowserDataBackup: React.FC = () => {
             position: 'absolute'
           }}
         >
-          <header className="sticky top-0 z-50 bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border-b border-white/20 dark:border-slate-600/20 shadow-2xl relative overflow-hidden">
+          <header className="sticky top-0 z-50 bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
             <div className="relative z-10 p-4">
               <div className="flex items-center space-x-4">
-                <Button onClick={() => navigate(-1)} variant="outline" size="sm" className="bg-white/20 dark:bg-slate-700/20 h-10 w-10 p-0 rounded-lg">
+                <Button onClick={() => navigate(-1)} variant="outline" size="sm" className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] h-9 w-9 p-0 rounded-[10px] text-[#c8ccd4]">
                   <ArrowLeft className="h-4 w-4" />
                 </Button>
                 <div>
-                  <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">{t('backup.title')}</h1>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">{t('backup.subtitle')}</p>
+                  <h1 className="text-[15px] font-bold text-[#e9ebef]">{t('backup.title')}</h1>
+                  <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">{t('backup.subtitle')}</p>
                 </div>
               </div>
             </div>
           </header>
-          <div className="container mx-auto px-4 py-8 max-w-2xl">
-            <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="bg-orange-50/80 dark:bg-orange-950/40 backdrop-blur border border-orange-200/40 dark:border-orange-800/40 rounded-2xl p-8 text-center shadow-xl">
-              <div className="bg-orange-600 p-3 rounded-full w-12 h-12 flex items-center justify-center mx-auto mb-4">
+          <div className="container mx-auto px-4 py-5 max-w-2xl">
+            <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="bg-[#ffa348]/[0.06] border border-[#ffa348]/[0.22] rounded-xl p-4 text-center shadow-xl">
+              <div className="bg-[#ffa348]/[0.12] border border-[#ffa348]/30 p-0 rounded-[10px] w-9 h-9 flex items-center justify-center mx-auto mb-4">
                 <Server className="w-6 h-6 text-white" />
               </div>
-              <h1 className="text-2xl font-bold text-orange-900 dark:text-orange-100 mb-2">{t('backup.serverRequired')}</h1>
-              <p className="text-orange-800 dark:text-orange-200 mb-6">{t('backup.connectPrompt')}</p>
+              <h1 className="text-[16px] font-bold text-[#ffd9ae] mb-2">{t('backup.serverRequired')}</h1>
+              <p className="text-[#ffa348] mb-3">{t('backup.connectPrompt')}</p>
               <Button onClick={() => navigate('/settings/server')} className="bg-orange-600 hover:bg-orange-700 text-white">
                 <Settings className="h-4 w-4 mr-2" />
                 {t('backup.configureServer')}
@@ -513,12 +513,12 @@ export const BrowserDataBackup: React.FC = () => {
   // If checking extension, show loading state
   if (isCheckingExtension) {
     return (
-      <div className="pwa-container bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-blue-950 dark:to-indigo-900 flex items-center justify-center h-[100dvh]">
-        <div className="text-center space-y-4">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+      <div className="pwa-container bg-[#0b0c0f] flex items-center justify-center h-[100dvh]">
+        <div className="text-center space-y-2.5">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-white/[0.08] border-t-[#3069f0] mx-auto"></div>
           <div className="space-y-2">
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t('backup.checkingExtension')}</h2>
-            <p className="text-slate-600 dark:text-slate-400">{t('backup.verifyingExtension')}</p>
+            <h2 className="text-[15px] font-semibold text-[#e9ebef]">{t('backup.checkingExtension')}</h2>
+            <p className="text-[#8a919e]">{t('backup.verifyingExtension')}</p>
           </div>
         </div>
       </div>
@@ -542,7 +542,7 @@ export const BrowserDataBackup: React.FC = () => {
           touchAction: 'none'
         }}
       >
-        <div className="absolute inset-0 bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-blue-950 dark:to-indigo-900" />
+        <div className="absolute inset-0 bg-[#0b0c0f]" />
         <div
           className="absolute top-0 left-0 right-0 bottom-0"
           style={{
@@ -553,20 +553,20 @@ export const BrowserDataBackup: React.FC = () => {
             position: 'absolute'
           }}
         >
-          <div className="container mx-auto px-4 py-8 max-w-2xl relative">
+          <div className="container mx-auto px-4 py-5 max-w-2xl relative">
             <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="text-center">
-              <Button onClick={() => navigate(-1)} variant="ghost" className="absolute top-0 left-0 text-slate-600 dark:text-slate-400">
+              <Button onClick={() => navigate(-1)} variant="ghost" className="absolute top-0 left-0 text-[#8a919e]">
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Back
               </Button>
-              <div className="bg-red-50/80 dark:bg-red-950/40 backdrop-blur border border-red-200/40 dark:border-red-800/40 rounded-2xl shadow-xl p-8 mt-12">
-                <div className="bg-red-600 p-3 rounded-full w-12 h-12 flex items-center justify-center mx-auto mb-4">
+              <div className="bg-[#f25555]/[0.08] border border-[#f25555]/25 rounded-xl shadow-xl p-4 mt-12">
+                <div className="bg-[#f25555]/[0.12] border border-[#f25555]/30 p-0 rounded-[10px] w-9 h-9 flex items-center justify-center mx-auto mb-4">
                   <AlertTriangle className="w-6 h-6 text-white" />
                 </div>
-                <h1 className="text-2xl font-bold text-red-900 dark:text-red-100 mb-2">{t('backup.extensionRequired')}</h1>
-                <p className="text-red-800 dark:text-red-200 mb-6">{t('backup.extensionRequiredDesc')}</p>
-                <div className="space-y-3 flex flex-col items-center">
-                  <Button onClick={() => window.open('https://github.com/jaeone94/comfy-mobile-ui', '_blank')} className="bg-red-600 hover:bg-red-700 text-white w-full sm:w-auto">
+                <h1 className="text-[16px] font-bold text-[#f8b3b3] mb-2">{t('backup.extensionRequired')}</h1>
+                <p className="text-[#f87c7c] mb-3">{t('backup.extensionRequiredDesc')}</p>
+                <div className="space-y-2 flex flex-col items-center">
+                  <Button onClick={() => window.open('https://github.com/jaeone94/comfy-mobile-ui', '_blank')} className="bg-[#f25555] hover:bg-[#f36d6d] text-white w-full sm:w-auto">
                     <Download className="h-4 w-4 mr-2" />
                     {t('backup.downloadExtension')}
                   </Button>
@@ -597,7 +597,7 @@ export const BrowserDataBackup: React.FC = () => {
         touchAction: 'none'
       }}
     >
-      <div className="absolute inset-0 bg-gradient-to-br from-slate-50 via-blue-50/30 to-cyan-50/30 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
       <div className="absolute inset-0 bg-black/5 dark:bg-black/10 pointer-events-none" />
 
       <div
@@ -610,42 +610,42 @@ export const BrowserDataBackup: React.FC = () => {
           position: 'absolute'
         }}
       >
-        <header className="sticky top-0 z-50 bg-white/40 dark:bg-slate-800/40 backdrop-blur-xl border-b border-white/20 dark:border-slate-600/20 shadow-2xl relative overflow-hidden">
+        <header className="sticky top-0 z-50 bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
           <div className="relative z-10 p-4">
             <div className="flex items-center space-x-4">
-              <Button onClick={() => navigate(-1)} variant="outline" size="sm" className="bg-white/20 dark:bg-slate-700/20 h-10 w-10 p-0 rounded-lg">
+              <Button onClick={() => navigate(-1)} variant="outline" size="sm" className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] h-9 w-9 p-0 rounded-[10px] text-[#c8ccd4]">
                 <ArrowLeft className="h-4 w-4" />
               </Button>
               <div>
-                <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">{t('backup.title')}</h1>
-                <p className="text-sm text-slate-500 dark:text-slate-400">{t('backup.subtitle')}</p>
+                <h1 className="text-[15px] font-bold text-[#e9ebef]">{t('backup.title')}</h1>
+                <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">{t('backup.subtitle')}</p>
               </div>
             </div>
           </div>
         </header>
 
-        <div className="container mx-auto px-4 py-8 max-w-2xl relative">
-          <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="bg-white/50 dark:bg-slate-800/50 backdrop-blur border border-slate-200/40 dark:border-slate-700/40 rounded-2xl shadow-xl p-6 space-y-6">
+        <div className="container mx-auto px-4 py-5 max-w-2xl relative">
+          <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="border border-white/[0.08] rounded-xl p-3.5 space-y-2" style={{ background: 'rgba(255,255,255,0.025)' }}>
 
             {/* Backup Status */}
-            <div className="space-y-4">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 flex items-center">
+            <div className="space-y-2.5">
+              <h2 className="text-[14px] font-semibold text-[#e9ebef] flex items-center">
                 <HardDrive className="w-5 h-5 mr-2" />
                 {t('backup.status.title')}
               </h2>
 
               {isCheckingBackup ? (
-                <div className="flex items-center space-x-3 p-4 bg-slate-100/80 dark:bg-slate-700/50 rounded-xl">
-                  <div className="animate-spin rounded-full h-5 w-5 border-2 border-slate-400/20 border-t-slate-600"></div>
-                  <span className="text-slate-600 dark:text-slate-400">{t('backup.status.checking')}</span>
+                <div className="flex items-center space-x-3 p-4 bg-white/[0.04] border border-white/[0.07] rounded-[10px]">
+                  <div className="animate-spin rounded-full h-5 w-5 border-2 border-white/[0.1] border-t-[#8a919e]"></div>
+                  <span className="text-[#8a919e]">{t('backup.status.checking')}</span>
                 </div>
               ) : backupInfo.hasBackup ? (
-                <div className="p-4 bg-green-50/80 dark:bg-green-950/40 border border-green-200/40 dark:border-green-800/40 rounded-xl">
-                  <div className="flex items-center space-x-2 text-green-700 dark:text-green-300 mb-2">
+                <div className="p-4 bg-[#34c77b]/[0.08] border border-[#34c77b]/25 rounded-[10px]">
+                  <div className="flex items-center space-x-2 text-[#4ade80] mb-2">
                     <CheckCircle className="h-5 w-5" />
                     <span className="font-semibold">{t('backup.status.available')}</span>
                   </div>
-                  <div className="text-sm text-green-600 dark:text-green-400 space-y-1">
+                  <div className="text-[12px] text-[#4ade80] space-y-1">
                     {backupInfo.createdAt && (
                       <div className="flex items-center space-x-1">
                         <Clock className="h-3 w-3" />
@@ -661,12 +661,12 @@ export const BrowserDataBackup: React.FC = () => {
                   </div>
                 </div>
               ) : (
-                <div className="p-4 bg-orange-50/80 dark:bg-orange-950/40 border border-orange-200/40 dark:border-orange-800/40 rounded-xl">
-                  <div className="flex items-center space-x-2 text-orange-700 dark:text-orange-300">
+                <div className="p-4 bg-[#ffa348]/[0.06] border border-[#ffa348]/[0.22] rounded-[10px]">
+                  <div className="flex items-center space-x-2 text-[#ffa348]">
                     <AlertTriangle className="h-5 w-5" />
                     <span className="font-semibold">{t('backup.status.notFound')}</span>
                   </div>
-                  <p className="text-sm text-orange-600 dark:text-orange-400 mt-1">{t('backup.status.createFirst')}</p>
+                  <p className="text-[12px] text-[#ffa348] mt-1">{t('backup.status.createFirst')}</p>
                 </div>
               )}
             </div>
@@ -674,30 +674,30 @@ export const BrowserDataBackup: React.FC = () => {
             {/* Error Display */}
             <AnimatePresence>
               {error && (
-                <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }} className="p-4 bg-red-50/80 dark:bg-red-950/40 border border-red-200/40 dark:border-red-800/40 rounded-xl">
+                <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }} className="p-4 bg-[#f25555]/[0.08] border border-[#f25555]/25 rounded-[10px]">
                   <div className="flex items-center space-x-2 text-red-700 dark:text-red-300">
                     <AlertTriangle className="h-4 w-4" />
-                    <span className="text-sm font-medium">Error</span>
+                    <span className="text-[12px] font-medium">Error</span>
                   </div>
-                  <p className="text-sm text-red-600 dark:text-red-400 mt-1">{error}</p>
-                  <Button variant="ghost" size="sm" className="mt-2 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300" onClick={() => setError('')}>Dismiss</Button>
+                  <p className="text-[12px] text-[#f87c7c] mt-1">{error}</p>
+                  <Button variant="ghost" size="sm" className="mt-2 text-red-600 hover:text-red-700 dark:text-[#f87c7c] dark:hover:text-red-300" onClick={() => setError('')}>Dismiss</Button>
                 </motion.div>
               )}
             </AnimatePresence>
 
             {/* Action Buttons */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Button onClick={showBackupConfirmation} disabled={isLoading} className="h-14 text-base font-medium rounded-xl bg-transparent border-2 border-blue-300 dark:border-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/50 text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 transition-all shadow-sm hover:shadow-md active:scale-95">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+              <Button onClick={showBackupConfirmation} disabled={isLoading} className="h-[42px] text-[13px] font-semibold rounded-[10px] bg-[#3069f0] hover:bg-[#3f78f5] text-white border-none transition-all shadow-[0_2px_12px_rgba(48,105,240,0.3)] active:scale-95 disabled:opacity-50">
                 {isLoading ? (
-                  <div className="flex items-center"><div className="animate-spin rounded-full h-4 w-4 border-2 border-blue-600/20 border-t-blue-600 mr-2"></div>{t('backup.action.creating')}</div>
+                  <div className="flex items-center"><div className="animate-spin rounded-full h-4 w-4 border-2 border-[#3069f0]/20 border-t-[#3069f0] mr-2"></div>{t('backup.action.creating')}</div>
                 ) : (
                   <><Download className="h-4 w-4 mr-2" />{t('backup.action.create')}</>
                 )}
               </Button>
 
-              <Button onClick={showRestoreConfirmation} disabled={isLoading || !backupInfo.hasBackup} className="h-14 text-base font-medium rounded-xl bg-transparent border-2 border-green-300 dark:border-green-600 hover:bg-green-50 dark:hover:bg-green-950/50 text-green-700 dark:text-green-300 hover:text-green-800 dark:hover:text-green-200 disabled:border-slate-300 disabled:text-slate-400 transition-all shadow-sm hover:shadow-md active:scale-95">
+              <Button onClick={showRestoreConfirmation} disabled={isLoading || !backupInfo.hasBackup} className="h-[42px] text-[13px] font-semibold rounded-[10px] border bg-[#34c77b]/[0.12] border-[#34c77b]/30 text-[#4ade80] hover:bg-[#34c77b]/[0.2] disabled:opacity-40 transition-all active:scale-95">
                 {isLoading ? (
-                  <div className="flex items-center"><div className="animate-spin rounded-full h-4 w-4 border-2 border-green-600/20 border-t-green-600 mr-2"></div>{t('backup.action.restoring')}</div>
+                  <div className="flex items-center"><div className="animate-spin rounded-full h-4 w-4 border-2 border-[#34c77b]/20 border-t-[#34c77b] mr-2"></div>{t('backup.action.restoring')}</div>
                 ) : (
                   <><Upload className="h-4 w-4 mr-2" />{t('backup.action.restore')}</>
                 )}
@@ -705,68 +705,68 @@ export const BrowserDataBackup: React.FC = () => {
             </div>
 
             {/* Information & Options */}
-            <div className="p-5 bg-slate-100/80 dark:bg-slate-700/50 rounded-2xl border border-slate-200/50 dark:border-slate-600/30">
-              <h3 className="font-semibold text-slate-900 dark:text-slate-100 flex items-center mb-3">
-                <Shield className="w-4 h-4 mr-2 text-blue-500" />
+            <div className="p-5 bg-white/[0.04] border border-white/[0.07] rounded-[10px] border border-slate-200/50 dark:border-white/[0.1]/30">
+              <h3 className="font-semibold text-[#e9ebef] flex items-center mb-3">
+                <Shield className="w-4 h-4 mr-2 text-[#5b8af5]" />
                 {t('backup.info.title')}
               </h3>
-              <ul className="text-sm text-slate-600 dark:text-slate-400 space-y-3">
+              <ul className="text-[12px] text-[#8a919e] space-y-2">
                 <li className="flex items-center justify-between group">
                   <div className="flex items-start">
-                    <span className="text-blue-500 mr-2 mt-0.5">•</span>
+                    <span className="text-[#5b8af5] mr-2 mt-0.5">•</span>
                     <span>{t('backup.info.workflows')}</span>
                   </div>
-                  <Badge variant="secondary" className="bg-slate-200 dark:bg-slate-700 text-[10px] py-0 h-4 opacity-60">CORE</Badge>
+                  <Badge variant="secondary" className="bg-white/[0.08] font-mono text-[9px] py-0 h-4 opacity-60">CORE</Badge>
                 </li>
                 <li className="flex items-center justify-between">
                   <div className="flex items-start">
-                    <span className="text-blue-500 mr-2 mt-0.5">•</span>
+                    <span className="text-[#5b8af5] mr-2 mt-0.5">•</span>
                     <span>{t('backup.info.folders')}</span>
                   </div>
-                  <Badge variant="secondary" className="bg-slate-200 dark:bg-slate-700 text-[10px] py-0 h-4 opacity-60">CORE</Badge>
+                  <Badge variant="secondary" className="bg-white/[0.08] font-mono text-[9px] py-0 h-4 opacity-60">CORE</Badge>
                 </li>
                 <li className="flex items-center justify-between">
                   <div className="flex items-start">
-                    <span className="text-blue-500 mr-2 mt-0.5">•</span>
+                    <span className="text-[#5b8af5] mr-2 mt-0.5">•</span>
                     <span>{t('backup.info.storage')}</span>
                   </div>
-                  <Badge variant="secondary" className="bg-slate-200 dark:bg-slate-700 text-[10px] py-0 h-4 opacity-60">CORE</Badge>
+                  <Badge variant="secondary" className="bg-white/[0.08] font-mono text-[9px] py-0 h-4 opacity-60">CORE</Badge>
                 </li>
 
                 <li className="flex items-center justify-between">
                   <div className="flex items-start">
-                    <span className="text-blue-500 mr-2 mt-0.5">•</span>
+                    <span className="text-[#5b8af5] mr-2 mt-0.5">•</span>
                     <span>{t('backup.info.settings')}</span>
                   </div>
-                  <Badge variant="secondary" className="bg-slate-200 dark:bg-slate-700 text-[10px] py-0 h-4 opacity-60">CORE</Badge>
+                  <Badge variant="secondary" className="bg-white/[0.08] font-mono text-[9px] py-0 h-4 opacity-60">CORE</Badge>
                 </li>
 
                 {includeApiKeys && (
                   <motion.li
                     initial={{ opacity: 0, x: -10 }}
                     animate={{ opacity: 1, x: 0 }}
-                    className="flex items-center justify-between font-medium text-blue-600 dark:text-blue-400"
+                    className="flex items-center justify-between font-medium text-blue-600 dark:text-[#5b8af5]"
                   >
                     <div className="flex items-start">
-                      <span className="text-blue-500 mr-2 mt-0.5">•</span>
+                      <span className="text-[#5b8af5] mr-2 mt-0.5">•</span>
                       <span>{t('backup.info.apiKeys')}</span>
                     </div>
-                    <Badge variant="outline" className="border-amber-500 text-amber-500 bg-amber-500/10 text-[10px] py-0 h-4">WARNING</Badge>
+                    <Badge variant="outline" className="border-[#ffa348]/40 text-[#ffa348] bg-[#ffa348]/10 font-mono text-[10px] py-0 h-4">WARNING</Badge>
                   </motion.li>
                 )}
               </ul>
 
               <Separator className="my-4 bg-slate-200 dark:bg-slate-600" />
 
-              <div className="space-y-4">
+              <div className="space-y-2.5">
 
-                <div className="flex items-center justify-between p-2 rounded-lg hover:bg-slate-200/50 dark:hover:bg-slate-800/30 transition-colors">
+                <div className="flex items-center justify-between p-2 rounded-lg hover:bg-white/[0.04] transition-colors">
                   <div className="flex-1 pr-4">
-                    <div className="flex items-center text-sm font-semibold text-slate-800 dark:text-slate-200">
-                      <HardDrive className="w-4 h-4 mr-2 text-blue-500" />
+                    <div className="flex items-center text-[12px] font-semibold text-[#d5d9e0]">
+                      <HardDrive className="w-4 h-4 mr-2 text-[#5b8af5]" />
                       {t('backup.options.includeApiKeys')}
                     </div>
-                    <p className="text-xs text-slate-500 dark:text-slate-500 mt-0.5">{t('backup.options.includeApiKeysDesc')}</p>
+                    <p className="text-xs text-[#71798a] dark:text-[#71798a] mt-0.5">{t('backup.options.includeApiKeysDesc')}</p>
                   </div>
                   <Switch id="include-apikeys" checked={includeApiKeys} onCheckedChange={setIncludeApiKeys} />
                 </div>
@@ -774,11 +774,11 @@ export const BrowserDataBackup: React.FC = () => {
                 {includeApiKeys && (
                   <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} className="flex items-start gap-2 p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200/50 dark:border-amber-800/30 rounded-xl">
                     <ShieldAlert className="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" />
-                    <p className="text-[11px] leading-relaxed text-amber-700 dark:text-amber-400 font-medium">{t('backup.options.securityWarning')}</p>
+                    <p className="text-[11px] leading-relaxed text-amber-700 dark:text-[#ffa348] font-medium">{t('backup.options.securityWarning')}</p>
                   </motion.div>
                 )}
               </div>
-              <p className="text-xs text-slate-500 dark:text-slate-500 mt-4 italic">{t('backup.info.note')}</p>
+              <p className="text-xs text-[#71798a] dark:text-[#71798a] mt-4 italic">{t('backup.info.note')}</p>
             </div>
           </motion.div>
         </div>
@@ -787,28 +787,28 @@ export const BrowserDataBackup: React.FC = () => {
       {/* Confirmation Dialog */}
       {confirmDialog.isOpen && (
         <div className="fixed inset-0 pwa-modal z-[65] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-          <div className="relative max-w-md w-full bg-white/20 dark:bg-slate-800/20 backdrop-blur-xl rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 flex flex-col overflow-hidden">
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-slate-900/10 pointer-events-none" />
-            <div className="relative flex items-center justify-between p-4 border-b border-white/10 dark:border-slate-600/10 flex-shrink-0">
+          <div className="relative max-w-md w-full bg-white/20 dark:bg-[#14171e]/20 backdrop-blur-xl rounded-xl shadow-2xl border border-white/20 dark:border-white/[0.1]/20 flex flex-col overflow-hidden">
+            <div className="absolute inset-0 bg-transparent pointer-events-none" />
+            <div className="relative flex items-center justify-between p-4 border-b border-white/10 dark:border-white/[0.1]/10 flex-shrink-0">
               <div className="flex items-center space-x-2">
-                <div className={`w-6 h-6 rounded-full flex items-center justify-center border ${confirmDialog.type === 'backup' ? 'bg-blue-500/20 border-blue-400/30' : 'bg-orange-500/20 border-orange-400/30'}`}>
-                  {confirmDialog.type === 'backup' ? <Download className="w-4 h-4 text-blue-300" /> : <AlertTriangle className="w-4 h-4 text-orange-300" />}
+                <div className={`w-6 h-6 rounded-full flex items-center justify-center border ${confirmDialog.type === 'backup' ? 'bg-[#3069f0]/20 border-[#3069f0]/30' : 'bg-orange-500/20 border-orange-400/30'}`}>
+                  {confirmDialog.type === 'backup' ? <Download className="w-4 h-4 text-[#7ba3f5]" /> : <AlertTriangle className="w-4 h-4 text-orange-300" />}
                 </div>
-                <h3 className="text-lg font-semibold text-white">{confirmDialog.title}</h3>
+                <h3 className="text-[14px] font-semibold text-white">{confirmDialog.title}</h3>
               </div>
             </div>
             <div className="relative p-4">
               <p className="text-white/90 mb-4">{confirmDialog.message}</p>
               {confirmDialog.type === 'restore' && (
                 <div className="p-3 bg-orange-500/10 border border-orange-400/20 rounded-lg mb-4">
-                  <p className="text-orange-200 text-sm font-medium">⚠️ {t('backup.dialog.warning')}</p>
-                  <p className="text-orange-300/90 text-sm mt-1">{t('backup.dialog.warningMessage')}</p>
+                  <p className="text-orange-200 text-[12px] font-medium">⚠️ {t('backup.dialog.warning')}</p>
+                  <p className="text-orange-300/90 text-[12px] mt-1">{t('backup.dialog.warningMessage')}</p>
                 </div>
               )}
             </div>
-            <div className="relative flex justify-end gap-2 p-4 border-t border-white/10 dark:border-slate-600/10 flex-shrink-0">
+            <div className="relative flex justify-end gap-2 p-4 border-t border-white/10 dark:border-white/[0.1]/10 flex-shrink-0">
               <Button onClick={closeConfirmDialog} variant="outline" className="bg-white/10 backdrop-blur-sm text-white border-white/20 hover:bg-white/20 transition-all duration-300">{t('backup.dialog.cancel')}</Button>
-              <Button onClick={confirmDialog.onConfirm} className={`backdrop-blur-sm text-white transition-all duration-300 ${confirmDialog.type === 'backup' ? 'bg-blue-500/80 hover:bg-blue-500/90 border border-blue-400/30' : 'bg-orange-500/80 hover:bg-orange-500/90 border border-orange-400/30'}`}>{confirmDialog.confirmText}</Button>
+              <Button onClick={confirmDialog.onConfirm} className={`backdrop-blur-sm text-white transition-all duration-300 ${confirmDialog.type === 'backup' ? 'bg-[#3069f0]/80 hover:bg-[#3069f0]/90 border border-[#3069f0]/30' : 'bg-orange-500/80 hover:bg-orange-500/90 border border-orange-400/30'}`}>{confirmDialog.confirmText}</Button>
             </div>
           </div>
         </div>

--- a/src/components/execution/ErrorViewer.tsx
+++ b/src/components/execution/ErrorViewer.tsx
@@ -339,7 +339,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
   
   return (
     <div 
-      className="fixed inset-0 flex items-center justify-center z-[9999] p-4 bg-black/30 backdrop-blur-sm pwa-modal"
+      className="fixed inset-0 flex items-center justify-center z-[9999] p-4 bg-black/60 backdrop-blur-sm pwa-modal"
       onClick={handleBackdropClick}
       style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
     >
@@ -353,7 +353,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
           exit={{ x: 300, opacity: 0 }}
           transition={{ duration: 0.3, ease: "easeInOut" }}
           onClick={(e) => e.stopPropagation()}
-          className="w-full max-w-2xl max-h-[90vh] overflow-y-auto"
+          className="w-full max-w-lg max-h-[82vh] overflow-y-auto"
           style={{
             touchAction: 'pan-y pinch-zoom',
             overscrollBehaviorX: 'none'
@@ -366,7 +366,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
           }}
         >
           <div className={cn(
-            'bg-white/10 backdrop-blur-md border border-white/20 rounded-xl shadow-2xl overflow-hidden',
+            'bg-[#101217] border border-white/10 rounded-xl shadow-2xl overflow-hidden',
             className
           )}
           style={{
@@ -380,7 +380,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
             e.stopPropagation();
           }}>
             {/* Technical Details Header */}
-            <div className="p-6 pb-3">
+            <div className="p-4 pb-2.5">
               <div className="flex items-start justify-between">
                 <div className="flex items-start gap-3">
                   <Button 
@@ -392,8 +392,8 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
                     <ArrowLeft className="h-4 w-4" />
                   </Button>
                   <div>
-                    <h2 className="text-lg font-semibold text-white">Raw Details</h2>
-                    <p className="mt-1 text-sm text-white/70">
+                    <h2 className="text-[14px] font-bold text-[#e9ebef]">Raw Details</h2>
+                    <p className="mt-0.5 text-[11.5px] leading-relaxed text-[#8a919e]">
                       Node: {technicalDetailsError.nodeTitle || technicalDetailsError.nodeId}
                       {technicalDetailsError.nodeType && (
                         <span className="ml-2 text-xs">({technicalDetailsError.nodeType})</span>
@@ -442,7 +442,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
                   </Button>
                 </div>
                 <div 
-                  className="p-3 bg-black/20 backdrop-blur-sm rounded-md max-h-96 overflow-auto"
+                  className="p-2.5 bg-[#08090c] border border-white/[0.06] rounded-lg max-h-80 overflow-auto"
                   style={{
                     touchAction: 'pan-y pinch-zoom',
                     overscrollBehaviorX: 'none'
@@ -483,7 +483,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
           exit={{ x: -300, opacity: 0 }}
           transition={{ duration: 0.3, ease: "easeInOut" }}
           onClick={(e) => e.stopPropagation()}
-          className="w-full max-w-2xl max-h-[90vh]"
+          className="w-full max-w-lg max-h-[82vh]"
           style={{
             touchAction: 'pan-y pinch-zoom',
             overscrollBehaviorX: 'none'
@@ -504,14 +504,14 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
           }}
         >
           <div className={cn(
-            'bg-white/10 backdrop-blur-md border border-white/20 rounded-xl shadow-2xl',
+            'bg-[#101217] border border-white/10 rounded-xl shadow-2xl',
             processedErrors.length === 1 ? 'overflow-y-auto' : 'overflow-hidden',
             className
           )}
           style={{
             touchAction: 'pan-y pinch-zoom',
             overscrollBehaviorX: 'none',
-            maxHeight: '90vh'
+            maxHeight: '82vh'
           } as React.CSSProperties}
           onTouchStart={(e) => {
             e.stopPropagation();
@@ -529,7 +529,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
           }}>
             {/* Modal Header */}
             <div 
-              className="p-6 pb-3"
+              className="p-4 pb-2.5"
               style={{
                 touchAction: 'pan-y pinch-zoom',
                 overscrollBehaviorX: 'none'
@@ -543,11 +543,11 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-start gap-3">
-                  <AlertCircle className={cn('h-5 w-5 mt-0.5', criticalErrors.length > 0 ? 'text-red-400' : 'text-yellow-400')} />
+                  <AlertCircle className={cn('h-5 w-5 mt-0.5', criticalErrors.length > 0 ? 'text-[#f87c7c]' : 'text-[#ffa348]')} />
                   <div>
-                    <h2 className="text-lg font-semibold text-white">Workflow Execution Failed</h2>
-                    <p className="mt-1 text-sm text-white/70">
-                      {workflowName && <span className="font-medium text-white/80">{workflowName}: </span>}
+                    <h2 className="text-[14px] font-bold text-[#e9ebef]">Workflow Execution Failed</h2>
+                    <p className="mt-0.5 text-[11.5px] leading-relaxed text-[#8a919e]">
+                      {workflowName && <span className="font-medium text-[#c8ccd4]">{workflowName}: </span>}
                       {processedErrors.length} {processedErrors.length === 1 ? 'error' : 'errors'} occurred during execution
                       {promptId && (
                         <span className="text-xs text-white/50 ml-2">
@@ -636,7 +636,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
                       <Button
                         size="sm"
                         onClick={() => handleFixNode(nodeError.nodeId)}
-                        className="bg-white/10 hover:bg-white/20 backdrop-blur-sm border border-red-400/50 text-red-400 hover:text-red-300 hover:border-red-300/60 shadow-lg hover:shadow-xl transition-all duration-200"
+                        className="bg-[#f25555]/[0.1] hover:bg-[#f25555]/[0.18] border border-[#f25555]/30 text-[#f87c7c] transition-all duration-200"
                       >
                         <Wrench className="h-3 w-3 mr-1" />
                         Fix Node
@@ -645,14 +645,14 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
                   </div>
 
                   {/* Error Message */}
-                  <div className="p-2 bg-black/20 backdrop-blur-sm rounded relative overflow-hidden">
+                  <div className="p-2 bg-[#08090c] border border-white/[0.06] rounded-lg relative overflow-hidden">
                     <div className="flex items-start justify-between">
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-red-400 mb-1">
+                        <p className="text-[11.5px] font-semibold text-[#f87c7c] mb-1">
                           {nodeError.error?.type || 'Error'}
                         </p>
                         <div 
-                          className="text-xs text-white/70 max-h-10 overflow-y-auto pr-8" 
+                          className="font-mono text-[10.5px] text-[#9aa3b2] max-h-10 overflow-y-auto pr-8" 
                           style={{ wordBreak: 'break-all', overflowWrap: 'anywhere' }}
                         >
                           {formatErrorMessage(nodeError)}
@@ -687,11 +687,11 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
                   {/* Suggestions */}
                   {suggestions.length > 0 && (
                     <div className="space-y-1 mt-3">
-                      <p className="text-xs font-medium flex items-center gap-1 text-white">
-                        <Info className="h-3 w-3 text-blue-400" />
+                      <p className="text-[10.5px] font-medium flex items-center gap-1 text-[#c8ccd4]">
+                        <Info className="h-3 w-3 text-[#5b8af5]" />
                         Suggested Solutions:
                       </p>
-                      <ul className="text-xs text-white/70 space-y-0.5 ml-4">
+                      <ul className="text-[10.5px] text-[#8a919e] space-y-0.5 ml-4">
                         {suggestions.map((suggestion, i) => (
                           <li key={i} className="list-disc list-outside">
                             {suggestion}
@@ -769,7 +769,7 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
                         <Button
                           size="sm"
                           onClick={() => handleFixNode(nodeError.nodeId)}
-                          className="bg-white/10 hover:bg-white/20 backdrop-blur-sm border border-red-400/50 text-red-400 hover:text-red-300 hover:border-red-300/60 shadow-lg hover:shadow-xl transition-all duration-200"
+                          className="bg-[#f25555]/[0.1] hover:bg-[#f25555]/[0.18] border border-[#f25555]/30 text-[#f87c7c] transition-all duration-200"
                         >
                           <Wrench className="h-3 w-3 mr-1" />
                           Fix Node
@@ -778,14 +778,14 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
                     </div>
 
                     {/* Error Message */}
-                    <div className="p-2 bg-black/20 backdrop-blur-sm rounded relative overflow-hidden">
+                    <div className="p-2 bg-[#08090c] border border-white/[0.06] rounded-lg relative overflow-hidden">
                       <div className="flex items-start justify-between">
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-red-400 mb-1">
+                          <p className="text-[11.5px] font-semibold text-[#f87c7c] mb-1">
                             {nodeError.error?.type || 'Error'}
                           </p>
                           <div 
-                            className="text-xs text-white/70 max-h-10 overflow-y-auto pr-8" 
+                            className="font-mono text-[10.5px] text-[#9aa3b2] max-h-10 overflow-y-auto pr-8" 
                             style={{ wordBreak: 'break-all', overflowWrap: 'anywhere' }}
                           >
                             {formatErrorMessage(nodeError)}
@@ -831,11 +831,11 @@ export const ExecutionErrorDisplay: React.FC<ExecutionErrorDisplayProps> = ({
               
               return suggestions.length > 0 && (
                 <div className="space-y-1 mt-3">
-                  <p className="text-xs font-medium flex items-center gap-1 text-white">
-                    <Info className="h-3 w-3 text-blue-400" />
+                  <p className="text-[10.5px] font-medium flex items-center gap-1 text-[#c8ccd4]">
+                    <Info className="h-3 w-3 text-[#5b8af5]" />
                     Suggested Solutions:
                   </p>
-                  <ul className="text-xs text-white/70 space-y-0.5 ml-4">
+                  <ul className="text-[10.5px] text-[#8a919e] space-y-0.5 ml-4">
                     {suggestions.map((suggestion, i) => (
                       <li key={i} className="list-disc list-outside">
                         {suggestion}

--- a/src/components/execution/ExecutionProgressBar.tsx
+++ b/src/components/execution/ExecutionProgressBar.tsx
@@ -286,54 +286,32 @@ export const WorkflowHeaderProgressBar: React.FC = () => {
   }
 
   return (
-    <div className="bg-emerald-500/10 dark:bg-emerald-500/10 backdrop-blur-xl rounded-xl p-3 shadow-2xl border border-emerald-500/30 dark:border-emerald-500/20 relative overflow-hidden">
-      {/* Subtle Green Glow Overlay */}
-      <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/10 via-transparent to-black/20 pointer-events-none" />
-      <div className="flex items-center justify-between mb-2 relative z-10">
-        <div className="flex items-center space-x-2">
-          <div className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse shadow-[0_0_8px_rgba(52,211,153,0.8)]" />
-          <span className="text-sm font-bold text-white dark:text-emerald-50 tracking-tight">
-            {t('execution.title')}
+    <div className="relative">
+      {/* Compact mono status line */}
+      <div className="flex items-center justify-between gap-2 px-3 pb-[5px] font-mono text-[9px] font-medium tracking-[0.12em] uppercase">
+        <span className="flex items-center gap-1.5 min-w-0">
+          <span className="w-1.5 h-1.5 rounded-full bg-[#4ade80] animate-pulse shrink-0" />
+          <span className="text-[#7ba3f5] truncate">
+            {executingNode?.type || t('execution.starting')}
           </span>
-        </div>
-        <div className="flex items-center space-x-2 text-[10px] font-medium text-white/70 dark:text-emerald-50/70">
-          {state.currentPromptId && (
-            <span>{t('execution.id', { id: state.currentPromptId.substring(0, 8) })}</span>
-          )}
           {state.executingNodeId && (
-            <span className="px-1.5 py-0.5 rounded bg-emerald-500/20 border border-emerald-500/30 text-white dark:text-emerald-50">{t('execution.node', { nodeId: state.executingNodeId })}</span>
+            <span className="text-[#565d6b] shrink-0">#{state.executingNodeId}</span>
           )}
-        </div>
+        </span>
+        <span className="text-[#8a919e] shrink-0">
+          {state.nodeExecutionProgress ? `${Math.round(state.nodeExecutionProgress.progress)}%` : '0%'}
+        </span>
       </div>
 
-      {/* Overall Progress */}
-      <div className="space-y-1.5 relative z-10">
-        <div className="relative h-2 w-full overflow-hidden rounded-full bg-black/40 border border-emerald-500/20">
-          <motion.div
-            initial={{ width: 0 }}
-            animate={{ width: `${state.nodeExecutionProgress?.progress || 0}%` }}
-            transition={{ duration: 0.5, ease: "easeOut" }}
-            className="h-full bg-gradient-to-r from-emerald-500 to-emerald-400 shadow-[0_0_12px_rgba(16,185,129,0.4)]"
-          />
-        </div>
-        <div className="flex justify-between text-[10px] font-bold uppercase tracking-wider text-white">
-          <span className="flex items-center gap-1">
-            <span className="text-white">
-              {state.nodeExecutionProgress ? `${Math.round(state.nodeExecutionProgress.progress)}%` : '0%'}
-            </span>
-            <span className="text-white/80">
-              {state.nodeExecutionProgress ? t('execution.node', { nodeId: '' }).trim() : t('execution.starting')}
-              {executingNode?.type && (
-                <span className="ml-1 text-emerald-300 font-extrabold">
-                  {executingNode.type}
-                </span>
-              )}
-            </span>
-          </span>
-          <span className="animate-pulse text-white">
-            {t('execution.running')}
-          </span>
-        </div>
+      {/* 3px progress bar attached to the header bottom */}
+      <div className="h-[3px] w-full bg-white/[0.05] relative overflow-hidden">
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width: `${state.nodeExecutionProgress?.progress || 0}%` }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="h-full"
+          style={{ background: 'linear-gradient(90deg, #3069f0, #5b8af5)', boxShadow: '0 0 8px rgba(48,105,240,0.6)' }}
+        />
       </div>
     </div>
   );

--- a/src/components/history/PromptHistory.tsx
+++ b/src/components/history/PromptHistory.tsx
@@ -98,11 +98,11 @@ const LazyThumbnail: React.FC<LazyThumbnailProps> = ({ file, onFileClick, imageL
 
   const getFileIcon = (filename: string) => {
     if (isImageFile(filename)) {
-      return <ImageIcon className="h-4 w-4 text-blue-400" />;
+      return <ImageIcon className="h-4 w-4 text-[#7ba3f5]" />;
     } else if (isVideoFile(filename)) {
       return <Video className="h-4 w-4 text-purple-400" />;
     } else {
-      return <FileText className="h-4 w-4 text-slate-400" />;
+      return <FileText className="h-4 w-4 text-[#565d6b]" />;
     }
   };
 
@@ -175,18 +175,18 @@ const LazyThumbnail: React.FC<LazyThumbnailProps> = ({ file, onFileClick, imageL
 
   return (
     <div
-      className="flex items-center space-x-3 p-3 bg-white/20 dark:bg-slate-800/20 backdrop-blur-sm border border-white/20 dark:border-slate-700/20 rounded-xl hover:bg-white/30 dark:hover:bg-slate-700/30 cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-lg"
+      className="flex items-center gap-2 p-2 bg-white/[0.03] border border-white/[0.07] rounded-[10px] hover:bg-white/[0.06] cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-lg"
       onClick={() => onFileClick(file)}
     >
       <div
         ref={thumbnailRef}
-        className="flex-shrink-0 w-12 h-12 bg-white/10 dark:bg-slate-700/30 backdrop-blur-sm border border-white/10 dark:border-slate-600/30 rounded-lg overflow-hidden relative"
+        className="flex-shrink-0 w-9 h-9 bg-white/[0.05] border border-white/[0.08] rounded-md overflow-hidden relative"
       >
         <div className="absolute inset-0 flex items-center justify-center">
           {!isInView || hasError ? (
             getFileIcon(file.filename)
           ) : !isLoaded && thumbnailUrl ? (
-            <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+            <Loader2 className="h-4 w-4 animate-spin text-[#565d6b]" />
           ) : !thumbnailUrl ? (
             getFileIcon(file.filename)
           ) : null}
@@ -206,15 +206,15 @@ const LazyThumbnail: React.FC<LazyThumbnailProps> = ({ file, onFileClick, imageL
       </div>
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
+        <p className="text-[11.5px] font-medium text-[#e9ebef] truncate">
           {file.filename}
         </p>
         <div className="flex items-center space-x-2 mt-1">
-          <span className="text-xs text-slate-500 dark:text-slate-400 capitalize">
+          <span className="text-xs text-[#71798a] capitalize">
             {file.type}
           </span>
           {file.subfolder && (
-            <span className="text-xs text-slate-500 dark:text-slate-400">
+            <span className="text-xs text-[#71798a]">
               • {file.subfolder}
             </span>
           )}
@@ -558,40 +558,40 @@ export const PromptHistoryContent: React.FC<{
     }
 
     if (hasException || status.status_str === 'error') {
-      return <XCircle className="h-4 w-4 text-red-400" />;
+      return <XCircle className="h-3.5 w-3.5 text-[#f87c7c]" />;
     }
 
     if (status.completed) {
-      return <CheckCircle className="h-4 w-4 text-green-400" />;
+      return <CheckCircle className="h-3.5 w-3.5 text-[#4ade80]" />;
     }
 
     if (status.status_str === 'executing') {
-      return <Loader2 className="h-4 w-4 text-blue-400 animate-spin" />;
+      return <Loader2 className="h-3.5 w-3.5 text-[#7ba3f5] animate-spin" />;
     }
 
-    return <Clock className="h-4 w-4 text-yellow-400" />;
+    return <Clock className="h-3.5 w-3.5 text-[#ffa348]" />;
   };
 
   const getStatusIndicator = (item: PromptHistoryItem, hasException: boolean) => {
     const { status, isInterrupted } = item;
 
     if (isInterrupted) {
-      return <div className="w-3 h-3 rounded-full bg-orange-400 flex-shrink-0 shadow-lg shadow-orange-400/50" title={t('promptHistory.status.interrupted')} />;
+      return <div className="w-2 h-2 rounded-full bg-[#ffa348] flex-shrink-0 " title={t('promptHistory.status.interrupted')} />;
     }
 
     if (hasException || status.status_str === 'error') {
-      return <div className="w-3 h-3 rounded-full bg-red-400 flex-shrink-0 shadow-lg shadow-red-400/50" title={t('promptHistory.status.error')} />;
+      return <div className="w-2 h-2 rounded-full bg-[#f25555] flex-shrink-0 " title={t('promptHistory.status.error')} />;
     }
 
     if (status.completed) {
-      return <div className="w-3 h-3 rounded-full bg-green-400 flex-shrink-0 shadow-lg shadow-green-400/50" title={t('promptHistory.status.completed')} />;
+      return <div className="w-2 h-2 rounded-full bg-[#4ade80] flex-shrink-0 " title={t('promptHistory.status.completed')} />;
     }
 
     if (status.status_str === 'executing') {
-      return <div className="w-3 h-3 rounded-full bg-blue-400 animate-pulse flex-shrink-0 shadow-lg shadow-blue-400/50" title={t('promptHistory.status.executing')} />;
+      return <div className="w-2 h-2 rounded-full bg-[#3069f0] animate-pulse flex-shrink-0 " title={t('promptHistory.status.executing')} />;
     }
 
-    return <div className="w-3 h-3 rounded-full bg-slate-400 flex-shrink-0 shadow-lg shadow-slate-400/50" title={t('promptHistory.status.pending')} />;
+    return <div className="w-2 h-2 rounded-full bg-[#565d6b] flex-shrink-0 " title={t('promptHistory.status.pending')} />;
   };
 
   const getShortPromptId = (promptId: string): string => {
@@ -678,11 +678,11 @@ export const PromptHistoryContent: React.FC<{
     <>
       <div className={`flex flex-col h-full overflow-hidden relative ${isEmbedded ? '' : ''}`}>
         {/* Glassmorphism Header with Tabs */}
-        <div className={`relative flex flex-col ${isEmbedded ? 'bg-transparent' : 'bg-white/10 dark:bg-slate-700/10 backdrop-blur-sm border-b border-white/10 dark:border-slate-600/10'}`}>
+        <div className={`relative flex flex-col ${isEmbedded ? 'bg-transparent' : 'bg-[#0f1116]/90 backdrop-blur-xl border-b border-white/[0.08]'}`}>
           <div className={`flex items-center justify-between ${isEmbedded ? 'p-0 pb-3' : 'p-6 pb-4'}`}>
             <div className="flex items-center space-x-3">
-              <Layers className={`${isEmbedded ? 'h-5 w-5' : 'h-6 w-6'} text-violet-400 drop-shadow-sm`} />
-              <h2 className={`${isEmbedded ? 'text-lg' : 'text-xl'} font-bold text-slate-900 dark:text-white drop-shadow-sm`}>
+              <Layers className={`${isEmbedded ? 'h-4 w-4' : 'h-5 w-5'} text-[#5b8af5]`} strokeWidth={1.8} />
+              <h2 className={`${isEmbedded ? 'text-[13.5px]' : 'text-[17px]'} font-bold text-[#e9ebef]`}>
                 {t('promptHistory.title')}
               </h2>
             </div>
@@ -692,7 +692,7 @@ export const PromptHistoryContent: React.FC<{
                 disabled={isLoading || outputsLoading}
                 variant="ghost"
                 size="sm"
-                className="h-8 w-8 p-0 hover:bg-white/20 dark:hover:bg-slate-700/30 text-slate-700 dark:text-slate-200 backdrop-blur-sm border border-white/10 dark:border-slate-600/10 rounded-full disabled:opacity-50"
+                className="h-7 w-7 p-0 rounded-[7px] border border-white/[0.08] bg-white/[0.045] text-[#c8ccd4] hover:text-white hover:bg-white/[0.08] disabled:opacity-50"
               >
                 <RefreshCw className={`h-4 w-4 ${(isLoading || outputsLoading) ? 'animate-spin' : ''}`} />
               </Button>
@@ -701,7 +701,7 @@ export const PromptHistoryContent: React.FC<{
                   onClick={onClose}
                   variant="ghost"
                   size="sm"
-                  className="h-8 w-8 p-0 hover:bg-white/20 dark:hover:bg-slate-700/30 text-slate-700 dark:text-slate-200 backdrop-blur-sm border border-white/10 dark:border-slate-600/10 rounded-full"
+                  className="h-7 w-7 p-0 rounded-[7px] border border-white/[0.08] bg-white/[0.045] text-[#c8ccd4] hover:text-white hover:bg-white/[0.08]"
                 >
                   <X className="h-4 w-4" />
                 </Button>
@@ -711,19 +711,19 @@ export const PromptHistoryContent: React.FC<{
 
           {/* Enhanced Glassmorphism Tabs */}
           <div className={`flex ${isEmbedded ? 'px-0 pb-3' : 'px-6 pb-2'}`}>
-            <div className="flex bg-white/10 dark:bg-slate-700/10 backdrop-blur-sm border border-white/20 dark:border-slate-600/20 rounded-2xl p-1 shadow-lg w-full">
+            <div className="flex gap-[3px] bg-white/[0.04] border border-white/[0.08] rounded-[10px] p-1 w-full">
               <button
                 onClick={() => setActiveTab('queues')}
-                className={`flex-1 px-4 py-2 text-sm font-medium rounded-xl transition-all duration-300 ${activeTab === 'queues'
-                  ? 'bg-white/30 dark:bg-slate-600/30 text-slate-900 dark:text-white shadow-lg backdrop-blur-sm border border-white/20 dark:border-slate-500/20'
-                  : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-white/10 dark:hover:bg-slate-700/10'
+                className={`flex-1 px-3 py-1.5 text-[11.5px] font-semibold rounded-[7px] transition-all duration-200 ${activeTab === 'queues'
+                  ? 'bg-[#e9ebef] text-[#0b0c0f]'
+                  : 'text-[#71798a] hover:text-[#9aa3b2]'
                   }`}
               >
                 <div className="flex items-center justify-center space-x-2">
                   <Clock className="h-4 w-4" />
                   <span>{t('promptHistory.queuesTab')}</span>
                   {historyData.length > 0 && activeTab === 'queues' && (
-                    <Badge variant="secondary" className="ml-1 bg-white/20 dark:bg-slate-800/30">
+                    <Badge variant="secondary" className="ml-1 h-[17px] px-1.5 rounded-md bg-black/20 text-current font-mono text-[10px]">
                       {historyData.length}
                     </Badge>
                   )}
@@ -731,16 +731,16 @@ export const PromptHistoryContent: React.FC<{
               </button>
               <button
                 onClick={() => setActiveTab('outputs')}
-                className={`flex-1 px-4 py-2 text-sm font-medium rounded-xl transition-all duration-300 ${activeTab === 'outputs'
-                  ? 'bg-white/30 dark:bg-slate-600/30 text-slate-900 dark:text-white shadow-lg backdrop-blur-sm border border-white/20 dark:border-slate-500/20'
-                  : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-white/10 dark:hover:bg-slate-700/10'
+                className={`flex-1 px-3 py-1.5 text-[11.5px] font-semibold rounded-[7px] transition-all duration-200 ${activeTab === 'outputs'
+                  ? 'bg-[#e9ebef] text-[#0b0c0f]'
+                  : 'text-[#71798a] hover:text-[#9aa3b2]'
                   }`}
               >
                 <div className="flex items-center justify-center space-x-2">
                   <ImageIcon className="h-4 w-4" />
                   <span>{t('promptHistory.outputsTab')}</span>
                   {outputFiles.length > 0 && activeTab === 'outputs' && (
-                    <Badge variant="secondary" className="ml-1 bg-white/20 dark:bg-slate-800/30">
+                    <Badge variant="secondary" className="ml-1 h-[17px] px-1.5 rounded-md bg-black/20 text-current font-mono text-[10px]">
                       {outputFiles.length}
                     </Badge>
                   )}
@@ -765,8 +765,8 @@ export const PromptHistoryContent: React.FC<{
                 {isLoading && (
                   <div className="flex-1 flex items-center justify-center py-12">
                     <div className="text-center">
-                      <Loader2 className="h-8 w-8 animate-spin text-violet-400 mx-auto mb-4" />
-                      <p className="text-slate-600 dark:text-slate-400">{t('promptHistory.loading')}</p>
+                      <Loader2 className="h-8 w-8 animate-spin text-[#5b8af5] mx-auto mb-4" />
+                      <p className="text-[#8a919e]">{t('promptHistory.loading')}</p>
                     </div>
                   </div>
                 )}
@@ -774,13 +774,13 @@ export const PromptHistoryContent: React.FC<{
                 {error && !isLoading && (
                   <div className="flex-1 flex items-center justify-center py-12">
                     <div className="text-center">
-                      <AlertTriangle className="h-8 w-8 text-red-400 mx-auto mb-4" />
-                      <p className="text-red-400 mb-4">{error}</p>
+                      <AlertTriangle className="h-8 w-8 text-[#f87c7c] mx-auto mb-4" />
+                      <p className="text-[#f87c7c] mb-4">{error}</p>
                       <Button
                         onClick={fetchHistory}
                         variant="outline"
                         size="sm"
-                        className="bg-white/10 dark:bg-slate-800/20 backdrop-blur-sm border-white/20 dark:border-slate-700/20 hover:bg-white/20 dark:hover:bg-slate-700/30"
+                        className="bg-white/[0.05] border-white/[0.08] text-[#c8ccd4] hover:bg-white/[0.08]"
                       >
                         <RefreshCw className="h-4 w-4 mr-2" />
                         {t('promptHistory.retry')}
@@ -792,38 +792,38 @@ export const PromptHistoryContent: React.FC<{
                 {!isLoading && !error && historyData.length === 0 && (
                   <div className="flex-1 flex items-center justify-center py-12">
                     <div className="text-center">
-                      <Clock className="h-8 w-8 text-slate-400 mx-auto mb-4" />
-                      <p className="text-slate-600 dark:text-slate-400">{t('promptHistory.empty')}</p>
+                      <Clock className="h-8 w-8 text-[#565d6b] mx-auto mb-4" />
+                      <p className="text-[#8a919e]">{t('promptHistory.empty')}</p>
                     </div>
                   </div>
                 )}
 
                 {!isLoading && !error && historyData.length > 0 && (
-                  <div className={`${isEmbedded ? 'p-1' : 'p-6'} space-y-4`}>
+                  <div className={`${isEmbedded ? 'p-0.5' : 'p-6'} space-y-2`}>
                     {historyData.map((item) => {
                       const hasException = !!(item.exception_message || item.exception_type);
 
                       return (
                         <div
                           key={item.promptId}
-                          className="p-4 bg-white/10 dark:bg-slate-800/10 backdrop-blur-sm border border-white/20 dark:border-slate-700/20 rounded-xl hover:bg-white/20 dark:hover:bg-slate-700/20 transition-all duration-200 hover:scale-[1.01] hover:shadow-lg"
+                          className="px-2 py-1.5 bg-white/[0.03] border border-white/[0.07] rounded-lg hover:bg-white/[0.05] hover:border-white/[0.12] transition-colors"
                         >
                           <div className="flex items-start justify-between">
-                            <div className="flex-1 space-y-3">
+                            <div className="flex-1 space-y-1.5">
                               <div className="flex items-center justify-between">
-                                <div className="flex items-center space-x-3 flex-1 min-w-0">
+                                <div className="flex items-center space-x-2 flex-1 min-w-0">
                                   {getStatusIcon(item, hasException)}
-                                  <span className="font-mono text-xs text-slate-700 dark:text-slate-300 truncate flex-1">
+                                  <span className="font-mono text-[11px] text-[#c8ccd4] truncate flex-1">
                                     {getShortPromptId(item.promptId)}
                                   </span>
                                   {getStatusIndicator(item, hasException)}
                                 </div>
                                 <div className="flex flex-col items-end ml-3">
-                                  <span className="text-[10px] text-slate-500 dark:text-slate-400 flex-shrink-0">
+                                  <span className="font-mono text-[9px] text-[#71798a] flex-shrink-0">
                                     {formatTimestamp(item.timestamp)}
                                   </span>
                                   {item.duration !== undefined && (
-                                    <span className="text-[9px] text-violet-400/70 font-mono mt-0.5">
+                                    <span className="text-[9px] text-[#5b8af5]/70 font-mono mt-0.5">
                                       {formatDuration(item.duration)}
                                     </span>
                                   )}
@@ -837,13 +837,13 @@ export const PromptHistoryContent: React.FC<{
 
                               {hasException && (
                                 <div
-                                  className="p-3 bg-red-500/10 backdrop-blur-sm border border-red-400/20 rounded-lg space-y-3 cursor-pointer hover:bg-red-500/20 transition-colors"
+                                  className="p-2 bg-[#f25555]/10 border border-[#f25555]/25 rounded-lg space-y-1.5 cursor-pointer hover:bg-red-500/20 transition-colors"
                                   onClick={() => handleErrorClick(item)}
                                   title="Click to view full error details"
                                 >
                                   {item.exception_type && (
                                     <div className="flex items-start space-x-2">
-                                      <XCircle className="h-5 w-5 text-red-400 mt-0.5 flex-shrink-0" />
+                                      <XCircle className="h-3.5 w-3.5 text-[#f87c7c] mt-0.5 flex-shrink-0" />
                                       <div className="flex-1">
                                         <div className="font-medium text-red-300 mb-1 text-xs">
                                           {t('promptHistory.errorType')}
@@ -872,19 +872,19 @@ export const PromptHistoryContent: React.FC<{
                                   <Button
                                     onClick={() => toggleOutputsExpansion(item.promptId)}
                                     variant="ghost"
-                                    className={`w-full p-3 backdrop-blur-sm border rounded-lg ${expandedPromptId === item.promptId
-                                      ? 'bg-green-500/20 border-green-400/40 shadow-lg shadow-green-500/10'
-                                      : 'bg-green-500/10 border-green-400/20 hover:bg-green-500/20'
+                                    className={`w-full h-7 px-2 py-0 border rounded-md ${expandedPromptId === item.promptId
+                                      ? 'bg-[#34c77b]/[0.18] border-[#34c77b]/40'
+                                      : 'bg-[#34c77b]/[0.1] border-[#34c77b]/25 hover:bg-[#34c77b]/[0.18]'
                                       }`}
                                   >
                                     <div className="flex items-center justify-between w-full">
                                       <div className="flex items-center space-x-2">
-                                        <CheckCircle className="h-4 w-4 text-green-400" />
-                                        <span className="text-xs text-green-300 font-bold">
+                                        <CheckCircle className="h-3.5 w-3.5 text-[#4ade80]" />
+                                        <span className="text-[10.5px] text-[#4ade80] font-semibold">
                                           {t('promptHistory.generatedFiles', { count: getOutputFiles(item.outputs).length })}
                                         </span>
                                       </div>
-                                      <ChevronDown className={`h-4 w-4 text-green-400 ${expandedPromptId === item.promptId ? 'rotate-180' : ''}`} />
+                                      <ChevronDown className={`h-3.5 w-3.5 text-[#4ade80] ${expandedPromptId === item.promptId ? 'rotate-180' : ''}`} />
                                     </div>
                                   </Button>
 
@@ -894,21 +894,21 @@ export const PromptHistoryContent: React.FC<{
                                         <button
                                           key={`${item.promptId}-${idx}`}
                                           onClick={() => handleOutputFileClick(file)}
-                                          className="flex items-center space-x-3 p-2.5 bg-white/5 dark:bg-slate-800/10 border border-white/10 dark:border-slate-700/20 rounded-lg hover:bg-white/10 dark:hover:bg-slate-700/20 transition-colors w-full group"
+                                          className="flex items-center gap-2 p-2 bg-white/[0.03] border border-white/[0.07] rounded-lg hover:bg-white/[0.06] transition-colors w-full group"
                                         >
-                                          <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center bg-white/10 rounded-md group-hover:bg-violet-500/20 transition-colors">
+                                          <div className="flex-shrink-0 w-7 h-7 flex items-center justify-center bg-white/[0.07] rounded-md group-hover:bg-[#3069f0]/20 transition-colors">
                                             {isImageFile(file.filename) ? (
-                                              <ImageIcon className="h-4 w-4 text-blue-400 group-hover:text-blue-300" />
+                                              <ImageIcon className="h-4 w-4 text-[#7ba3f5] group-hover:text-blue-300" />
                                             ) : isVideoFile(file.filename) ? (
                                               <Video className="h-4 w-4 text-purple-400 group-hover:text-purple-300" />
                                             ) : (
-                                              <FileText className="h-4 w-4 text-slate-400" />
+                                              <FileText className="h-4 w-4 text-[#565d6b]" />
                                             )}
                                           </div>
-                                          <span className="text-xs font-medium text-slate-700 dark:text-slate-300 truncate text-left flex-1">
+                                          <span className="text-xs font-medium text-[#c8ccd4] truncate text-left flex-1">
                                             {file.filename}
                                           </span>
-                                          <Eye className="h-3.5 w-3.5 text-slate-500 group-hover:text-violet-400" />
+                                          <Eye className="h-3.5 w-3.5 text-[#71798a] group-hover:text-[#5b8af5]" />
                                         </button>
                                       ))}
                                     </div>
@@ -937,8 +937,8 @@ export const PromptHistoryContent: React.FC<{
                 {outputsLoading && (
                   <div className="flex items-center justify-center py-12">
                     <div className="text-center">
-                      <Loader2 className="h-8 w-8 animate-spin text-violet-400 mx-auto mb-3" />
-                      <p className="text-sm text-slate-600 dark:text-slate-400">
+                      <Loader2 className="h-8 w-8 animate-spin text-[#5b8af5] mx-auto mb-3" />
+                      <p className="text-[11.5px] text-[#8a919e]">
                         {t('promptHistory.loadingOutputs')}
                       </p>
                     </div>
@@ -947,7 +947,7 @@ export const PromptHistoryContent: React.FC<{
 
                 {outputsError && (
                   <div className="p-4 m-4 bg-red-500/10 backdrop-blur-sm border border-red-400/20 rounded-xl">
-                    <p className="text-sm text-red-400">{outputsError}</p>
+                    <p className="text-[11.5px] text-[#f87c7c]">{outputsError}</p>
                     <button
                       onClick={loadOutputHistory}
                       className="mt-2 text-xs text-red-300 hover:underline"
@@ -959,11 +959,11 @@ export const PromptHistoryContent: React.FC<{
 
                 {!outputsLoading && !outputsError && outputFiles.length === 0 && (
                   <div className="text-center py-12 px-4">
-                    <ImageIcon className="h-16 w-16 text-slate-400 mx-auto mb-4" />
-                    <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100 mb-2">
+                    <ImageIcon className="h-16 w-16 text-[#565d6b] mx-auto mb-4" />
+                    <h3 className="text-lg font-medium text-[#e9ebef] mb-2">
                       {t('promptHistory.noOutputHistory')}
                     </h3>
-                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                    <p className="text-[11.5px] text-[#71798a]">
                       {t('promptHistory.noOutputFiles')}
                     </p>
                   </div>
@@ -1029,13 +1029,13 @@ export const PromptHistory: React.FC = () => {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 bg-slate-900/60 backdrop-blur-sm z-[9999] flex items-center justify-center p-4"
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[9999] flex items-center justify-center p-4"
         >
           <motion.div
             initial={{ scale: 0.9, opacity: 0, y: 20 }}
             animate={{ scale: 1, opacity: 1, y: 0 }}
             exit={{ scale: 0.9, opacity: 0, y: 20 }}
-            className="bg-white dark:bg-slate-800 rounded-2xl shadow-2xl w-full max-w-lg h-[80vh] flex flex-col overflow-hidden"
+            className="bg-[#101217] border border-white/10 rounded-xl shadow-2xl w-full max-w-lg h-[76vh] flex flex-col overflow-hidden"
           >
             <PromptHistoryContent
               onClose={closePromptHistory}

--- a/src/components/media/InlineImagePreview.tsx
+++ b/src/components/media/InlineImagePreview.tsx
@@ -138,7 +138,7 @@ export const InlineImagePreview: React.FC<InlineImagePreviewProps> = ({
   if (loading) {
     return (
       <div
-        className="w-full h-32 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-blue-900/30 dark:to-purple-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-blue-300 dark:border-blue-700"
+ className="w-full h-32 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-blue-900/30 dark:to-purple-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-blue-300 dark:border-blue-700"
         onClick={onClick}
       >
         <div className="text-center">
@@ -152,7 +152,7 @@ export const InlineImagePreview: React.FC<InlineImagePreviewProps> = ({
   if (error || !imageUrl) {
     return (
       <div
-        className="w-full h-32 bg-gradient-to-r from-red-100 to-orange-100 dark:from-red-900/30 dark:to-orange-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-red-300 dark:border-red-700"
+ className="w-full h-32 bg-gradient-to-r from-red-100 to-orange-100 dark:from-red-900/30 dark:to-orange-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-red-300 dark:border-red-700"
         onClick={onClick}
       >
         <div className="text-center">
@@ -166,24 +166,24 @@ export const InlineImagePreview: React.FC<InlineImagePreviewProps> = ({
 
   return (
     <div
-      className={`w-full rounded-lg overflow-hidden cursor-pointer hover:shadow-md transition-all hover:scale-[1.02] group ${themeOverride?.container || 'bg-slate-50 dark:bg-slate-800/50'}`}
+ className={`w-full rounded-lg overflow-hidden cursor-pointer hover:shadow-md transition-all hover:scale-[1.02] group ${themeOverride?.container || 'bg-white/[0.04]'}`}
       onClick={onClick}
     >
       <div className="relative">
         <img
           src={imageUrl}
           alt={typeof imagePreview === 'string' ? imagePreview : (imagePreview.filename || t('media.preview'))}
-          className="w-full max-h-48 object-contain"
+ className="w-full max-h-48 object-contain"
           onError={() => setError(t('media.failedToDisplayImage'))}
         />
         <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors flex items-center justify-center opacity-0 group-hover:opacity-100">
-          <div className="bg-white/90 dark:bg-slate-900/90 rounded-full p-2">
-            <Image className="w-5 h-5 text-slate-700 dark:text-slate-300" />
+          <div className="bg-white/90 rounded-full p-2">
+            <Image className="w-5 h-5 text-[#c8ccd4]" />
           </div>
         </div>
       </div>
       <div className="p-3">
-        <p className={`text-xs truncate ${themeOverride?.text || 'text-slate-600 dark:text-slate-400'}`}>
+        <p className={`text-xs truncate ${themeOverride?.text || 'text-[#8a919e]'}`}>
           {typeof imagePreview === 'string' ? imagePreview : (imagePreview.filename || t('media.preview'))}
         </p>
         <p className={`text-xs mt-1 ${themeOverride?.secondaryText || 'text-blue-600 dark:text-blue-400'}`}>

--- a/src/components/media/InlineVideoPreview.tsx
+++ b/src/components/media/InlineVideoPreview.tsx
@@ -138,7 +138,7 @@ export const InlineVideoPreview: React.FC<InlineVideoPreviewProps> = ({
   if (loading) {
     return (
       <div
-        className="w-full h-32 bg-gradient-to-r from-purple-100 to-pink-100 dark:from-purple-900/30 dark:to-pink-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-purple-300 dark:border-purple-700"
+ className="w-full h-32 bg-gradient-to-r from-purple-100 to-pink-100 dark:from-purple-900/30 dark:to-pink-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-purple-300 dark:border-purple-700"
         onClick={onClick}
       >
         <div className="text-center">
@@ -152,7 +152,7 @@ export const InlineVideoPreview: React.FC<InlineVideoPreviewProps> = ({
   if (error || !videoUrl) {
     return (
       <div
-        className="w-full h-32 bg-gradient-to-r from-red-100 to-orange-100 dark:from-red-900/30 dark:to-orange-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-red-300 dark:border-red-700"
+ className="w-full h-32 bg-gradient-to-r from-red-100 to-orange-100 dark:from-red-900/30 dark:to-orange-900/30 rounded-lg flex items-center justify-center cursor-pointer hover:shadow-md transition-shadow border-2 border-dashed border-red-300 dark:border-red-700"
         onClick={onClick}
       >
         <div className="text-center">
@@ -166,13 +166,13 @@ export const InlineVideoPreview: React.FC<InlineVideoPreviewProps> = ({
 
   return (
     <div
-      className={`w-full rounded-lg overflow-hidden cursor-pointer hover:shadow-md transition-all hover:scale-[1.02] group ${themeOverride?.container || 'bg-slate-50 dark:bg-slate-800/50'}`}
+ className={`w-full rounded-lg overflow-hidden cursor-pointer hover:shadow-md transition-all hover:scale-[1.02] group ${themeOverride?.container || 'bg-white/[0.04]'}`}
       onClick={onClick}
     >
       <div className="relative">
         <video
           src={videoUrl}
-          className="w-full max-h-48 object-contain"
+ className="w-full max-h-48 object-contain"
           preload="metadata"
           muted
           playsInline
@@ -199,8 +199,8 @@ export const InlineVideoPreview: React.FC<InlineVideoPreviewProps> = ({
           }}
         />
         <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors flex items-center justify-center opacity-0 group-hover:opacity-100">
-          <div className="bg-white/90 dark:bg-slate-900/90 rounded-full p-3">
-            <Play className="w-6 h-6 text-slate-700 dark:text-slate-300" fill="currentColor" />
+          <div className="bg-white/90 rounded-full p-3">
+            <Play className="w-6 h-6 text-[#c8ccd4]" fill="currentColor" />
           </div>
         </div>
         {/* Video duration overlay */}
@@ -210,7 +210,7 @@ export const InlineVideoPreview: React.FC<InlineVideoPreviewProps> = ({
         </div>
       </div>
       <div className="p-3">
-        <p className={`text-xs truncate ${themeOverride?.text || 'text-slate-600 dark:text-slate-400'}`}>
+        <p className={`text-xs truncate ${themeOverride?.text || 'text-[#8a919e]'}`}>
           {typeof videoPreview === 'string' ? videoPreview : (videoPreview.filename || t('media.videoPreview'))}
         </p>
         <p className={`text-xs mt-1 ${themeOverride?.secondaryText || 'text-purple-600 dark:text-purple-400'}`}>

--- a/src/components/media/OutputsGallery.tsx
+++ b/src/components/media/OutputsGallery.tsx
@@ -144,27 +144,27 @@ const LazyImage: React.FC<LazyImageProps> = ({
 
   return (
     <div
-      className={`relative aspect-square bg-slate-900 overflow-hidden cursor-pointer group transition-transform duration-150 hover:scale-[1.02] active:scale-[0.98] ${isSelected ? 'z-10' : ''}`}
-      style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 256px' }}
+      className={`relative aspect-square overflow-hidden cursor-pointer group transition-transform duration-150 hover:scale-[1.02] active:scale-[0.98] ${isSelected ? 'z-10' : ''}`}
+      style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 256px', background: '#0d1016' }}
       onClick={handleClick}
     >
       {/* Loading Placeholder */}
       {!isLoaded && !hasError && (
         <div className="absolute inset-0 flex items-center justify-center">
-          <div className="h-8 w-8 bg-slate-300 dark:bg-slate-700 rounded animate-pulse" />
+          <div className="h-8 w-8 bg-white/[0.06] rounded animate-pulse" />
         </div>
       )}
 
       {/* Error State */}
       {hasError && (
-        <div className="absolute inset-0 flex items-center justify-center bg-slate-100 dark:bg-slate-800">
+        <div className="absolute inset-0 flex items-center justify-center" style={{ background: '#0d1016' }}>
           <div className="text-center">
             {isVideoFile(file.filename) ? (
-              <Video className="h-8 w-8 text-slate-400 mx-auto mb-2" />
+              <Video className="h-8 w-8 text-white/20 mx-auto mb-2" strokeWidth={1.6} />
             ) : (
-              <ImageIcon className="h-8 w-8 text-slate-400 mx-auto mb-2" />
+              <ImageIcon className="h-8 w-8 text-white/20 mx-auto mb-2" strokeWidth={1.6} />
             )}
-            <p className="text-xs text-slate-500 dark:text-slate-400">{t('media.failedToLoad')}</p>
+            <p className="text-xs text-[#565d6b]">{t('media.failedToLoad')}</p>
           </div>
         </div>
       )}
@@ -187,14 +187,14 @@ const LazyImage: React.FC<LazyImageProps> = ({
             />
           ) : (
             /* Video placeholder when no thumbnail available */
-            <div className="w-full h-full flex items-center justify-center bg-slate-100 dark:bg-slate-800">
-              <Video className="h-12 w-12 text-slate-400" />
+            <div className="w-full h-full flex items-center justify-center" style={{ background: '#0d1016' }}>
+              <Video className="h-10 w-10 text-white/20" strokeWidth={1.6} />
             </div>
           )}
           {/* Video Overlay Icon */}
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <div className="bg-black/50 rounded-full p-3">
-              <Video className="h-8 w-8 text-white" />
+            <div className="rounded-lg p-2 border border-white/[0.12]" style={{ background: 'rgba(5,6,8,0.72)' }}>
+              <Video className="h-5 w-5 text-[#e9ebef]" strokeWidth={1.8} />
             </div>
           </div>
         </>
@@ -218,33 +218,39 @@ const LazyImage: React.FC<LazyImageProps> = ({
         </>
       )}
 
-      {/* Selection Checkbox - Immersive Circle */}
+      {/* Selected State Overlay (blue wash + border, per design spec) */}
+      {isSelected && (
+        <div
+          className="absolute inset-0 z-20 pointer-events-none border-2 border-[#3069f0]"
+          style={{ background: 'rgba(48,105,240,0.28)' }}
+        />
+      )}
+
+      {/* Selection Checkbox - square check */}
       {isSelectionMode && (
-        <div className="absolute top-3 left-3 z-30">
-          <div className={`w-7 h-7 rounded-full border-2 border-white/50 backdrop-blur-md flex items-center justify-center transition-all duration-300 ${isSelected ? 'bg-blue-600 border-blue-400 scale-110 shadow-lg' : 'bg-black/20 hover:bg-black/40'}`}>
-            {isSelected && <Check className="h-4 w-4 text-white stroke-[3px]" />}
+        <div className="absolute top-1.5 left-1.5 z-30">
+          <div
+            className={`w-5 h-5 rounded-md flex items-center justify-center transition-colors ${isSelected ? 'bg-[#3069f0]' : 'border-[1.5px] border-white/55'}`}
+            style={isSelected ? undefined : { background: 'rgba(5,6,8,0.4)' }}
+          >
+            {isSelected && <Check className="h-3 w-3 text-white" strokeWidth={2.6} />}
           </div>
         </div>
       )}
 
-      {/* Selected State Overlay */}
-      {isSelected && (
-        <div className="absolute inset-0 border-4 border-blue-500 z-20 pointer-events-none shadow-[inset_0_0_20px_rgba(59,130,246,0.3)]" />
-      )}
-
-      {/* Folder Type Badge - Simplified */}
-      <div className="absolute top-3 right-3 z-30">
-        <div className={`px-2 py-0.5 rounded-full text-[9px] font-black tracking-widest uppercase backdrop-blur-md border border-white/20 ${file.type === 'input' ? 'bg-emerald-500/80 text-white' :
-          file.type === 'output' ? 'bg-blue-500/80 text-white' :
-            'bg-amber-500/80 text-white'
-          }`}>
+      {/* Folder Type Badge - mono micro chip */}
+      <div className="absolute top-1.5 right-1.5 z-30">
+        <div
+          className="px-1.5 py-[3px] rounded-md font-mono text-[8.5px] font-semibold tracking-[0.1em] uppercase border border-white/[0.12] text-[#e9ebef]"
+          style={{ background: 'rgba(5,6,8,0.72)' }}
+        >
           {file.type}
         </div>
       </div>
 
-      {/* Immersive Filename Overlay on Hover */}
-      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-4 opacity-0 group-hover:opacity-100 transition-all duration-300 z-30">
-        <p className="text-white text-xs font-bold truncate tracking-tight">
+      {/* Filename Overlay on Hover */}
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/45 to-transparent px-2.5 py-2 opacity-0 group-hover:opacity-100 transition-all duration-300 z-30">
+        <p className="text-[#e9ebef] font-mono text-[10px] truncate">
           {file.filename}
         </p>
       </div>
@@ -843,117 +849,115 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
   const totalFiles = files.images.length + files.videos.length;
 
   return (
-    <div className="fixed inset-0 bg-black overflow-y-auto overflow-x-hidden pt-safe pb-safe z-0">
+    <div className="fixed inset-0 overflow-y-auto overflow-x-hidden pt-safe pb-safe z-0" style={{ background: '#050608' }}>
       {/* Immersive Fixed Header */}
       <header
         ref={headerRef}
         className="fixed top-0 inset-x-0 z-50 pointer-events-none"
       >
         <div
-          className="absolute inset-x-0 top-0 h-full backdrop-blur-xl bg-gradient-to-b from-black/25 via-black/10 to-transparent"
-          style={{
-            maskImage: 'linear-gradient(to bottom, black 0%, transparent 100%)',
-            WebkitMaskImage: 'linear-gradient(to bottom, black 0%, transparent 100%)'
-          }}
+          className="absolute inset-x-0 top-0 h-full"
+          style={{ background: 'linear-gradient(to bottom, rgba(5,6,8,.92) 30%, transparent)' }}
         />
-        {/* Balanced Padding & Multi-row Header Layout */}
-        <div className="relative flex flex-col p-4 pt-6 md:px-8 pointer-events-auto space-y-0.5">
-          {/* Row 1: Back Button | Title | Selection Button */}
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
-              <button
-                onClick={handleGoBack}
-                className="w-14 h-14 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 transition-all active:scale-95 shadow-lg backdrop-blur-md border border-white/10"
-                title={t('common.back')}
-              >
-                <ChevronLeft className="h-8 w-8 text-white stroke-[2.5]" />
-              </button>
-              <h1 className="text-4xl font-black text-white leading-none tracking-tighter">
-                {isFileSelectionMode
-                  ? (selectionTitle || t('gallery.selectFile'))
-                  : (selectedSubfolder && viewMode === 'folders'
-                    ? (selectedSubfolder === '/' ? 'Root' : selectedSubfolder.split('/').pop())
-                    : t(`gallery.tabs.${activeTab}`))}
-              </h1>
-            </div>
+        {/* Single-row header: back tile | title + mono sub | action tiles */}
+        <div className="relative flex items-center gap-2.5 px-3.5 pt-3 pb-2 md:px-8 pointer-events-auto">
+          <button
+            onClick={handleGoBack}
+            className="w-9 h-9 shrink-0 flex items-center justify-center rounded-[10px] border border-white/10 text-[#e9ebef] backdrop-blur-md transition-all active:scale-95"
+            style={{ background: 'rgba(255,255,255,0.06)' }}
+            title={t('common.back')}
+          >
+            <ChevronLeft className="h-[17px] w-[17px]" strokeWidth={1.9} />
+          </button>
 
-            <div className="flex items-center space-x-2">
-              {/* View Mode Toggle */}
-              {!isSelectionMode && (!selectedSubfolder || selectedSubfolder === '/') && (
-                <button
-                  onClick={() => {
-                    setViewMode(viewMode === 'flat' ? 'folders' : 'flat');
-                    setSelectedSubfolder(viewMode === 'flat' ? '/' : null);
-                  }}
-                  className="w-14 h-14 flex items-center justify-center rounded-full bg-white/10 border border-white/20 text-white hover:bg-white/20 backdrop-blur-xl transition-all duration-300 active:scale-90 shadow-2xl"
-                  title={viewMode === 'flat' ? 'Folders' : 'Grid'}
-                >
-                  {viewMode === 'flat' ? <FolderTree className="h-7 w-7" /> : <LayoutGrid className="h-7 w-7" />}
-                </button>
-              )}
-
-              {/* Refresh Button - Added per user request */}
-              <AnimatePresence>
-                {!isSelectionMode && (
-                  <motion.button
-                    initial={{ opacity: 0, scale: 0.5, x: 20 }}
-                    animate={{ opacity: 1, scale: 1, x: 0 }}
-                    exit={{ opacity: 0, scale: 0.5, x: 20 }}
-                    onClick={loadFiles}
-                    disabled={loading}
-                    className="w-14 h-14 flex items-center justify-center rounded-full bg-white/10 border border-white/20 text-white hover:bg-white/20 backdrop-blur-xl transition-all duration-300 active:scale-90 shadow-2xl disabled:opacity-50"
-                    title={t('gallery.refreshFiles')}
-                  >
-                    <RefreshCw className={`h-7 w-7 ${loading ? 'animate-spin' : ''}`} />
-                  </motion.button>
-                )}
-              </AnimatePresence>
-
-              {/* Select All Button - Added per user request */}
-              <AnimatePresence>
-                {isSelectionMode && (
-                  <motion.button
-                    initial={{ opacity: 0, scale: 0.5, x: 20 }}
-                    animate={{ opacity: 1, scale: 1, x: 0 }}
-                    exit={{ opacity: 0, scale: 0.5, x: 20 }}
-                    onClick={() => handleSelectAll(true)}
-                    className="w-14 h-14 flex items-center justify-center rounded-full bg-white/10 border border-white/20 text-white hover:bg-white/20 backdrop-blur-xl transition-all duration-300 active:scale-90 shadow-2xl"
-                    title={t('gallery.selectAll')}
-                  >
-                    <CheckCircle className="h-7 w-7" />
-                  </motion.button>
-                )}
-              </AnimatePresence>
-
-              {/* Selection/X Button - Balanced Size */}
-              {!isFileSelectionMode && (
-                <button
-                  onClick={toggleSelectionMode}
-                  className={`w-14 h-14 flex items-center justify-center rounded-full border-2 transition-all duration-300 active:scale-90 shadow-2xl ${isSelectionMode
-                    ? 'bg-white border-white text-black'
-                    : 'bg-white/10 border-white/20 text-white hover:bg-white/20 backdrop-blur-xl'
-                    }`}
-                  title={isSelectionMode ? t('gallery.exitSelectionMode') : t('gallery.enterSelectionMode')}
-                >
-                  {isSelectionMode ? <X className="h-7 w-7" /> : <CheckSquare className="h-7 w-7" />}
-                </button>
-              )}
-            </div>
+          <div className="flex-1 min-w-0">
+            <h1 className="text-[19px] font-extrabold text-white leading-[1.15] tracking-[-0.01em] truncate">
+              {isFileSelectionMode
+                ? (selectionTitle || t('gallery.selectFile'))
+                : (selectedSubfolder && viewMode === 'folders'
+                  ? (selectedSubfolder === '/' ? 'Root' : selectedSubfolder.split('/').pop())
+                  : t(`gallery.tabs.${activeTab}`))}
+            </h1>
+            <p className={`font-mono text-[9px] font-medium tracking-[0.14em] uppercase mt-[3px] truncate ${isSelectionMode ? 'text-[#7ba3f5]' : 'text-[#8a919e]'}`}>
+              {isSelectionMode
+                ? `${selectedFiles.size} SELECTED`
+                : (viewMode === 'folders'
+                  ? (selectedSubfolder && selectedSubfolder !== '/' ? selectedSubfolder : 'Root Folder')
+                  : (activeFolder === 'all'
+                    ? t('gallery.filesTotal', { count: currentFiles.length })
+                    : t('gallery.folderSummary', {
+                      count: currentFiles.length,
+                      folder: t(`gallery.folders.${activeFolder}`),
+                      type: t('gallery.actions.files')
+                    })))}
+            </p>
           </div>
 
-          {/* Row 2: Sub-label aligned with Title - Scaled Up & Solid White */}
-          <div className="pl-[72px]">
-            <p className="text-base font-black text-white uppercase tracking-[0.2em]">
-              {viewMode === 'folders'
-                ? (selectedSubfolder && selectedSubfolder !== '/' ? selectedSubfolder : "Root Folder")
-                : (activeFolder === 'all'
-                  ? t('gallery.filesTotal', { count: currentFiles.length })
-                  : t('gallery.folderSummary', {
-                    count: currentFiles.length,
-                    folder: t(`gallery.folders.${activeFolder}`),
-                    type: t('gallery.actions.files')
-                  }))}
-            </p>
+          <div className="flex items-center gap-2 shrink-0">
+            {/* View Mode Toggle */}
+            {!isSelectionMode && (!selectedSubfolder || selectedSubfolder === '/') && (
+              <button
+                onClick={() => {
+                  setViewMode(viewMode === 'flat' ? 'folders' : 'flat');
+                  setSelectedSubfolder(viewMode === 'flat' ? '/' : null);
+                }}
+                className="w-9 h-9 flex items-center justify-center rounded-[10px] border border-white/10 text-[#c8ccd4] backdrop-blur-md transition-all active:scale-95"
+                style={{ background: 'rgba(255,255,255,0.06)' }}
+                title={viewMode === 'flat' ? 'Folders' : 'Grid'}
+              >
+                {viewMode === 'flat' ? <FolderTree className="h-4 w-4" strokeWidth={1.8} /> : <LayoutGrid className="h-4 w-4" strokeWidth={1.8} />}
+              </button>
+            )}
+
+            {/* Refresh */}
+            <AnimatePresence>
+              {!isSelectionMode && (
+                <motion.button
+                  initial={{ opacity: 0, scale: 0.5, x: 20 }}
+                  animate={{ opacity: 1, scale: 1, x: 0 }}
+                  exit={{ opacity: 0, scale: 0.5, x: 20 }}
+                  onClick={loadFiles}
+                  disabled={loading}
+                  className="w-9 h-9 flex items-center justify-center rounded-[10px] border border-white/10 text-[#c8ccd4] backdrop-blur-md transition-all active:scale-95 disabled:opacity-50"
+                  style={{ background: 'rgba(255,255,255,0.06)' }}
+                  title={t('gallery.refreshFiles')}
+                >
+                  <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} strokeWidth={1.8} />
+                </motion.button>
+              )}
+            </AnimatePresence>
+
+            {/* Select All (labeled chip, selection mode) */}
+            <AnimatePresence>
+              {isSelectionMode && (
+                <motion.button
+                  initial={{ opacity: 0, scale: 0.5, x: 20 }}
+                  animate={{ opacity: 1, scale: 1, x: 0 }}
+                  exit={{ opacity: 0, scale: 0.5, x: 20 }}
+                  onClick={() => handleSelectAll(true)}
+                  className="h-9 px-3 flex items-center rounded-[10px] border border-white/10 text-[#c8ccd4] text-[11.5px] font-semibold whitespace-nowrap backdrop-blur-md transition-all active:scale-95"
+                  style={{ background: 'rgba(255,255,255,0.06)' }}
+                  title={t('gallery.selectAll')}
+                >
+                  {t('gallery.selectAll')}
+                </motion.button>
+              )}
+            </AnimatePresence>
+
+            {/* Selection toggle */}
+            {!isFileSelectionMode && (
+              <button
+                onClick={toggleSelectionMode}
+                className={`w-9 h-9 flex items-center justify-center rounded-[10px] border backdrop-blur-md transition-all active:scale-95 ${isSelectionMode
+                  ? 'bg-[#e9ebef] border-[#e9ebef] text-[#0b0c0f]'
+                  : 'border-white/10 text-[#c8ccd4]'
+                  }`}
+                style={isSelectionMode ? undefined : { background: 'rgba(255,255,255,0.06)' }}
+                title={isSelectionMode ? t('gallery.exitSelectionMode') : t('gallery.enterSelectionMode')}
+              >
+                {isSelectionMode ? <X className="h-4 w-4" strokeWidth={2} /> : <CheckSquare className="h-4 w-4" strokeWidth={1.8} />}
+              </button>
+            )}
           </div>
         </div>
       </header>
@@ -1009,15 +1013,16 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                               setSelectedSubfolder(folder.fullPath);
                             }
                           }}
-                          className={`bg-slate-900/50 border rounded-3xl overflow-hidden cursor-pointer group hover:bg-slate-800/80 transition-all shadow-xl ${selectedFiles.has(`folder:${folder.fullPath}`) ? 'border-blue-500 ring-2 ring-blue-500/50' : 'border-white/10'
+                          className={`border rounded-xl overflow-hidden cursor-pointer group transition-all ${selectedFiles.has(`folder:${folder.fullPath}`) ? 'border-[#3069f0]/70 ring-1 ring-[#3069f0]/40' : 'border-white/[0.08] hover:border-white/[0.16]'
                             }`}
+                          style={{ background: '#101217' }}
                         >
                           <div className="aspect-square relative">
                             {/* Selection Checkbox - Immersive Circle */}
                             {isSelectionMode && (
                               <div className="absolute top-3 left-3 z-30">
-                                <div className={`w-7 h-7 rounded-full border-2 border-white/50 backdrop-blur-md flex items-center justify-center transition-all duration-300 ${selectedFiles.has(`folder:${folder.fullPath}`) ? 'bg-blue-600 border-blue-400 scale-110 shadow-lg' : 'bg-black/20 hover:bg-black/40'}`}>
-                                  {selectedFiles.has(`folder:${folder.fullPath}`) && <Check className="h-4 w-4 text-white stroke-[3px]" />}
+                                <div className={`w-5 h-5 rounded-md flex items-center justify-center transition-colors ${selectedFiles.has(`folder:${folder.fullPath}`) ? 'bg-[#3069f0]' : 'border-[1.5px] border-white/55 bg-black/40'}`}>
+                                  {selectedFiles.has(`folder:${folder.fullPath}`) && <Check className="h-3 w-3 text-white" strokeWidth={2.6} />}
                                 </div>
                               </div>
                             )}
@@ -1047,16 +1052,16 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                               }}
                             />
                             <div className="absolute inset-0 flex items-center justify-center">
-                              <div className="bg-black/40 backdrop-blur-md rounded-full p-4 group-hover:bg-blue-600/60 transition-colors">
-                                <FolderTree className="h-8 w-8 text-white" />
+                              <div className="rounded-xl p-3 border border-white/[0.12] group-hover:border-[#3069f0]/50 transition-colors" style={{ background: 'rgba(5,6,8,0.6)' }}>
+                                <FolderTree className="h-6 w-6 text-[#e9ebef]" strokeWidth={1.7} />
                               </div>
                             </div>
-                            <div className="absolute bottom-3 right-3 bg-blue-600 text-white text-[10px] font-black px-2 py-1 rounded-full shadow-lg">
+                            <div className="absolute bottom-2 right-2 font-mono text-[9px] font-semibold text-[#7ba3f5] px-1.5 py-[3px] rounded-md border border-[#3069f0]/25" style={{ background: 'rgba(61,123,253,0.1)' }}>
                               {folder.count}
                             </div>
                           </div>
-                          <div className="p-4 bg-gradient-to-b from-transparent to-black/80">
-                            <p className="text-white font-bold truncate text-sm">
+                          <div className="px-3 py-2.5 border-t border-white/[0.06]">
+                            <p className="text-[#e9ebef] font-semibold truncate text-[12.5px]">
                               {folder.name}
                             </p>
                           </div>
@@ -1067,7 +1072,7 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
 
                   {/* Files Section Second */}
                   {folderContent.files.length > 0 ? (
-                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-px">
+                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-0.5">
                       {folderContent.files.map((file, index) => (
                         <LazyImage
                           key={`${file.filename}-${file.subfolder}-${file.type}-${index}`}
@@ -1096,7 +1101,7 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
-                  className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-px"
+                  className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-0.5"
                 >
                   {currentFiles.map((file, index) => (
                     <LazyImage
@@ -1119,96 +1124,81 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
         )}
       </main>
 
-      {/* Immersive Footer - Fixed pointer events to allow scroll */}
-      <footer className="fixed bottom-0 inset-x-0 z-50 bg-gradient-to-t from-black/25 via-black/10 to-transparent pt-20 pb-10 pointer-events-none">
-        <div className="px-6 md:px-12 max-w-2xl mx-auto flex items-center justify-between pointer-events-auto">
+      {/* Immersive Footer */}
+      <footer
+        className="fixed bottom-0 inset-x-0 z-50 pt-16 pb-4 pointer-events-none"
+        style={{ background: 'linear-gradient(to top, rgba(5,6,8,.92) 25%, transparent)' }}
+      >
+        <div className="px-3.5 md:px-12 max-w-2xl mx-auto pointer-events-auto">
           {isSelectionMode ? (
-            // Selection Mode Footer
-            <div className="grid grid-cols-[1fr_auto_1fr] items-center w-full">
-              {/* Move Button */}
-              <div className="flex justify-start relative">
-                <AnimatePresence>
-                  {showMovePanel && (
-                    <motion.div
-                      initial={{ opacity: 0, y: 10, scale: 0.95 }}
-                      animate={{ opacity: 1, y: 0, scale: 1 }}
-                      exit={{ opacity: 0, y: 10, scale: 0.95 }}
-                      className="absolute bottom-20 left-0 bg-zinc-900 border border-white/10 rounded-3xl p-3 shadow-[0_20px_50px_rgba(0,0,0,0.5)] min-w-[180px]"
-                    >
-                      {(['input', 'output', 'temp'] as const).filter(f => f !== activeFolder).map(f => (
-                        <button
-                          key={f}
-                          onClick={() => handleMoveSelected(f)}
-                          className="w-full flex items-center space-x-4 px-5 py-4 hover:bg-white/5 rounded-2xl transition-colors text-white text-base font-black uppercase tracking-tight"
-                        >
-                          <FolderOpen className="h-5 w-5 text-blue-400" />
-                          <span>{t(`gallery.folders.${f}`)}</span>
-                        </button>
-                      ))}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
+            // Selection Mode: centered floating glass bar (Move | Delete)
+            <div className="flex justify-center relative">
+              <AnimatePresence>
+                {showMovePanel && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 10, scale: 0.95 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: 10, scale: 0.95 }}
+                    className="absolute bottom-16 border border-white/10 rounded-xl p-1.5 min-w-[170px] overflow-hidden"
+                    style={{ background: 'rgba(15,17,22,0.96)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', boxShadow: '0 20px 48px rgba(0,0,0,0.55)' }}
+                  >
+                    {(['input', 'output', 'temp'] as const).filter(f => f !== activeFolder).map(f => (
+                      <button
+                        key={f}
+                        onClick={() => handleMoveSelected(f)}
+                        className="w-full h-10 flex items-center gap-2.5 px-3 hover:bg-white/5 rounded-lg transition-colors text-[#d5d9e0] font-mono text-[11px] font-semibold tracking-[0.1em] uppercase"
+                      >
+                        <FolderOpen className="h-[15px] w-[15px] text-[#5b8af5]" strokeWidth={1.8} />
+                        <span>{t(`gallery.folders.${f}`)}</span>
+                      </button>
+                    ))}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              <div
+                className="flex items-center gap-1.5 p-1.5 rounded-[14px] border border-white/10"
+                style={{ background: 'rgba(15,17,22,0.9)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}
+              >
                 <button
                   onClick={() => setShowMovePanel(!showMovePanel)}
                   disabled={selectedFiles.size === 0 || isAnyFolderSelected}
-                  className={`w-14 h-14 flex items-center justify-center rounded-full backdrop-blur-md border-2 transition-all active:scale-90 ${selectedFiles.size > 0 && !isAnyFolderSelected
-                    ? 'bg-white/10 border-white/20 text-white'
-                    : 'opacity-0 scale-75 pointer-events-none'
-                    }`}
+                  className="h-10 px-[18px] flex items-center gap-2 rounded-[10px] border border-white/[0.08] text-[#c8ccd4] text-[12.5px] font-semibold whitespace-nowrap transition-all active:scale-95 disabled:opacity-35"
+                  style={{ background: 'rgba(255,255,255,0.05)' }}
                 >
-                  <FolderOpen className="h-6 w-6" />
+                  <FolderOpen className="h-[15px] w-[15px]" strokeWidth={1.8} />
+                  {t('workflow.move')}
                 </button>
-              </div>
-
-              {/* Selection Counter - Scaled Up */}
-              <div className="flex flex-col items-center">
-                <span className="text-white text-xl font-black tracking-tighter text-center leading-tight">
-                  {isAnyFolderSelected ? (
-                    t('gallery.selectionCombined', {
-                      folderCount: Array.from(selectedFiles).filter(k => k.startsWith('folder:')).length,
-                      fileCount: Array.from(selectedFiles).filter(k => !k.startsWith('folder:')).length
-                    })
-                  ) : (
-                    t('gallery.selectionSummary', { count: selectedFiles.size, type: t(`gallery.tabs.${activeTab}`) })
-                  )}
-                </span>
-                <span className="text-blue-400 text-[10px] font-black uppercase tracking-[0.3em] mt-0.5">
-                  {t('gallery.selectedLabel')}
-                </span>
-              </div>
-
-              {/* Delete Button */}
-              <div className="flex justify-end">
+                <span className="w-px h-[22px] bg-white/[0.08]" />
                 <button
                   onClick={handleDeleteClick}
                   disabled={selectedFiles.size === 0}
-                  className={`w-14 h-14 flex items-center justify-center rounded-full backdrop-blur-md border-2 transition-all active:scale-90 ${selectedFiles.size > 0
-                    ? 'bg-red-500/80 text-white border-red-500/40 shadow-lg shadow-red-500/20'
-                    : 'bg-white/5 text-white/10 border-white/5 grayscale pointer-events-none'
-                    }`}
+                  className="h-10 px-[18px] flex items-center gap-2 rounded-[10px] border text-[12.5px] font-semibold whitespace-nowrap transition-all active:scale-95 disabled:opacity-35"
+                  style={{ background: 'rgba(242,85,85,0.12)', borderColor: 'rgba(242,85,85,0.3)', color: '#f87c7c' }}
                 >
-                  <Trash2 className="h-6 w-6" />
+                  <Trash2 className="h-[15px] w-[15px]" strokeWidth={1.8} />
+                  {t('common.delete')}
                 </button>
               </div>
             </div>
           ) : (
-            // Normal Mode Footer - Responsive Alignment
-            <div className="flex items-center justify-between w-full flex-wrap gap-4 overflow-visible">
-              {/* Type Toggle Button - Larger */}
-              <div className="flex-shrink-0">
-                <button
-                  onClick={() => {
-                    setActiveTab(activeTab === 'images' ? 'videos' : 'images');
-                    window.scrollTo(0, 0);
-                  }}
-                  className="w-14 h-14 flex items-center justify-center rounded-full bg-white/10 backdrop-blur-md border-2 border-white/20 text-white hover:bg-white/20 active:scale-90 transition-all shadow-2xl"
-                >
-                  {activeTab === 'images' ? <Video className="h-6 w-6" /> : <ImageIcon className="h-6 w-6" />}
-                </button>
-              </div>
+            // Normal Mode: media-type toggle + INPUT/OUTPUT/TEMP segment control
+            <div className="flex items-center gap-2.5">
+              <button
+                onClick={() => {
+                  setActiveTab(activeTab === 'images' ? 'videos' : 'images');
+                  window.scrollTo(0, 0);
+                }}
+                className="w-11 h-11 shrink-0 flex items-center justify-center rounded-xl border border-white/10 text-[#c8ccd4] transition-all active:scale-95"
+                style={{ background: 'rgba(15,17,22,0.88)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
+              >
+                {activeTab === 'images' ? <Video className="h-[18px] w-[18px]" strokeWidth={1.8} /> : <ImageIcon className="h-[18px] w-[18px]" strokeWidth={1.8} />}
+              </button>
 
-              {/* Tab Switcher (Folders) - Centered or Right Aligned if narrow */}
-              <div className="flex bg-white/10 backdrop-blur-2xl rounded-full p-2 border border-white/20 shadow-2xl mx-auto sm:mx-auto ml-auto">
+              <div
+                className="flex-1 h-11 flex gap-[3px] p-1 rounded-xl border border-white/10"
+                style={{ background: 'rgba(15,17,22,0.88)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
+              >
                 {(['input', 'output', 'temp'] as FolderType[]).map((f) => (
                   <button
                     key={f}
@@ -1216,9 +1206,9 @@ export const OutputsGallery: React.FC<OutputsGalleryProps> = ({
                       setActiveFolder(f);
                       window.scrollTo(0, 0);
                     }}
-                    className={`px-8 py-3 rounded-full text-[11px] font-black uppercase tracking-widest transition-all active:scale-95 ${activeFolder === f
-                      ? 'bg-white text-black shadow-[0_10px_30px_rgba(255,255,255,0.3)]'
-                      : 'text-white hover:bg-white/10'
+                    className={`flex-1 rounded-lg font-mono text-[10px] tracking-[0.12em] uppercase transition-all active:scale-[0.98] ${activeFolder === f
+                      ? 'bg-[#e9ebef] text-[#0b0c0f] font-bold'
+                      : 'text-[#71798a] font-semibold hover:text-[#9aa3b2]'
                       }`}
                   >
                     {t(`gallery.folders.${f}`)}

--- a/src/components/media/VideoPreviewSection.tsx
+++ b/src/components/media/VideoPreviewSection.tsx
@@ -171,10 +171,10 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
 
   if (loading) {
     return (
-      <div className="p-4 bg-slate-100 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
+      <div className="p-4 bg-white/[0.06] rounded-lg border border-white/[0.08]">
         <div className="flex items-center space-x-3">
           <div className="animate-spin w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full"></div>
-          <span className="text-slate-600 dark:text-slate-400">{t('media.loading')} preview...</span>
+          <span className="text-[#8a919e]">{t('media.loading')} preview...</span>
         </div>
       </div>
     );
@@ -192,7 +192,7 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
               variant="outline"
               size="sm"
               onClick={loadVideo}
-              className="mt-2 text-red-600 border-red-300 hover:bg-red-50 dark:text-red-400 dark:border-red-700 dark:hover:bg-red-950/10"
+ className="mt-2 text-red-600 border-red-300 hover:bg-red-50 dark:text-red-400 dark:border-red-700 dark:hover:bg-red-950/10"
             >
               {t('media.retry')}
             </Button>
@@ -208,21 +208,21 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
 
   return (
     <div className="space-y-3">
-      <h4 className={`text-md font-medium flex items-center space-x-2 ${themeOverride?.text || 'text-slate-700 dark:text-slate-300'}`}>
+      <h4 className={`text-md font-medium flex items-center space-x-2 ${themeOverride?.text || 'text-[#c8ccd4]'}`}>
         <span>🎥</span>
         <span>{t('media.videoPreview')}</span>
         {nodeTitle && (
-          <span className="text-sm text-slate-500 dark:text-slate-400">({nodeTitle})</span>
+          <span className="text-sm text-[#71798a]">({nodeTitle})</span>
         )}
       </h4>
 
-      <div className={`rounded-lg overflow-hidden border ${themeOverride ? (themeOverride.container || 'bg-black/10 border-white/10') : 'bg-slate-100 dark:bg-slate-800 border-slate-200 dark:border-slate-700'}`}>
+      <div className={`rounded-lg overflow-hidden border ${themeOverride ? (themeOverride.container || 'bg-black/10 border-white/10') : 'bg-white/[0.06]  border-white/[0.08]'}`}>
         {/* Video Player */}
         <div className="relative bg-black">
           <video
             ref={videoRef}
             src={videoUrl}
-            className="w-full max-h-64 object-contain"
+ className="w-full max-h-64 object-contain"
             onTimeUpdate={handleTimeUpdate}
             onLoadedMetadata={handleLoadedMetadata}
             onEnded={() => setIsPlaying(false)}
@@ -235,7 +235,7 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
               <Button
                 size="lg"
                 onClick={handlePlayPause}
-                className="bg-white bg-opacity-90 hover:bg-opacity-100 text-black rounded-full p-4"
+ className="bg-white bg-opacity-90 hover:bg-opacity-100 text-black rounded-full p-4"
               >
                 <Play className="w-8 h-8" />
               </Button>
@@ -252,9 +252,9 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
               max={duration || 100}
               step={0.1}
               onValueChange={handleSeek}
-              className="w-full"
+ className="w-full"
             />
-            <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400">
+            <div className="flex justify-between text-xs text-[#71798a]">
               <span>{formatTime(currentTime)}</span>
               <span>{formatTime(duration)}</span>
             </div>
@@ -267,7 +267,7 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
                 variant="ghost"
                 size="sm"
                 onClick={handlePlayPause}
-                className={themeOverride?.secondaryText || "text-slate-600 dark:text-slate-400"}
+ className={themeOverride?.secondaryText || "text-[#8a919e]"}
               >
                 {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
               </Button>
@@ -276,7 +276,7 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
                 variant="ghost"
                 size="sm"
                 onClick={resetVideo}
-                className={themeOverride?.secondaryText || "text-slate-600 dark:text-slate-400"}
+ className={themeOverride?.secondaryText || "text-[#8a919e]"}
               >
                 <RotateCcw className="w-4 h-4" />
               </Button>
@@ -286,7 +286,7 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
                   variant="ghost"
                   size="sm"
                   onClick={toggleMute}
-                  className={themeOverride?.secondaryText || "text-slate-600 dark:text-slate-400"}
+ className={themeOverride?.secondaryText || "text-[#8a919e]"}
                 >
                   {isMuted ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
                 </Button>
@@ -297,7 +297,7 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
                     max={1}
                     step={0.1}
                     onValueChange={handleVolumeChange}
-                    className="w-full"
+ className="w-full"
                   />
                 </div>
               </div>
@@ -307,14 +307,14 @@ export const VideoPreviewSection: React.FC<VideoPreviewSectionProps> = ({
               variant="ghost"
               size="sm"
               onClick={toggleFullscreen}
-              className={themeOverride?.secondaryText || "text-slate-600 dark:text-slate-400"}
+ className={themeOverride?.secondaryText || "text-[#8a919e]"}
             >
               <Maximize2 className="w-4 h-4" />
             </Button>
           </div>
 
           {/* Video Info */}
-          <div className={`text-xs pt-2 border-t ${themeOverride ? `border-white/10 ${themeOverride.text || ''}` : 'text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-600'}`}>
+          <div className={`text-xs pt-2 border-t ${themeOverride ? `border-white/10 ${themeOverride.text || ''}` : 'text-[#71798a] border-white/[0.08] '}`}>
             <div className="flex justify-between items-center">
               <span className="truncate max-w-[200px] md:max-w-[300px]" title={videoPreview.filename}>
                 {t('media.file')}: {videoPreview.filename}

--- a/src/components/modals/FilePreviewModal.tsx
+++ b/src/components/modals/FilePreviewModal.tsx
@@ -244,13 +244,13 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
-          className={`${isCompact ? 'absolute h-full' : 'fixed h-[100dvh]'} top-0 left-0 right-0 bottom-0 z-[99999] bg-white dark:bg-slate-900 flex flex-col ${isCompact ? 'px-0 pt-0 pb-0' : ''} overflow-hidden`}
+ className={`${isCompact ? 'absolute h-full' : 'fixed h-[100dvh]'} top-0 left-0 right-0 bottom-0 z-[99999] bg-[#101217] flex flex-col ${isCompact ? 'px-0 pt-0 pb-0' : ''} overflow-hidden`}
         >
           {/* Header (Always Visible unless Compact) */}
           {!isCompact && (
-            <div className="flex items-center justify-between gap-3 flex-shrink-0 bg-white/80 dark:bg-slate-900/80 backdrop-blur-xl p-4 md:px-8 md:py-5 border-b border-slate-200 dark:border-slate-800 z-[100003] shadow-sm">
+            <div className="flex items-center justify-between gap-3 flex-shrink-0 bg-white/80 dark:bg-[#0b0c0f]/80 backdrop-blur-xl p-4 md:px-8 md:py-5 border-b border-white/[0.08] z-[100003] shadow-sm">
               <div className="flex items-center space-x-3 md:space-x-4 min-w-0 flex-1">
-                <div className={`p-2.5 rounded-2xl flex-shrink-0 shadow-sm ${isImage ? 'bg-blue-500/15 text-blue-500' : 'bg-purple-500/15 text-purple-500'}`}>
+                <div className={`p-2.5 rounded-xl flex-shrink-0 shadow-sm ${isImage ? 'bg-[#3069f0]/15 text-[#5b8af5]' : 'bg-[#9a8af0]/15 text-purple-500'}`}>
                   {isImage ? (
                     <Image className="w-5 h-5 md:w-6 md:h-6" />
                   ) : (
@@ -258,20 +258,20 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                   )}
                 </div>
                 <div className="min-w-0 flex-1">
-                  <h3 className="text-sm md:text-lg font-bold text-slate-800 dark:text-slate-100 truncate tracking-tight" title={filename}>
+                  <h3 className="text-[12px] md:text-[14px] font-bold text-[#e9ebef] truncate tracking-tight" title={filename}>
                     {filename}
                   </h3>
                   <div className="flex items-center flex-wrap gap-1.5 mt-1">
-                    <Badge variant="secondary" className="text-[10px] md:text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-none px-2">
+                    <Badge variant="secondary" className="text-[10px] md:text-xs font-medium bg-white/[0.06] text-[#8a919e] border-none px-2">
                       {getFileExtension(filename)}
                     </Badge>
                     {fileSize && (
-                      <Badge variant="secondary" className="text-[10px] md:text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-none px-2">
+                      <Badge variant="secondary" className="text-[10px] md:text-xs font-medium bg-white/[0.06] text-[#8a919e] border-none px-2">
                         {formatFileSize(fileSize)}
                       </Badge>
                     )}
                     {dimensions && (
-                      <Badge variant="secondary" className="text-[10px] md:text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-none px-2">
+                      <Badge variant="secondary" className="text-[10px] md:text-xs font-medium bg-white/[0.06] text-[#8a919e] border-none px-2">
                         {dimensions.width}×{dimensions.height}
                       </Badge>
                     )}
@@ -287,7 +287,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                       onClick={() => setShowInfo(!showInfo)}
                       variant="ghost"
                       size="sm"
-                      className="h-10 w-10 p-0 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400"
+ className="h-10 w-10 p-0 rounded-xl hover:bg-white/[0.06] dark:hover:bg-[#14171e] text-[#71798a]"
                       title={t('media.showFileInfo')}
                     >
                       <Info className="w-5 h-5" />
@@ -297,7 +297,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                       onClick={handleOpenInNewTab}
                       variant="ghost"
                       size="sm"
-                      className="h-10 w-10 p-0 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400"
+ className="h-10 w-10 p-0 rounded-xl hover:bg-white/[0.06] dark:hover:bg-[#14171e] text-[#71798a]"
                       title={t('media.openInNewTab')}
                     >
                       <ExternalLink className="w-5 h-5" />
@@ -308,7 +308,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                       disabled={isDownloading}
                       variant="ghost"
                       size="sm"
-                      className="h-10 px-3 md:px-4 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400 font-semibold"
+ className="h-10 px-3 md:px-4 rounded-xl hover:bg-white/[0.06] dark:hover:bg-[#14171e] text-[#71798a] font-semibold"
                       title={t('media.downloadFile')}
                     >
                       <Download className="w-5 h-5 md:mr-2" />
@@ -321,7 +321,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                   onClick={onClose}
                   variant="ghost"
                   size="sm"
-                  className="h-10 w-10 md:w-auto md:px-4 rounded-xl bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 font-bold"
+ className="h-10 w-10 md:w-auto md:px-4 rounded-xl bg-white/[0.06] text-[#8a919e] dark:text-[#c8ccd4] hover:bg-white/[0.08] font-bold"
                   title={t('common.close')}
                 >
                   <X className="w-5 h-5 md:mr-1.5" />
@@ -338,7 +338,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                 onClick={onClose}
                 variant="ghost"
                 size="sm"
-                className="h-10 w-10 p-0 rounded-full bg-black/20 hover:bg-black/40 backdrop-blur-md border border-white/20 text-white shadow-lg transition-all active:scale-90"
+ className="h-10 w-10 p-0 rounded-full bg-black/20 hover:bg-black/40 backdrop-blur-md border border-white/20 text-white shadow-lg transition-all active:scale-90"
                 title={t('common.close')}
               >
                 <X className="w-5 h-5" />
@@ -353,36 +353,36 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: 'auto', opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}
-                className="border-b border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-800/50 backdrop-blur-sm"
+ className="border-b border-white/[0.08] bg-white/[0.04]/50 dark:bg-[#14171e]/50 backdrop-blur-sm"
               >
                 <div className="p-4 md:px-8 space-y-3">
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-xs md:text-sm">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs md:text-[12px]">
                     <div>
-                      <span className="text-slate-500 dark:text-slate-500 uppercase font-black tracking-tighter">{t('media.type')}</span>
-                      <div className="text-slate-700 dark:text-slate-200 font-bold mt-0.5">{fileType || getFileExtension(filename)}</div>
+                      <span className="text-[#71798a] dark:text-[#71798a] uppercase font-black tracking-tighter">{t('media.type')}</span>
+                      <div className="text-[#c8ccd4] dark:text-[#d5d9e0] font-bold mt-0.5">{fileType || getFileExtension(filename)}</div>
                     </div>
                     {fileSize && (
                       <div>
-                        <span className="text-slate-500 dark:text-slate-500 uppercase font-black tracking-tighter">{t('media.size')}</span>
-                        <div className="text-slate-700 dark:text-slate-200 font-bold mt-0.5">{formatFileSize(fileSize)}</div>
+                        <span className="text-[#71798a] dark:text-[#71798a] uppercase font-black tracking-tighter">{t('media.size')}</span>
+                        <div className="text-[#c8ccd4] dark:text-[#d5d9e0] font-bold mt-0.5">{formatFileSize(fileSize)}</div>
                       </div>
                     )}
                     {dimensions && (
                       <div>
-                        <span className="text-slate-500 dark:text-slate-500 uppercase font-black tracking-tighter">{t('media.dimensions')}</span>
-                        <div className="text-slate-700 dark:text-slate-200 font-bold mt-0.5">{dimensions.width} × {dimensions.height}</div>
+                        <span className="text-[#71798a] dark:text-[#71798a] uppercase font-black tracking-tighter">{t('media.dimensions')}</span>
+                        <div className="text-[#c8ccd4] dark:text-[#d5d9e0] font-bold mt-0.5">{dimensions.width} × {dimensions.height}</div>
                       </div>
                     )}
                     {duration && (
                       <div>
-                        <span className="text-slate-500 dark:text-slate-500 uppercase font-black tracking-tighter">{t('media.duration')}</span>
-                        <div className="text-slate-700 dark:text-slate-200 font-bold mt-0.5">{formatDuration(duration)}</div>
+                        <span className="text-[#71798a] dark:text-[#71798a] uppercase font-black tracking-tighter">{t('media.duration')}</span>
+                        <div className="text-[#c8ccd4] dark:text-[#d5d9e0] font-bold mt-0.5">{formatDuration(duration)}</div>
                       </div>
                     )}
                   </div>
                   <div>
-                    <span className="text-slate-500 dark:text-slate-500 uppercase font-black tracking-tighter">{t('media.filename')}</span>
-                    <div className="text-slate-700 dark:text-slate-200 font-mono text-xs break-all mt-0.5 opacity-80">{filename}</div>
+                    <span className="text-[#71798a] dark:text-[#71798a] uppercase font-black tracking-tighter">{t('media.filename')}</span>
+                    <div className="text-[#c8ccd4] dark:text-[#d5d9e0] font-mono text-xs break-all mt-0.5 opacity-80">{filename}</div>
                   </div>
                 </div>
               </motion.div>
@@ -390,30 +390,30 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
           </AnimatePresence>
 
           {/* Content Area - No Padding for Full Experience */}
-          <div className="flex-1 relative overflow-hidden flex flex-col min-h-0 bg-slate-50 dark:bg-slate-950/20">
+          <div className="flex-1 relative overflow-hidden flex flex-col min-h-0 bg-black/20">
             {/* Loading Overlay */}
             {loading && (
-              <div className="absolute inset-0 z-[100004] flex items-center justify-center bg-white/40 dark:bg-slate-900/40 backdrop-blur-[2px]">
+              <div className="absolute inset-0 z-[100004] flex items-center justify-center bg-white/40 dark:bg-[#0b0c0f]/40 backdrop-blur-[2px]">
                 <div className="text-center">
-                  <div className="w-12 h-12 border-3 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-                  <p className="text-slate-600 dark:text-slate-300 text-sm font-bold tracking-tight">{t('media.loadingPreview')}</p>
+                  <div className="w-12 h-10 border-3 border-[#3069f0] border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+                  <p className="text-[#8a919e] dark:text-[#c8ccd4] text-[12px] font-bold tracking-tight">{t('media.loadingPreview')}</p>
                 </div>
               </div>
             )}
 
             {/* Error State */}
             {error && (
-              <div className="flex items-center justify-center flex-1 z-[100005] bg-white dark:bg-slate-900">
-                <div className="text-center p-6">
-                  <div className="w-20 h-20 bg-red-500/15 rounded-3xl flex items-center justify-center mx-auto mb-6">
-                    <X className="w-10 h-10 text-red-500" />
+              <div className="flex items-center justify-center flex-1 z-[100005] bg-[#101217]">
+                <div className="text-center p-4">
+                  <div className="w-20 h-20 bg-[#f25555]/15 rounded-xl flex items-center justify-center mx-auto mb-6">
+                    <X className="w-10 h-10 text-[#f25555]" />
                   </div>
-                  <p className="text-red-500 font-bold text-xl mb-2">{t('media.previewFailed')}</p>
-                  <p className="text-slate-500 dark:text-slate-400 mb-8 max-w-md mx-auto">{error}</p>
+                  <p className="text-[#f25555] font-bold text-[15px] mb-2">{t('media.previewFailed')}</p>
+                  <p className="text-[#71798a] mb-8 max-w-md mx-auto">{error}</p>
                   <Button
                     onClick={() => onRetry(filename)}
                     variant="outline"
-                    className="bg-slate-100 dark:bg-slate-800 border-none text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-700 px-8 py-6 rounded-2xl font-bold"
+ className="bg-white/[0.06] border-none text-[#c8ccd4] dark:text-[#d5d9e0] hover:bg-white/[0.08] px-8 py-6 rounded-xl font-bold"
                   >
                     {t('common.retry')}
                   </Button>
@@ -439,7 +439,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                         <img
                           src={url}
                           alt={filename}
-                          className="max-w-full max-h-full object-contain"
+ className="max-w-full max-h-full object-contain"
                           onError={handleImageError}
                         />
                       </TransformComponent>
@@ -449,7 +449,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                       src={`${url}#t=0.001`}
                       controls
                       preload="auto"
-                      className="max-w-full max-h-full object-contain"
+ className="max-w-full max-h-full object-contain"
                       onError={handleVideoError}
                       {...(isCompact ? { playsInline: true, "webkit-playsinline": "true" } : {})}
                     >
@@ -468,10 +468,10 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                         handlePrevious();
                       }}
                       disabled={currentIndex <= 0}
-                      className={`absolute left-4 md:left-8 top-1/2 -translate-y-1/2 z-[100006] w-14 h-14 md:w-20 md:h-20 flex items-center justify-center rounded-3xl bg-black/10 hover:bg-black/20 text-white backdrop-blur-xl border border-white/10 transition-all active:scale-90 shadow-2xl group disabled:opacity-0 disabled:pointer-events-none`}
+ className={`absolute left-4 md:left-8 top-1/2 -translate-y-1/2 z-[100006] w-14 h-10 md:w-20 md:h-20 flex items-center justify-center rounded-xl bg-black/10 hover:bg-black/20 text-white backdrop-blur-xl border border-white/10 transition-all active:scale-90 shadow-2xl group disabled:opacity-0 disabled:pointer-events-none`}
                       title={t('common.previous')}
                     >
-                      <ChevronLeft className="w-8 h-8 md:w-12 md:h-12 group-active:-translate-x-1 transition-transform" />
+                      <ChevronLeft className="w-8 h-8 md:w-12 md:h-10 group-active:-translate-x-1 transition-transform" />
                     </button>
 
                     {/* Next Button */}
@@ -481,10 +481,10 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
                         handleNext();
                       }}
                       disabled={currentIndex >= files.length - 1}
-                      className={`absolute right-4 md:right-8 top-1/2 -translate-y-1/2 z-[100006] w-14 h-14 md:w-20 md:h-20 flex items-center justify-center rounded-3xl bg-black/10 hover:bg-black/20 text-white backdrop-blur-xl border border-white/10 transition-all active:scale-90 shadow-2xl group disabled:opacity-0 disabled:pointer-events-none`}
+ className={`absolute right-4 md:right-8 top-1/2 -translate-y-1/2 z-[100006] w-14 h-10 md:w-20 md:h-20 flex items-center justify-center rounded-xl bg-black/10 hover:bg-black/20 text-white backdrop-blur-xl border border-white/10 transition-all active:scale-90 shadow-2xl group disabled:opacity-0 disabled:pointer-events-none`}
                       title={t('common.next')}
                     >
-                      <ChevronRight className="w-8 h-8 md:w-12 md:h-12 group-active:translate-x-1 transition-transform" />
+                      <ChevronRight className="w-8 h-8 md:w-12 md:h-10 group-active:translate-x-1 transition-transform" />
                     </button>
                   </>
                 )}

--- a/src/components/modals/JsonViewerModal.tsx
+++ b/src/components/modals/JsonViewerModal.tsx
@@ -291,46 +291,36 @@ export const JsonViewerModal: React.FC<JsonViewerModalProps> = ({
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 15 }}
             transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-            className={`relative pwa-modal ${isCompact ? 'w-[95vw] max-w-[384px] h-[85vh] max-h-[480px]' : 'w-[90vw] h-[85vh]'} pointer-events-auto flex flex-col`}
+            className={`relative pwa-modal ${isCompact ? 'w-[92vw] max-w-[360px] h-[78vh] max-h-[440px]' : 'w-[92vw] max-w-2xl h-[78vh]'} pointer-events-auto flex flex-col`}
             onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
             onTouchStart={(e) => e.stopPropagation()}
           >
             <div
-              style={{ backgroundColor: '#374151' }}
-              className={`relative w-full h-full ${isCompact ? 'rounded-2xl' : 'rounded-[40px]'} shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white`}
+              style={{ backgroundColor: '#101217' }}
+              className={`relative w-full h-full ${isCompact ? 'rounded-xl' : 'rounded-xl'} shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white`}
             >
-              <div className="absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] pt-2 pb-[13px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10">
-                <div className="absolute right-4 top-1/2 -translate-y-1/2 flex-shrink-0 scale-75">
-                  <button onClick={onClose} className="p-2 rounded-full bg-black/20 text-white hover:bg-black/40 transition-all pointer-events-auto">
-                    <X className="w-5 h-5" />
+              <div className="absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b h-11 pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]">
+                <div className="absolute right-3 top-1/2 -translate-y-1/2 flex-shrink-0">
+                  <button onClick={onClose} className="p-1.5 rounded-lg bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1] transition-all pointer-events-auto">
+                    <X className="w-4 h-4" />
                   </button>
                 </div>
 
-                <div className="flex flex-col justify-center flex-1 min-w-0 pointer-events-none">
-                  <div className="flex items-center space-x-2 mb-1 scale-90 origin-left">
-                    <Badge variant="secondary" className="text-[10px] font-mono px-2 py-0.5 rounded-full bg-black/20 text-white/80 border-transparent">
-                      VIEWER
-                    </Badge>
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">
-                      {isProcessing ? t('jsonViewer.processingJson') :
-                        `${isTooLarge ? 'MASSIVE' : jsonString.split('\n').length} LINES • ${(fileSize / 1024).toFixed(1)} KB`
-                      }
-                    </span>
-                  </div>
-                  <div className="flex items-center min-w-0 h-[13px]">
-                    <h2
-                      style={{ fontSize: baseTitleSize, lineHeight: '1', transform: `scale(${0.8125 / 1.875})`, transformOrigin: 'left center' }}
-                      className="font-extrabold tracking-tight leading-tight text-white/95 truncate pr-4"
-                    >
-                      {title}
-                    </h2>
-                  </div>
+                <div className="flex items-center gap-2 flex-1 min-w-0 pointer-events-none">
+                  <h2 className="text-[14px] font-bold text-[#e9ebef] truncate">
+                    {title}
+                  </h2>
+                  <span className="font-mono text-[9px] font-semibold text-[#565d6b] tracking-[0.1em] px-1.5 py-0.5 rounded-md bg-black/20 shrink-0 whitespace-nowrap">
+                    {isProcessing ? t('jsonViewer.processingJson') :
+                      `${isTooLarge ? 'MASSIVE' : jsonString.split('\n').length}L · ${(fileSize / 1024).toFixed(1)}KB`
+                    }
+                  </span>
                 </div>
               </div>
 
-              <div className="absolute left-0 w-full z-20 px-4 top-[68px]">
-                <div className="flex bg-[#374151]/90 backdrop-blur-xl p-2 rounded-2xl border border-white/10 shadow-2xl items-center gap-2">
+              <div className="absolute left-0 w-full z-20 px-3 top-[52px]">
+                <div className="flex bg-[#101217]/90 backdrop-blur-xl p-1.5 rounded-[10px] border border-white/[0.08] shadow-xl items-center gap-1.5">
                   <div className="relative flex-[2] min-w-0">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
                     <input
@@ -340,10 +330,10 @@ export const JsonViewerModal: React.FC<JsonViewerModalProps> = ({
                       onChange={(e) => { if (!e.target.value) { setActiveSearchQuery(''); setCurrentMatchIndex(0); } }}
                       onKeyDown={(e) => { if (e.key === 'Enter') handleSearch(); }}
                       placeholder={isTooLarge ? t('jsonViewer.searchDisabled') : t('jsonViewer.searchPlaceholder')}
-                      className={`w-full bg-black/40 border-white/10 text-xs text-white/90 placeholder:text-white/20 h-10 pl-9 pr-8 rounded-xl focus:outline-none transition-all duration-300 border shadow-inner ${isTooLarge ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      className={`w-full bg-white/[0.045] border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] h-8 pl-8 pr-8 rounded-lg text-[12px] focus:outline-none focus:border-[#3069f0]/50 transition-all duration-300 border ${isTooLarge ? 'opacity-50 cursor-not-allowed' : ''}`}
                     />
                     {searchMatches.length > 0 && !isTooLarge && (
-                      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5 bg-black/40 rounded-lg px-2 py-1 border border-white/5">
+                      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5 bg-black/40 rounded-md px-1.5 py-0.5 border border-white/[0.06]">
                         <span className="text-[10px] font-mono text-white/60">
                           {currentMatchIndex + 1}/{searchMatches.length}
                         </span>
@@ -356,43 +346,43 @@ export const JsonViewerModal: React.FC<JsonViewerModalProps> = ({
                       disabled={isCopying || isProcessing || isTooLarge}
                       variant="ghost"
                       size="sm"
-                      className="flex-1 h-10 min-w-[40px] px-2 bg-white/5 text-white/60 hover:bg-white/10 hover:text-white border border-white/5 rounded-xl transition-all flex items-center justify-center"
+                      className="flex-1 h-7 min-w-[32px] px-2 bg-white/[0.04] text-[#8a919e] hover:bg-white/[0.07] hover:text-[#c8ccd4] border border-white/[0.07] rounded-lg transition-all flex items-center justify-center"
                       title={t('jsonViewer.copy')}
                     >
-                      {isCopying ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Copy className="w-4 h-4" />}
-                      <span className="hidden sm:inline-block ml-1.5 text-[10px] font-bold uppercase tracking-wider">{t('jsonViewer.copy')}</span>
+                      {isCopying ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Copy className="w-3.5 h-3.5" />}
+                      <span className="hidden sm:inline-block ml-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.1em]">{t('jsonViewer.copy')}</span>
                     </Button>
                     <Button
                       onClick={handleDownload}
                       disabled={isProcessing}
                       variant="ghost"
                       size="sm"
-                      className="flex-1 h-10 min-w-[40px] px-2 bg-white/5 text-white/60 hover:bg-white/10 hover:text-white border border-white/5 rounded-xl transition-all flex items-center justify-center"
+                      className="flex-1 h-7 min-w-[32px] px-2 bg-white/[0.04] text-[#8a919e] hover:bg-white/[0.07] hover:text-[#c8ccd4] border border-white/[0.07] rounded-lg transition-all flex items-center justify-center"
                       title={t('jsonViewer.download')}
                     >
-                      <Download className="w-4 h-4" />
-                      <span className="hidden sm:inline-block ml-1.5 text-[10px] font-bold uppercase tracking-wider">{t('jsonViewer.download')}</span>
+                      <Download className="w-3.5 h-3.5" />
+                      <span className="hidden sm:inline-block ml-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.1em]">{t('jsonViewer.download')}</span>
                     </Button>
                   </div>
                 </div>
               </div>
 
               <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
-                <div className="h-[185px] relative pointer-events-none" />
+                <div className="h-[104px] relative pointer-events-none" />
                 <div className="px-5 pb-6 sm:px-6">
                   {isProcessing ? (
                     <div className="flex flex-col items-center justify-center py-20 space-y-4">
                       <div className="relative">
                         <Loader2 className="h-10 w-10 animate-spin text-white/20" />
-                        <Sparkles className="absolute -top-1 -right-1 h-4 w-4 text-violet-400/50 animate-pulse" />
+                        <Sparkles className="absolute -top-1 -right-1 h-4 w-4 text-[#5b8af5]/50 animate-pulse" />
                       </div>
                       <p className="text-xs font-medium tracking-wide text-white/40 uppercase">{t('jsonViewer.processingJson')}</p>
                     </div>
                   ) : (
                     <div className="relative group">
-                      <div className="absolute -inset-4 bg-gradient-to-br from-violet-500/5 to-transparent rounded-[32px] opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+                      <div className="absolute -inset-4 bg-gradient-to-br from-[#3069f0]/5 to-transparent rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
                       {isTooLarge ? (
-                        <div className="flex flex-col items-center justify-center py-20 px-6 text-center bg-black/40 backdrop-blur-md rounded-[32px] border border-white/10 shadow-2xl space-y-6">
+                        <div className="flex flex-col items-center justify-center py-20 px-6 text-center bg-black/40 backdrop-blur-md rounded-xl border border-white/10 shadow-2xl space-y-6">
                           <div className="relative">
                             <div className="absolute -inset-4 bg-amber-500/20 blur-2xl rounded-full" />
                             <AlertTriangle className="h-16 w-16 text-amber-400 relative" />
@@ -404,7 +394,7 @@ export const JsonViewerModal: React.FC<JsonViewerModalProps> = ({
                             </p>
                           </div>
                           <div className="flex flex-col w-full gap-3 pt-4">
-                            <Button onClick={handleDownload} className="h-12 bg-violet-600 hover:bg-violet-500 text-white font-bold rounded-2xl shadow-lg transition-all active:scale-95 flex items-center justify-center gap-2">
+                            <Button onClick={handleDownload} className="h-12 bg-[#3069f0] hover:bg-[#3f78f5] text-white font-bold rounded-[10px] shadow-lg transition-all active:scale-95 flex items-center justify-center gap-2">
                               <Download className="w-5 h-5" />
                               {t('jsonViewer.downloadToView')}
                             </Button>
@@ -412,7 +402,7 @@ export const JsonViewerModal: React.FC<JsonViewerModalProps> = ({
                           </div>
                         </div>
                       ) : (
-                        <pre ref={preRef} className="relative text-xs font-mono bg-black/20 backdrop-blur-sm rounded-3xl p-6 overflow-auto text-white/80 leading-relaxed border border-white/5 shadow-inner" dangerouslySetInnerHTML={{ __html: activeSearchQuery ? highlightedJsonString : jsonString }} />
+                        <pre ref={preRef} className="relative text-[10.5px] font-mono bg-[#08090c] rounded-[10px] p-3 overflow-auto text-[#9aa3b2] leading-relaxed border border-white/[0.06]" dangerouslySetInnerHTML={{ __html: activeSearchQuery ? highlightedJsonString : jsonString }} />
                       )}
                     </div>
                   )}
@@ -422,16 +412,16 @@ export const JsonViewerModal: React.FC<JsonViewerModalProps> = ({
               <AnimatePresence>
                 {searchMatches.length > 0 && activeSearchQuery && !isTooLarge && (
                   <motion.div initial={{ opacity: 0, scale: 0.8, y: 20 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.8, y: 20 }} className="absolute bottom-8 right-8 z-50 flex flex-col gap-3">
-                    <div className="flex flex-col gap-2 p-2 bg-black/40 backdrop-blur-xl rounded-2xl border border-white/10 shadow-2xl">
-                      <Button onClick={handlePreviousMatch} variant="ghost" size="sm" className="w-12 h-12 rounded-xl bg-white/5 text-white/80 hover:bg-white/10 hover:text-white border border-white/5 flex items-center justify-center p-0 transition-all active:scale-90">
+                    <div className="flex flex-col gap-1.5 p-1.5 bg-[#0f1116]/90 backdrop-blur-xl rounded-[10px] border border-white/10 shadow-xl">
+                      <Button onClick={handlePreviousMatch} variant="ghost" size="sm" className="w-10 h-10 rounded-lg bg-white/[0.05] text-[#c8ccd4] hover:bg-white/[0.09] hover:text-white border border-white/[0.07] flex items-center justify-center p-0 transition-all active:scale-90">
                         <ChevronUp className="w-6 h-6" />
                       </Button>
                       <div className="h-px bg-white/5 mx-2" />
-                      <Button onClick={handleNextMatch} variant="ghost" size="sm" className="w-12 h-12 rounded-xl bg-white/5 text-white/80 hover:bg-white/10 hover:text-white border border-white/5 flex items-center justify-center p-0 transition-all active:scale-90">
+                      <Button onClick={handleNextMatch} variant="ghost" size="sm" className="w-10 h-10 rounded-lg bg-white/[0.05] text-[#c8ccd4] hover:bg-white/[0.09] hover:text-white border border-white/[0.07] flex items-center justify-center p-0 transition-all active:scale-90">
                         <ChevronDown className="w-6 h-6" />
                       </Button>
                     </div>
-                    <motion.div layout className="bg-violet-600 text-white text-[10px] font-bold px-3 py-1.5 rounded-full shadow-lg border border-violet-400/30 flex items-center justify-center min-w-[50px] self-center">
+                    <motion.div layout className="bg-[#3069f0] text-white font-mono text-[10px] font-bold px-2.5 py-1 rounded-md shadow-lg flex items-center justify-center min-w-[50px] self-center">
                       {currentMatchIndex + 1} / {searchMatches.length}
                     </motion.div>
                   </motion.div>

--- a/src/components/modals/MissingModelDetectorModal.tsx
+++ b/src/components/modals/MissingModelDetectorModal.tsx
@@ -32,7 +32,7 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [isHeaderCompact, setIsHeaderCompact] = useState(false);
 
-  const baseTitleSize = '1.5rem';
+  const baseTitleSize = '1.125rem';
 
   useEffect(() => {
     if (isOpen) {
@@ -98,20 +98,20 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.96, y: 15 }}
           transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-          className="relative w-[90vw] h-[85vh] pointer-events-auto flex flex-col"
+          className="relative w-[92vw] max-w-lg h-[76vh] pointer-events-auto flex flex-col"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Main Card */}
           <div
-            style={{ backgroundColor: '#374151' }}
-            className="relative w-full h-full rounded-[40px] shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white"
+            style={{ backgroundColor: '#101217' }}
+            className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
             {/* Dynamic Sticky Header */}
             <div
               className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] transition-all duration-300 ease-in-out
                 ${isHeaderCompact
-                  ? 'pt-2 pb-[11px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10'
-                  : 'pt-5 pb-5 pl-6 pr-16 border-transparent bg-black/20 backdrop-blur-0'
+                  ? 'pt-1.5 pb-[11px] pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]'
+                  : 'pt-4 pb-3.5 pl-4 pr-12 border-transparent bg-black/20 backdrop-blur-0'
                 }`}
             >
               {/* Floating Close Button */}
@@ -120,7 +120,7 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
               >
                 <button
                   onClick={onClose}
-                  className="p-1.5 rounded-full bg-black/20 text-white hover:bg-black/40 transition-all pointer-events-auto"
+                  className="p-1.5 rounded-lg bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1] transition-all pointer-events-auto"
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -128,15 +128,15 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
 
               <div className="flex flex-col justify-center flex-1 min-w-0 pointer-events-none">
                 <div className={`flex items-center space-x-2 transition-all duration-300 origin-left ${isHeaderCompact ? 'mb-0.5 scale-90' : 'mb-2 scale-100'}`}>
-                  <Badge variant="secondary" className="text-[9px] font-mono px-1.5 py-0.5 rounded-full bg-black/20 text-white/80 border-transparent">
+                  <Badge variant="secondary" className="text-[9px] font-mono px-1.5 py-0.5 rounded-md bg-black/20 text-white/80 border-transparent">
                     SYSTEM
                   </Badge>
-                  <span className="text-[9px] font-bold uppercase tracking-widest text-white/60">
+                  <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-white/60">
                     {t('missingModels.title')}
                   </span>
                 </div>
 
-                <div className="flex items-center min-w-0 transition-all duration-300" style={{ height: isHeaderCompact ? '11px' : '1.75rem' }}>
+                <div className="flex items-center min-w-0 transition-all duration-300" style={{ height: isHeaderCompact ? '12px' : '1.125rem' }}>
                   <h2
                     style={{
                       fontSize: baseTitleSize,
@@ -155,18 +155,18 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
             {/* Content Area */}
             <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
               {/* Static Top Bumper */}
-              <div className="h-[120px] relative pointer-events-none">
+              <div className="h-[96px] relative pointer-events-none">
                 <div ref={sentinelRef} className="absolute top-[10px] left-0 h-px w-full" />
               </div>
 
               <div className="px-5 pb-6 sm:px-6">
                 {missingModels.length === 0 ? (
-                  <div className="text-center py-16 rounded-[32px] bg-black/10 border border-dashed border-white/10">
+                  <div className="text-center py-16 rounded-xl bg-black/10 border border-dashed border-white/10">
                     <div className="relative mb-4">
-                      <Package className="h-12 w-12 text-white/10 mx-auto" />
-                      <Sparkles className="absolute top-0 right-1/2 translate-x-10 h-5 w-5 text-violet-400/30 animate-pulse" />
+                      <Package className="h-10 w-12 text-white/10 mx-auto" />
+                      <Sparkles className="absolute top-0 right-1/2 translate-x-10 h-5 w-5 text-[#5b8af5]/30 animate-pulse" />
                     </div>
-                    <p className="text-base font-medium text-white/60">
+                    <p className="text-[13px] font-medium text-white/60">
                       {t('missingModels.noMissingModels')}
                     </p>
                     <p className="text-xs text-white/30 mt-1">
@@ -176,10 +176,10 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
                 ) : (
                   <div className="space-y-5">
                     {/* Warning Banner */}
-                    <div className="p-4 rounded-[20px] bg-yellow-500/10 border border-yellow-500/20">
+                    <div className="p-4 rounded-[20px] bg-[#ffa348]/10 border border-yellow-500/20">
                       <div className="flex items-start gap-3">
-                        <div className="p-1.5 rounded-lg bg-yellow-500/20">
-                          <AlertTriangle className="h-4 w-4 text-yellow-400" />
+                        <div className="p-1.5 rounded-lg bg-[#ffa348]/20">
+                          <AlertTriangle className="h-4 w-4 text-[#ffa348]" />
                         </div>
                         <div className="flex-1">
                           <p className="text-xs font-bold text-yellow-200">
@@ -209,11 +209,11 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
                               <div className="flex items-start justify-between">
                                 <div className="flex-1 min-w-0">
                                   <div className="flex items-center gap-3 mb-2">
-                                    <div className={`p-2.5 rounded-xl bg-black/20 border border-white/5 transition-colors ${isExpanded ? 'text-violet-400 border-violet-500/20' : 'text-white/40'}`}>
+                                    <div className={`p-2.5 rounded-xl bg-black/20 border border-white/5 transition-colors ${isExpanded ? 'text-[#5b8af5] border-[#3069f0]/20' : 'text-white/40'}`}>
                                       <Package className="h-4 w-4" />
                                     </div>
                                     <div className="min-w-0">
-                                      <h3 className="text-sm font-bold text-white/95 break-all leading-tight mb-0.5">
+                                      <h3 className="text-[12px] font-bold text-white/95 break-all leading-tight mb-0.5">
                                         {modelName}
                                       </h3>
                                       <Badge variant="outline" className="bg-white/5 text-white/40 border-white/10 text-[8px] font-bold tracking-widest uppercase px-1 py-0 h-4">
@@ -282,7 +282,7 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
                                             </p>
                                             {widgetEditor.getWidgetValue(info.nodeId, info.widgetName, null) &&
                                               widgetEditor.getWidgetValue(info.nodeId, info.widgetName, null) !== info.missingModel && (
-                                                <Badge className="bg-emerald-500/20 text-emerald-300 border-emerald-500/30 text-[8px] h-3.5">
+                                                <Badge className="bg-[#34c77b]/20 text-emerald-300 border-emerald-500/30 text-[8px] h-3.5">
                                                   SAVED
                                                 </Badge>
                                               )}
@@ -307,7 +307,7 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
 
                                           {widgetEditor.getWidgetValue(info.nodeId, info.widgetName, null) &&
                                             widgetEditor.getWidgetValue(info.nodeId, info.widgetName, null) !== info.missingModel && (
-                                              <p className="text-[9px] font-medium text-emerald-400 animate-in fade-in slide-in-from-left-1">
+                                              <p className="text-[9px] font-medium text-[#4ade80] animate-in fade-in slide-in-from-left-1">
                                                 ✓ {t('missingModels.replacementSelected', { value: widgetEditor.getWidgetValue(info.nodeId, info.widgetName, null) })}
                                               </p>
                                             )}
@@ -324,10 +324,10 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
                     </div>
 
                     {/* Instructions */}
-                    <div className="p-5 rounded-[24px] bg-blue-500/10 border border-blue-500/20">
+                    <div className="p-5 rounded-[24px] bg-[#3069f0]/10 border border-[#3069f0]/20">
                       <div className="flex items-start gap-4">
-                        <div className="p-1.5 rounded-lg bg-blue-500/20">
-                          <Info className="h-4 w-4 text-blue-400" />
+                        <div className="p-1.5 rounded-lg bg-[#3069f0]/20">
+                          <Info className="h-4 w-4 text-[#5b8af5]" />
                         </div>
                         <div className="flex-1">
                           <p className="text-xs font-bold text-blue-200 mb-2">
@@ -336,7 +336,7 @@ const MissingModelDetectorModal: React.FC<MissingModelDetectorModalProps> = ({
                           <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
                             {[1, 2, 3, 4].map((step) => (
                               <div key={step} className="flex gap-2">
-                                <span className="flex-shrink-0 w-4 h-4 rounded-full bg-blue-500/20 flex items-center justify-center text-[9px] font-bold text-blue-300 border border-blue-500/30">
+                                <span className="flex-shrink-0 w-4 h-4 rounded-full bg-[#3069f0]/20 flex items-center justify-center text-[9px] font-bold text-[#7ba3f5] border border-[#3069f0]/30">
                                   {step}
                                 </span>
                                 <p className="text-[10px] text-blue-100/60 leading-tight">

--- a/src/components/modals/MissingNodeInstallerModal.tsx
+++ b/src/components/modals/MissingNodeInstallerModal.tsx
@@ -68,7 +68,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
   const [isConsoleOpen, setIsConsoleOpen] = useState(false);
   const logContainerRef = useRef<HTMLDivElement>(null);
 
-  const baseTitleSize = '1.5rem';
+  const baseTitleSize = '1.125rem';
 
   const installablePackages = useMemo(
     () => packages.filter((pkg) => pkg.isInstallable),
@@ -392,11 +392,11 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex-1 min-w-0 space-y-3">
             <div className="flex flex-wrap items-center gap-2.5">
-              <div className="p-2.5 rounded-xl bg-black/20 border border-white/5 text-white/40 group-hover:text-violet-400 transition-colors">
+              <div className="p-2.5 rounded-xl bg-black/20 border border-white/5 text-white/40 group-hover:text-[#5b8af5] transition-colors">
                 <Box className="h-4 w-4" />
               </div>
               <div className="min-w-0">
-                <h3 className="text-sm font-bold text-white/95 break-all leading-tight mb-0.5">
+                <h3 className="text-[12px] font-bold text-white/95 break-all leading-tight mb-0.5">
                   {pkg.packName ?? pkg.packId}
                 </h3>
                 <div className="flex flex-wrap items-center gap-1.5">
@@ -404,7 +404,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
                     {getStatusLabel()}
                   </Badge>
                   {pkg.isUpdateAvailable && (
-                    <Badge variant="destructive" className="bg-red-500/10 text-red-400 border-red-500/20 text-[8px] font-bold tracking-widest uppercase px-1 py-0 h-4">
+                    <Badge variant="destructive" className="bg-[#f25555]/10 text-[#f87c7c] border-[#f25555]/20 text-[8px] font-bold tracking-widest uppercase px-1 py-0 h-4">
                       {t('missingNodes.updateAvailable')}
                     </Badge>
                   )}
@@ -474,7 +474,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
                 <SelectTrigger className="h-10 rounded-xl border-white/10 bg-black/30 text-white/80 text-xs">
                   <SelectValue placeholder={t('missingNodes.selectVersion')} />
                 </SelectTrigger>
-                <SelectContent className="z-[130] bg-slate-900 border-white/10 text-white">
+                <SelectContent className="z-[130] bg-[#0b0c0f] border-white/10 text-white">
                   {pkg.availableVersions.map((version) => (
                     <SelectItem key={version} value={version}>{version}</SelectItem>
                   ))}
@@ -484,7 +484,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
             <Button
               variant="outline"
               className={`h-10 rounded-xl border transition-all active:scale-95 text-xs ${state.isInstalling
-                ? 'bg-violet-500/10 border-violet-500/30 text-violet-400'
+                ? 'bg-[#3069f0]/10 border-[#3069f0]/30 text-[#5b8af5]'
                 : 'bg-white/5 border-white/10 text-white/80 hover:bg-white/10 hover:text-white'}`}
               disabled={!pkg.isInstallable || state.isInstalling}
               onClick={() => handleInstallPackage(pkg)}
@@ -523,20 +523,20 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.96, y: 15 }}
           transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-          className="relative w-[90vw] h-[85vh] pointer-events-auto flex flex-col"
+          className="relative w-[92vw] max-w-lg h-[76vh] pointer-events-auto flex flex-col"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Main Card */}
           <div
-            style={{ backgroundColor: '#374151' }}
-            className="relative w-full h-full rounded-[40px] shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white"
+            style={{ backgroundColor: '#101217' }}
+            className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
             {/* Dynamic Sticky Header */}
             <div
               className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] transition-all duration-300 ease-in-out
                 ${isHeaderCompact
-                  ? 'pt-2 pb-[13px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10'
-                  : 'pt-6 pb-6 pl-6 pr-16 border-transparent bg-black/20 backdrop-blur-0'
+                  ? 'pt-1.5 pb-[11px] pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]'
+                  : 'pt-4 pb-3.5 pl-4 pr-12 border-transparent bg-black/20 backdrop-blur-0'
                 }`}
             >
               {/* Floating Close Button */}
@@ -545,23 +545,23 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
               >
                 <button
                   onClick={onClose}
-                  className="p-1.5 rounded-full bg-black/20 text-white hover:bg-black/40 transition-all pointer-events-auto"
+                  className="p-1.5 rounded-lg bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1] transition-all pointer-events-auto"
                 >
                   <X className="w-4 h-4" />
                 </button>
               </div>
 
               <div className="flex flex-col justify-center flex-1 min-w-0 pointer-events-none">
-                <div className={`flex items-center space-x-2 transition-all duration-300 origin-left ${isHeaderCompact ? 'mb-1 scale-90' : 'mb-3 scale-100'}`}>
-                  <Badge variant="secondary" className="text-[9px] font-mono px-1.5 py-0.5 rounded-full bg-black/20 text-white/80 border-transparent">
+                <div className={`flex items-center space-x-2 transition-all duration-300 origin-left ${isHeaderCompact ? 'mb-0.5 scale-90' : 'mb-2 scale-100'}`}>
+                  <Badge variant="secondary" className="text-[9px] font-mono px-1.5 py-0.5 rounded-md bg-black/20 text-white/80 border-transparent">
                     INSTALLER
                   </Badge>
-                  <span className="text-[9px] font-bold uppercase tracking-widest text-white/60">
+                  <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-white/60">
                     {t('missingNodes.title')}
                   </span>
                 </div>
 
-                <div className="flex items-center min-w-0 transition-all duration-300" style={{ height: isHeaderCompact ? '11px' : '1.75rem' }}>
+                <div className="flex items-center min-w-0 transition-all duration-300" style={{ height: isHeaderCompact ? '12px' : '1.125rem' }}>
                   <h2
                     style={{
                       fontSize: baseTitleSize,
@@ -580,15 +580,15 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
             {/* Content Area */}
             <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
               {/* Static Top Bumper */}
-              <div className="h-[120px] relative pointer-events-none">
+              <div className="h-[96px] relative pointer-events-none">
                 <div ref={sentinelRef} className="absolute top-[10px] left-0 h-px w-full" />
               </div>
 
               <div className="px-5 pb-6 sm:px-6 space-y-5">
                 {isLoading && (
-                  <div className="flex flex-col items-center justify-center py-16 rounded-[32px] bg-black/10 border border-white/5">
+                  <div className="flex flex-col items-center justify-center py-16 rounded-xl bg-black/10 border border-white/5">
                     <div className="relative">
-                      <Loader2 className="h-10 w-10 text-violet-400 animate-spin" />
+                      <Loader2 className="h-10 w-10 text-[#5b8af5] animate-spin" />
                       <Sparkles className="absolute -top-1 -right-1 h-4 w-4 text-violet-300/50 animate-pulse" />
                     </div>
                     <p className="mt-5 text-[10px] font-bold text-white/40 uppercase tracking-widest">{t('missingNodes.loading')}</p>
@@ -596,18 +596,18 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
                 )}
 
                 {!isLoading && error && (
-                  <div className="p-4 rounded-[20px] bg-red-500/10 border border-red-500/20 flex gap-3 items-start">
-                    <div className="p-1.5 rounded-lg bg-red-500/20">
-                      <AlertCircle className="h-4 w-4 text-red-400" />
+                  <div className="p-4 rounded-[20px] bg-[#f25555]/10 border border-[#f25555]/20 flex gap-3 items-start">
+                    <div className="p-1.5 rounded-lg bg-[#f25555]/20">
+                      <AlertCircle className="h-4 w-4 text-[#f87c7c]" />
                     </div>
                     <p className="text-xs font-medium text-red-200 mt-0.5">{error}</p>
                   </div>
                 )}
 
                 {!isLoading && !error && packages.length === 0 && (
-                  <div className="text-center py-16 rounded-[32px] bg-black/10 border border-dashed border-white/10">
-                    <Box className="h-12 w-12 text-white/10 mx-auto mb-4" />
-                    <p className="text-base font-medium text-white/60">{t('missingNodes.allAvailable')}</p>
+                  <div className="text-center py-16 rounded-xl bg-black/10 border border-dashed border-white/10">
+                    <Box className="h-10 w-12 text-white/10 mx-auto mb-4" />
+                    <p className="text-[13px] font-medium text-white/60">{t('missingNodes.allAvailable')}</p>
                   </div>
                 )}
 
@@ -628,7 +628,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
                     >
                       <div className="px-4 py-2 bg-white/5 border-b border-white/5 flex items-center justify-between">
                         <div className="flex items-center gap-2">
-                          <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
+                          <div className="w-2 h-2 rounded-full bg-[#34c77b] animate-pulse" />
                           <span className="text-[10px] font-bold text-white/40 uppercase tracking-widest">Installation Console</span>
                         </div>
                         <button
@@ -647,7 +647,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
                         ) : (
                           logMessages.map((log, i) => (
                             <div key={i} className="text-white/60 mb-1 break-all">
-                              <span className="text-violet-400/50 mr-2">[{new Date().toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })}]</span>
+                              <span className="text-[#5b8af5]/50 mr-2">[{new Date().toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })}]</span>
                               {log.m}
                             </div>
                           ))
@@ -660,21 +660,21 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
             </div>
 
             {/* Sticky Footer Actions */}
-            <div className="px-6 py-4 border-t border-white/10 bg-black/30 backdrop-blur-xl flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="px-3 py-2 border-t border-white/10 bg-black/30 backdrop-blur-xl flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-[9px] font-bold uppercase tracking-widest text-white/40">
                 {queueStatus ? (
                   queueStatus.status === 'in_progress' ? (
                     <span className="flex items-center gap-2.5">
-                      <Loader2 className="h-3 w-3 animate-spin text-violet-400" />
+                      <Loader2 className="h-3 w-3 animate-spin text-[#5b8af5]" />
                       {t('missingNodes.installing')}
                       {typeof queueStatus.doneCount === 'number' && (
-                        <span className="text-violet-400">
+                        <span className="text-[#5b8af5]">
                           {queueStatus.doneCount}/{queueStatus.totalCount}
                         </span>
                       )}
                     </span>
                   ) : (
-                    <span className="text-emerald-400 flex items-center gap-1.5">
+                    <span className="text-[#4ade80] flex items-center gap-1.5">
                       <Sparkles className="h-3.5 w-3.5" /> {t('missingNodes.queueCompleted')}
                     </span>
                   )
@@ -695,7 +695,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
                 </Button>
                 <Button
                   variant="outline"
-                  className="h-10 px-5 rounded-xl border-emerald-500/30 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20 active:scale-95 transition-all text-xs"
+                  className="h-10 px-5 rounded-xl border-emerald-500/30 bg-[#34c77b]/10 text-emerald-300 hover:bg-[#34c77b]/20 active:scale-95 transition-all text-xs"
                   onClick={handleInstallAll}
                   disabled={
                     installablePackages.length === 0 ||
@@ -707,7 +707,7 @@ export const MissingNodeInstallerModal: React.FC<MissingNodeInstallerModalProps>
                 {showRebootPrompt && (
                   <Button
                     variant="outline"
-                    className="h-10 px-5 rounded-xl border-violet-500/30 bg-violet-500/10 text-violet-300 hover:bg-violet-500/20 active:scale-95 transition-all text-xs"
+                    className="h-10 px-5 rounded-xl border-[#3069f0]/30 bg-[#3069f0]/10 text-violet-300 hover:bg-[#3f78f5]/20 active:scale-95 transition-all text-xs"
                     onClick={handleRebootServer}
                   >
                     <RefreshCw className="h-3.5 w-3.5 mr-1.5" /> {t('missingNodes.goToReboot')}

--- a/src/components/modals/NodeAddModal.tsx
+++ b/src/components/modals/NodeAddModal.tsx
@@ -195,7 +195,7 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
     return (
       <div className={`mb-3 last:mb-0`}>
         <div
-          className="group relative rounded-3xl bg-black/10 border border-white/5 hover:bg-black/20 hover:border-white/10 transition-all overflow-hidden"
+          className="group relative rounded-xl bg-black/10 border border-white/5 hover:bg-black/20 hover:border-white/10 transition-all overflow-hidden"
           style={{ marginLeft: level > 0 ? `${level * 12}px` : '0' }}
         >
           {/* Header */}
@@ -204,8 +204,8 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
             className="w-full px-5 py-3 flex items-center justify-between text-left transition-all"
           >
             <div className="flex items-center space-x-3 min-w-0">
-              <div className={`p-1.5 rounded-xl bg-black/20 border border-white/5 transition-transform duration-300 ${isExpanded ? 'rotate-180 bg-blue-500/10 border-blue-500/20' : ''}`}>
-                <ChevronDown className={`w-3 h-3 ${isExpanded ? 'text-blue-400' : 'text-white/40'}`} />
+              <div className={`p-1.5 rounded-xl bg-black/20 border border-white/5 transition-transform duration-300 ${isExpanded ? 'rotate-180 bg-[#3069f0]/10 border-[#3069f0]/20' : ''}`}>
+                <ChevronDown className={`w-3 h-3 ${isExpanded ? 'text-[#5b8af5]' : 'text-white/40'}`} />
               </div>
               <div className="flex flex-col min-w-0">
                 <span className="font-bold text-white/90 text-[11px] tracking-tight uppercase line-clamp-1 leading-snug">
@@ -241,13 +241,13 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
                         <button
                           key={node.name}
                           onClick={() => handleNodeSelect(node)}
-                          className="w-full p-3 rounded-2xl bg-black/20 border border-white/5 hover:border-blue-500/30 hover:bg-blue-500/5 text-white/60 hover:text-white/90 transition-all duration-200 flex flex-col items-start text-left group/node"
+                          className="w-full p-3 rounded-xl bg-black/20 border border-white/5 hover:border-[#3069f0]/30 hover:bg-[#3f78f5]/5 text-white/60 hover:text-white/90 transition-all duration-200 flex flex-col items-start text-left group/node"
                         >
                           <div className="flex items-center justify-between w-full mb-1">
                             <span className="text-[11px] font-bold text-white/80 group-hover/node:text-white transition-colors line-clamp-2 leading-snug">
                               {node.display_name}
                             </span>
-                            <Plus className="w-3 h-3 opacity-0 group-hover/node:opacity-100 transition-opacity text-blue-400 flex-shrink-0 ml-2" />
+                            <Plus className="w-3 h-3 opacity-0 group-hover/node:opacity-100 transition-opacity text-[#5b8af5] flex-shrink-0 ml-2" />
                           </div>
                           {node.description && node.description !== 'No description available' && (
                             <p className="text-[9px] text-white/30 line-clamp-2 leading-relaxed mb-1.5">
@@ -295,13 +295,13 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.96, y: 15 }}
           transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-          className="relative w-[90vw] h-[85vh] pointer-events-auto flex flex-col"
+          className="relative w-[92vw] max-w-md h-[72vh] pointer-events-auto flex flex-col"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Main Card */}
           <div
-            style={{ backgroundColor: '#374151' }}
-            className="relative w-full h-full rounded-[40px] shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white"
+            style={{ backgroundColor: '#101217' }}
+            className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
             {/* Always Compact Sticky Header */}
             <div
@@ -345,7 +345,7 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
 
             {/* Persistent Search Bar (Simplified) */}
             <div className="absolute left-0 w-full z-20 px-4 sm:px-8 top-[68px]">
-              <div className="flex flex-col gap-3 bg-[#374151]/80 backdrop-blur-md p-3 rounded-2xl border border-white/5 shadow-lg">
+              <div className="flex flex-col gap-3 bg-[#101217]/80 backdrop-blur-md p-3 rounded-xl border border-white/5 shadow-lg">
                 <form onSubmit={handleSearch} className="relative w-full flex items-center gap-2">
                   <div className="relative flex-1">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
@@ -373,7 +373,7 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
                   <Button
                     type="submit"
                     size="sm"
-                    className="h-9 px-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white shadow-lg active:scale-95 transition-all flex-shrink-0"
+                    className="h-9 px-3 rounded-xl bg-[#3069f0] hover:bg-[#3f78f5] text-white shadow-lg active:scale-95 transition-all flex-shrink-0"
                   >
                     <Search className="w-4 h-4" />
                   </Button>
@@ -388,10 +388,10 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
               <div className="px-5 pb-6 sm:px-6">
                 {/* Recent Copies Section */}
                 {recentNodes.length > 0 && !searchTerm && (
-                  <div className="mb-8 p-4 rounded-3xl bg-blue-500/5 border border-blue-500/10">
+                  <div className="mb-8 p-4 rounded-xl bg-[#3069f0]/5 border border-[#3069f0]/10">
                     <div className="flex items-center gap-2 mb-3 px-1">
-                      <Clock className="w-3.5 h-3.5 text-blue-400/60" />
-                      <span className="text-[10px] font-bold uppercase tracking-widest text-blue-400/60">
+                      <Clock className="w-3.5 h-3.5 text-[#5b8af5]/60" />
+                      <span className="text-[10px] font-bold uppercase tracking-widest text-[#5b8af5]/60">
                         {t('nodeAdd.recentCopies')}
                       </span>
                     </div>
@@ -400,9 +400,9 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
                         <button
                           key={node.id}
                           onClick={() => handlePasteNode(node)}
-                          className="flex flex-col items-start p-2.5 rounded-xl bg-black/20 border border-white/5 hover:border-blue-400/30 hover:bg-blue-400/5 transition-all group/recent"
+                          className="flex flex-col items-start p-2.5 rounded-xl bg-black/20 border border-white/5 hover:border-[#3069f0]/30 hover:bg-blue-400/5 transition-all group/recent"
                         >
-                          <span className="text-[10px] font-bold text-white/70 group-hover/recent:text-blue-400 line-clamp-1 mb-1">
+                          <span className="text-[10px] font-bold text-white/70 group-hover/recent:text-[#5b8af5] line-clamp-1 mb-1">
                             {node.title}
                           </span>
                           <span className="text-[8px] font-mono text-white/30 uppercase">
@@ -415,7 +415,7 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
                 )}
 
                 {nodeTree.length === 0 ? (
-                  <div className="text-center py-12 rounded-3xl bg-black/20 border border-dashed border-white/10">
+                  <div className="text-center py-12 rounded-xl bg-black/20 border border-dashed border-white/10">
                     <Hash className="h-10 w-10 text-white/10 mx-auto mb-3" />
                     <p className="text-white/40 text-[11px] font-medium">
                       {searchTerm ? t('nodeAdd.noMatchingNodes', { query: searchTerm }) : t('nodeAdd.noNodeTypes')}
@@ -449,7 +449,7 @@ export const NodeAddModal: React.FC<NodeAddModalProps> = ({
             {/* Footer Status */}
             <div className="px-8 py-4 bg-black/30 border-t border-white/5 flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <div className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+                <div className="w-1.5 h-1.5 rounded-full bg-[#34c77b] animate-pulse" />
                 <span className="text-[10px] font-bold text-white/40 uppercase tracking-widest">
                   {nodeTypes.length} Available Nodes
                 </span>

--- a/src/components/modals/WidgetTypeDefinitionModal.tsx
+++ b/src/components/modals/WidgetTypeDefinitionModal.tsx
@@ -234,7 +234,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-md p-4 pwa-modal"
+ className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-md p-4 pwa-modal"
           onClick={handleBackdropClick}
         >
           <motion.div
@@ -242,16 +242,16 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.9, y: 20 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="w-full max-w-4xl max-h-[90vh] bg-white/80 dark:bg-slate-900/80 backdrop-blur-xl rounded-xl shadow-2xl border border-white/30 dark:border-slate-700/40 flex flex-col"
+ className="w-full max-w-4xl max-h-[90vh] bg-white/80 /80 backdrop-blur-xl rounded-xl shadow-2xl border border-white/30 flex flex-col"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
-            <div className="p-6 border-b border-slate-200/50 dark:border-slate-700/50 flex items-center justify-between backdrop-blur-sm">
+            <div className="p-6 border-b border-white/[0.08] flex items-center justify-between backdrop-blur-sm">
               <div>
-                <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                <h2 className="text-xl font-semibold text-[#e9ebef]">
                   {editingWidgetType ? t('widgetType.editTitle') : t('widgetType.createTitle')}
                 </h2>
-                <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+                <p className="text-sm text-[#8a919e] mt-1">
                   {t('widgetType.subtitle')}
                 </p>
               </div>
@@ -259,7 +259,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                 onClick={onClose}
                 variant="ghost"
                 size="sm"
-                className="h-8 w-8 p-0"
+ className="h-8 w-8 p-0"
               >
                 <X className="h-4 w-4" />
               </Button>
@@ -268,10 +268,10 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
             {/* Content */}
             <div className="flex-1 overflow-auto p-6 space-y-6">
               {/* Basic Information */}
-              <div className="bg-white/60 dark:bg-slate-900/60 backdrop-blur-md border border-white/30 dark:border-slate-700/40 rounded-xl shadow-lg">
-                <div className="p-6 border-b border-slate-200/30 dark:border-slate-700/30">
-                  <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{t('widgetType.basicInfo')}</h3>
-                  <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+              <div className="bg-white/60 backdrop-blur-md border border-white/30 rounded-xl shadow-lg">
+                <div className="p-6 border-b border-white/[0.07]">
+                  <h3 className="text-lg font-semibold text-[#e9ebef]">{t('widgetType.basicInfo')}</h3>
+                  <p className="text-sm text-[#8a919e] mt-1">
                     {t('widgetType.basicInfoDesc')}
                   </p>
                 </div>
@@ -284,12 +284,12 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                         value={formData.id}
                         onChange={(e) => setFormData(prev => ({ ...prev, id: e.target.value }))}
                         placeholder={t('widgetType.idPlaceholder')}
-                        className="font-mono bg-white/50 dark:bg-slate-800/50 backdrop-blur-sm border-white/30 dark:border-slate-700/30"
+ className="font-mono bg-white/[0.04] backdrop-blur-sm border-white/30"
                         readOnly={!!editingWidgetType}
                         disabled={!!editingWidgetType}
                       />
                       {editingWidgetType && (
-                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                        <p className="text-xs text-[#71798a]">
                           {t('widgetType.idImmutable')}
                         </p>
                       )}
@@ -301,7 +301,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                         value={formData.tooltip}
                         onChange={(e) => setFormData(prev => ({ ...prev, tooltip: e.target.value }))}
                         placeholder={t('widgetType.tooltipPlaceholder')}
-                        className="bg-white/50 dark:bg-slate-800/50 backdrop-blur-sm border-white/30 dark:border-slate-700/30"
+ className="bg-white/[0.04] backdrop-blur-sm border-white/30"
                       />
                     </div>
                   </div>
@@ -313,26 +313,26 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                       onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
                       placeholder={t('widgetType.descriptionPlaceholder')}
                       rows={3}
-                      className="bg-white/50 dark:bg-slate-800/50 backdrop-blur-sm border-white/30 dark:border-slate-700/30"
+ className="bg-white/[0.04] backdrop-blur-sm border-white/30"
                     />
                   </div>
                 </div>
               </div>
 
               {/* Field Definitions */}
-              <div className="bg-white/60 dark:bg-slate-900/60 backdrop-blur-md border border-white/30 dark:border-slate-700/40 rounded-xl shadow-lg">
-                <div className="p-6 border-b border-slate-200/30 dark:border-slate-700/30">
+              <div className="bg-white/60 backdrop-blur-md border border-white/30 rounded-xl shadow-lg">
+                <div className="p-6 border-b border-white/[0.07]">
                   <div className="flex items-center justify-between">
                     <div>
-                      <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{t('widgetType.fieldDefinitions')}</h3>
-                      <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+                      <h3 className="text-lg font-semibold text-[#e9ebef]">{t('widgetType.fieldDefinitions')}</h3>
+                      <p className="text-sm text-[#8a919e] mt-1">
                         {t('widgetType.fieldDefinitionsDesc')}
                       </p>
                     </div>
                     <Button
                       onClick={addField}
                       size="sm"
-                      className="gap-2 bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700 text-white backdrop-blur-sm"
+ className="gap-2 bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700 text-white backdrop-blur-sm"
                     >
                       <Plus className="h-4 w-4" />
                       {t('widgetType.addField')}
@@ -341,21 +341,21 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                 </div>
                 <div className="p-6 space-y-4">
                   {formData.fields.length === 0 ? (
-                    <div className="text-center py-8 text-slate-500 dark:text-slate-400">
+                    <div className="text-center py-8 text-[#71798a]">
                       {t('widgetType.noFields')}
                     </div>
                   ) : (
                     <div className="space-y-4">
                       {formData.fields.map((field, index) => (
-                        <div key={field.id} className="bg-white/40 dark:bg-slate-900/40 backdrop-blur-sm border border-dashed border-slate-300/60 dark:border-slate-600/60 rounded-lg shadow-sm">
-                          <div className="p-4 pb-3 border-b border-slate-200/30 dark:border-slate-700/30">
+                        <div key={field.id} className="bg-white/40 /40 backdrop-blur-sm border border-dashed border-white/[0.1]/60 /60 rounded-lg shadow-sm">
+                          <div className="p-4 pb-3 border-b border-white/[0.07]">
                             <div className="flex items-center justify-between">
-                              <h4 className="text-base font-medium text-slate-900 dark:text-slate-100">{t('widgetType.field', { index: index + 1 })}</h4>
+                              <h4 className="text-base font-medium text-[#e9ebef]">{t('widgetType.field', { index: index + 1 })}</h4>
                               <Button
                                 onClick={() => removeField(field.id)}
                                 variant="ghost"
                                 size="sm"
-                                className="h-8 w-8 p-0 text-red-500 hover:text-red-700 hover:bg-red-50/50 dark:hover:bg-red-900/30"
+ className="h-8 w-8 p-0 text-red-500 hover:text-red-700 hover:bg-red-50/50 dark:hover:bg-red-900/30"
                               >
                                 <Trash2 className="h-4 w-4" />
                               </Button>
@@ -370,7 +370,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                   value={field.name}
                                   onChange={(e) => updateField(field.id, { name: e.target.value })}
                                   placeholder={t('widgetType.fieldNamePlaceholder')}
-                                  className="font-mono bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="font-mono bg-white/60 backdrop-blur-sm border-white/40"
                                 />
                               </div>
                               <div className="space-y-2">
@@ -379,7 +379,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                   value={field.config.label}
                                   onChange={(e) => updateFieldConfig(field.id, { label: e.target.value })}
                                   placeholder={t('widgetType.displayLabelPlaceholder')}
-                                  className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                                 />
                               </div>
                             </div>
@@ -399,7 +399,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                     <SelectItem key={option.value} value={option.value}>
                                       <div>
                                         <div className="font-medium">{option.label}</div>
-                                        <div className="text-sm text-slate-500">{option.description}</div>
+                                        <div className="text-sm text-[#71798a]">{option.description}</div>
                                       </div>
                                     </SelectItem>
                                   ))}
@@ -420,7 +420,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                 onChange={(e) => updateFieldConfig(field.id, { description: e.target.value })}
                                 placeholder={t('widgetType.fieldDescPlaceholder')}
                                 rows={2}
-                                className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                               />
                             </div>
 
@@ -447,7 +447,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                             ) : undefined
                                           })}
                                           placeholder={t('node.min')}
-                                          className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                                         />
                                       </div>
                                       <div className="space-y-2">
@@ -464,7 +464,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                             ) : undefined
                                           })}
                                           placeholder="No limit"
-                                          className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                                         />
                                       </div>
                                       <div className="space-y-2">
@@ -481,7 +481,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                             ) : undefined
                                           })}
                                           placeholder={field.config.type === 'int' ? "1" : "0.1"}
-                                          className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                                         />
                                       </div>
                                     </div>
@@ -493,11 +493,11 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                       <Label>{t('widgetType.options')}</Label>
                                       <div className="space-y-3">
                                         {/* Options List */}
-                                        <div className="flex flex-wrap gap-2 min-h-[40px] p-3 bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border border-white/40 dark:border-slate-700/40 rounded-md">
+                                        <div className="flex flex-wrap gap-2 min-h-[40px] p-3 bg-white/60 backdrop-blur-sm border border-white/40 rounded-md">
                                           {(field.config.options || []).map((option: string, index: number) => (
                                             <div
                                               key={index}
-                                              className="flex items-center gap-1 bg-violet-100 dark:bg-violet-900/30 text-violet-800 dark:text-violet-200 px-2 py-1 rounded text-sm border border-violet-200/50 dark:border-violet-700/50"
+ className="flex items-center gap-1 bg-violet-100 dark:bg-violet-900/30 text-violet-800 dark:text-violet-200 px-2 py-1 rounded text-sm border border-violet-200/50 dark:border-violet-700/50"
                                             >
                                               <span>{option}</span>
                                               <button
@@ -506,7 +506,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                                   const newOptions = (field.config.options || []).filter((_: string, i: number) => i !== index);
                                                   updateFieldConfig(field.id, { options: newOptions });
                                                 }}
-                                                className="ml-1 text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200"
+ className="ml-1 text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200"
                                               >
                                                 <X className="h-3 w-3" />
                                               </button>
@@ -518,7 +518,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                         <div className="flex gap-2">
                                           <Input
                                             placeholder={t('widgetType.addOption')}
-                                            className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                                             onKeyDown={(e) => {
                                               if (e.key === 'Enter') {
                                                 e.preventDefault();
@@ -546,7 +546,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                                 }
                                               }
                                             }}
-                                            className="bg-violet-600 hover:bg-violet-700 text-white backdrop-blur-sm"
+ className="bg-violet-600 hover:bg-violet-700 text-white backdrop-blur-sm"
                                           >
                                             <Plus className="h-4 w-4" />
                                           </Button>
@@ -554,7 +554,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
 
                                         {/* Fallback Textarea for Advanced Users */}
                                         <details className="text-sm">
-                                          <summary className="cursor-pointer text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200">
+                                          <summary className="cursor-pointer text-[#8a919e] hover:text-[#d5d9e0]">
                                             {t('widgetType.advancedBulk')}
                                           </summary>
                                           <div className="mt-2">
@@ -565,7 +565,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                               })}
                                               placeholder="option1&#10;option2&#10;option3"
                                               rows={4}
-                                              className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                                               style={{
                                                 resize: 'vertical',
                                                 minHeight: '80px'
@@ -591,7 +591,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                             updateFieldConfig(field.id, { default: value === 'true' });
                                           }}
                                         >
-                                          <SelectTrigger className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40">
+                                          <SelectTrigger className="bg-white/60 backdrop-blur-sm border-white/40">
                                             <SelectValue placeholder="Select default value" />
                                           </SelectTrigger>
                                           <SelectContent>
@@ -625,7 +625,7 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
                                             updateFieldConfig(field.id, { default: defaultValue });
                                           }}
                                           placeholder={`Default ${field.config.type} value`}
-                                          className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border-white/40 dark:border-slate-700/40"
+ className="bg-white/60 backdrop-blur-sm border-white/40"
                                         />
                                       )}
                                     </div>
@@ -643,11 +643,11 @@ export const WidgetTypeDefinitionModal: React.FC<WidgetTypeDefinitionModalProps>
             </div>
 
             {/* Footer */}
-            <div className="p-6 border-t border-slate-200/50 dark:border-slate-700/50 flex items-center justify-end gap-3 backdrop-blur-sm">
+            <div className="p-6 border-t border-white/[0.08] flex items-center justify-end gap-3 backdrop-blur-sm">
               <Button
                 onClick={onClose}
                 disabled={isSaving}
-                className="bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm hover:bg-white/80 dark:hover:bg-slate-800/80 border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100"
+ className="bg-white/60 backdrop-blur-sm hover:bg-white/80 border border-white/[0.08] text-[#c8ccd4] hover:text-[#e9ebef]"
               >
                 {t('widgetType.cancel')}
               </Button>

--- a/src/components/models/ModelBrowser.tsx
+++ b/src/components/models/ModelBrowser.tsx
@@ -476,15 +476,15 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
       case '.ckpt':
       case '.pt':
       case '.pth':
-        return <Layers className="h-4 w-4 text-blue-500 flex-shrink-0" />;
+        return <Layers className="h-4 w-4 text-[#5b8af5] flex-shrink-0" />;
       case '.bin':
         return <FileArchive className="h-4 w-4 text-orange-500 flex-shrink-0" />;
       case '.onnx':
-        return <FileCode className="h-4 w-4 text-green-500 flex-shrink-0" />;
+        return <FileCode className="h-4 w-4 text-[#4ade80] flex-shrink-0" />;
       case '.trt':
-        return <FileImage className="h-4 w-4 text-purple-500 flex-shrink-0" />;
+        return <FileImage className="h-4 w-4 text-[#9a8af0] flex-shrink-0" />;
       default:
-        return <File className="h-4 w-4 text-slate-500 flex-shrink-0" />;
+        return <File className="h-4 w-4 text-[#71798a] flex-shrink-0" />;
     }
   };
 
@@ -504,10 +504,10 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
       }}
     >
       {/* Main Background with Dark Theme */}
-      <div className="absolute inset-0 bg-[#374151]" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
 
       {/* Glassmorphism Background Overlay */}
-      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+      <div className="hidden" />
 
       {/* Main Scrollable Content Area */}
       <div
@@ -521,8 +521,8 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
         }}
       >
         {/* Header */}
-        <div className="sticky top-0 z-50 pwa-header bg-[#1e293b] border-b border-white/10 shadow-xl relative overflow-hidden">
-          <div className="relative z-10 p-4 space-y-3">
+        <div className="sticky top-0 z-50 pwa-header bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
+          <div className="relative z-10 p-4 space-y-2">
             {/* First Row - Back Button, Title, and Upload */}
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
@@ -530,15 +530,15 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                   onClick={handleBack}
                   variant="ghost"
                   size="sm"
-                  className="bg-white/10 backdrop-blur-sm border border-white/10 shadow-lg hover:bg-white/20 transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg text-white"
+                  className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] transition-all h-9 w-9 p-0 flex-shrink-0 rounded-[10px] text-[#c8ccd4]"
                 >
                   <ArrowLeft className="h-4 w-4" />
                 </Button>
                 <div>
-                  <h1 className="text-lg font-bold text-white/95 leading-none">
+                  <h1 className="text-[15px] font-bold text-[#e9ebef] leading-none">
                     {t('modelBrowser.title')}
                   </h1>
-                  <p className="text-[11px] text-white/40 mt-1">
+                  <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">
                     {t('modelBrowser.subtitle')}
                   </p>
                 </div>
@@ -563,14 +563,14 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                   placeholder={t('modelBrowser.searchPlaceholder')}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-9 h-9 bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl text-sm"
+                  className="pl-9 h-[42px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#71798a] rounded-[10px] text-[12.5px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50"
                 />
               </div>
               <Select value={selectedFolder} onValueChange={setSelectedFolder}>
-                <SelectTrigger className="w-32 h-9 bg-black/20 border-white/10 text-white/90 rounded-xl text-sm">
+                <SelectTrigger className="w-32 h-[42px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] rounded-[10px] text-[12.5px]">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="bg-[#1e293b] border-white/10 text-white">
+                <SelectContent className="bg-[#101217] border-white/10 text-white">
                   <SelectItem value="all text-xs">{t('modelBrowser.allFolders')}</SelectItem>
                   {folders.map((folder) => (
                     <SelectItem key={folder.name} value={folder.name} className="text-xs">
@@ -591,13 +591,13 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
         </div>
 
         {/* Content */}
-        <div className="container mx-auto px-4 py-8 max-w-6xl">
+        <div className="container mx-auto px-4 py-5 max-w-6xl">
           {/* Partial Uploads Banner */}
           {partialUploads.length > 0 && (
-            <div className="mb-8 p-4 bg-yellow-500/10 border border-yellow-500/20 rounded-2xl">
+            <div className="mb-8 p-4 bg-[#ffa348]/[0.06] border border-[#ffa348]/[0.22] rounded-xl">
               <div className="flex items-start justify-between">
                 <div className="flex-1">
-                  <h3 className="font-medium text-yellow-400 mb-2 flex items-center">
+                  <h3 className="font-medium text-[#ffa348] mb-2 flex items-center">
                     <AlertTriangle className="h-4 w-4 mr-2" />
                     {t('modelBrowser.incompleteUploads', { count: partialUploads.length })}
                   </h3>
@@ -605,7 +605,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                     {partialUploads.map((partial) => (
                       <div key={partial.partial_filename} className="flex items-center justify-between bg-black/20 p-2 rounded-xl border border-white/5">
                         <div className="flex-1 min-w-0">
-                          <div className="font-medium text-sm truncate text-white/90">{partial.filename}</div>
+                          <div className="font-medium text-[12px] truncate text-white/90">{partial.filename}</div>
                           <div className="text-xs text-white/40">
                             {partial.size_mb} MB uploaded · {new Date(partial.modified_iso).toLocaleString()}
                           </div>
@@ -614,7 +614,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                           <Button
                             size="sm"
                             variant="default"
-                            className="text-xs bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 border-yellow-500/20 rounded-lg h-8"
+                            className="text-xs bg-yellow-500/20 text-[#ffa348] hover:bg-yellow-500/30 border-yellow-500/20 rounded-lg h-8"
                             onClick={() => {
                               // Pre-fill upload form with this file's info
                               setUploadFolder(selectedFolder !== 'all' ? selectedFolder : '');
@@ -643,10 +643,10 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
 
           {/* Error Display */}
           {error && (
-            <div className="mb-8 p-4 bg-red-500/10 border border-red-500/20 rounded-2xl">
-              <div className="flex items-center space-x-2 text-red-400">
+            <div className="mb-8 p-4 bg-[#f25555]/10 border border-[#f25555]/20 rounded-xl">
+              <div className="flex items-center space-x-2 text-[#f87c7c]">
                 <AlertTriangle className="h-4 w-4 rotate-0" />
-                <span className="text-sm">{error}</span>
+                <span className="text-[12px]">{error}</span>
                 <Button
                   variant="ghost"
                   size="sm"
@@ -661,18 +661,18 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
 
           {/* Model List - Grouped */}
           {isLoading ? (
-            <div className="flex flex-col items-center justify-center h-64 space-y-4">
-              <Loader2 className="h-10 w-10 text-indigo-400 animate-spin" />
-              <p className="text-white/20 text-sm animate-pulse">Loading Models...</p>
+            <div className="flex flex-col items-center justify-center h-64 space-y-2.5">
+              <Loader2 className="h-10 w-10 text-[#5b8af5] animate-spin" />
+              <p className="text-white/20 text-[12px] animate-pulse">Loading Models...</p>
             </div>
           ) : displayModels.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-64 text-white/20">
               <File className="h-16 w-16 mb-4 opacity-10" />
-              <p className="text-lg font-medium">{searchQuery ? t('modelBrowser.noModels') : t('modelBrowser.noModelsFolder')}</p>
-              <p className="text-sm opacity-60">{t('modelBrowser.tryAdjusting')}</p>
+              <p className="text-[14px] font-medium">{searchQuery ? t('modelBrowser.noModels') : t('modelBrowser.noModelsFolder')}</p>
+              <p className="text-[12px] opacity-60">{t('modelBrowser.tryAdjusting')}</p>
             </div>
           ) : (
-            <div className="space-y-6">
+            <div className="space-y-2">
               {Object.entries(
                 displayModels.reduce((acc, model) => {
                   if (!acc[model.folder_type]) acc[model.folder_type] = [];
@@ -680,7 +680,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                   return acc;
                 }, {} as Record<string, ModelFile[]>)
               ).map(([folderName, folderModels]) => (
-                <div key={folderName} className="space-y-4">
+                <div key={folderName} className="space-y-2.5">
                   <div
                     className="flex items-center space-x-3 px-1 cursor-pointer select-none active:opacity-70 transition-opacity"
                     onClick={() => toggleGroup(folderName)}
@@ -702,12 +702,12 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                   {expandedGroups[folderName] && (
                     <div className="grid grid-cols-1 gap-3">
                       {folderModels.map((model, index) => (
-                        <div key={`${model.relative_path}-${index}`} className="hover:shadow-lg transition-all border border-white/5 bg-black/20 backdrop-blur-sm rounded-2xl px-4 py-4 space-y-2 group">
+                        <div key={`${model.relative_path}-${index}`} className="transition-all border border-white/[0.07] bg-white/[0.025] hover:bg-white/[0.04] hover:border-white/[0.12] rounded-[11px] px-3 py-3 space-y-2 group">
                           {/* Line 1: Title with File Icon and Date */}
                           <div className="flex items-center justify-between">
                             <div className="flex items-center space-x-2 flex-1 min-w-0">
                               {getFileIcon(model.extension)}
-                              <h3 className="font-medium text-white/95 truncate text-sm">
+                              <h3 className="text-[13px] font-semibold text-[#e9ebef] truncate leading-[1.35]">
                                 {model.filename}
                               </h3>
                             </div>
@@ -718,7 +718,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
 
                           {/* Line 2: Badges (Extension, Type, Folder, Size) */}
                           <div className="flex items-center flex-wrap gap-1">
-                            <Badge variant="secondary" className="text-[9px] bg-white/5 text-white/60 border-white/5 uppercase font-mono py-0.5">
+                            <Badge variant="secondary" className="font-mono text-[9px] bg-white/[0.05] text-[#8a919e] border-white/[0.06] uppercase py-0.5">
                               {model.extension}
                             </Badge>
                             {model.folder_type === 'loras' && (
@@ -726,11 +726,11 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                                 LoRA
                               </Badge>
                             )}
-                            <Badge variant="outline" className="text-[9px] border-white/5 text-white/40 uppercase py-0.5 bg-black/20">
+                            <Badge variant="outline" className="font-mono text-[9px] border-white/[0.06] text-[#565d6b] uppercase py-0.5 bg-black/20">
                               <FolderOpen className="h-2.5 w-2.5 mr-1" />
                               {model.subfolder ? `${model.subfolder}` : 'Root'}
                             </Badge>
-                            <Badge variant="outline" className="text-[9px] border-white/5 text-white/40 uppercase py-0.5 bg-black/20">
+                            <Badge variant="outline" className="font-mono text-[9px] border-white/[0.06] text-[#565d6b] uppercase py-0.5 bg-black/20">
                               {formatFileSize(model.size)}
                             </Badge>
                           </div>
@@ -738,7 +738,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                           {/* Trigger Words Count for LoRA (if exists) */}
                           {model.folder_type === 'loras' && triggerWords && triggerWords[model.filename] && Array.isArray(triggerWords[model.filename]) && triggerWords[model.filename].length > 0 && (
                             <div className="flex items-center gap-1">
-                              <Badge variant="outline" className="text-[9px] bg-purple-500/10 text-purple-400 border-purple-500/20 font-bold py-0.5">
+                              <Badge variant="outline" className="text-[9px] bg-purple-500/10 text-[#9a8af0] border-purple-500/20 font-bold py-0.5">
                                 <Zap className="h-2.5 w-2.5 mr-1" />
                                 {triggerWords[model.filename].length} WORD{triggerWords[model.filename].length === 1 ? '' : 'S'}
                               </Badge>
@@ -750,7 +750,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="h-12 p-1 flex flex-col items-center justify-center space-y-1 text-white/30 hover:text-white/90 hover:bg-white/5 rounded-xl transition-all"
+                              className="h-10 p-1 flex flex-col items-center justify-center space-y-1 text-[#71798a] hover:text-[#c8ccd4] hover:bg-white/[0.05] rounded-lg transition-all"
                               onClick={() => openOperationModal('copy', model)}
                               title={t('modelBrowser.actions.copy')}
                             >
@@ -760,7 +760,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="h-12 p-1 flex flex-col items-center justify-center space-y-1 text-white/30 hover:text-white/90 hover:bg-white/5 rounded-xl transition-all"
+                              className="h-10 p-1 flex flex-col items-center justify-center space-y-1 text-[#71798a] hover:text-[#c8ccd4] hover:bg-white/[0.05] rounded-lg transition-all"
                               onClick={() => openOperationModal('move', model)}
                               title={t('modelBrowser.actions.move')}
                             >
@@ -770,7 +770,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="h-12 p-1 flex flex-col items-center justify-center space-y-1 text-white/30 hover:text-white/90 hover:bg-white/5 rounded-xl transition-all"
+                              className="h-10 p-1 flex flex-col items-center justify-center space-y-1 text-[#71798a] hover:text-[#c8ccd4] hover:bg-white/[0.05] rounded-lg transition-all"
                               onClick={() => openOperationModal('rename', model)}
                               title={t('modelBrowser.actions.rename')}
                             >
@@ -781,7 +781,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                className="h-12 p-1 flex flex-col items-center justify-center space-y-1 text-purple-400/60 hover:text-purple-300 hover:bg-purple-500/10 rounded-xl transition-all"
+                                className="h-10 p-1 flex flex-col items-center justify-center space-y-1 text-[#9a8af0]/70 hover:text-[#b9adf5] hover:bg-[#9a8af0]/10 rounded-lg transition-all"
                                 onClick={() => openTriggerWordsModal(model.filename)}
                                 title={t('modelBrowser.actions.trigger')}
                               >
@@ -794,11 +794,11 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="h-12 p-1 flex flex-col items-center justify-center space-y-1 text-red-400/60 hover:text-red-300 hover:bg-red-500/10 rounded-xl transition-all"
+                              className="h-10 p-1 flex flex-col items-center justify-center space-y-1 text-[#f87c7c]/70 hover:text-[#f8b3b3] hover:bg-[#f25555]/10 rounded-lg transition-all"
                               onClick={() => openOperationModal('delete', model)}
                               title={t('modelBrowser.actions.delete')}
                             >
-                              <Trash2 className="h-4 w-4 text-red-400/80" />
+                              <Trash2 className="h-4 w-4 text-[#f87c7c]/80" />
                               <span className="text-[9px] font-bold uppercase tracking-wider">{t('modelBrowser.actions.delete')}</span>
                             </Button>
                           </div>
@@ -821,21 +821,21 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
           </DialogHeader>
 
           {selectedModel && (
-            <div className="space-y-4">
-              <div className="text-sm text-slate-600 dark:text-slate-400">
+            <div className="space-y-2.5">
+              <div className="text-[12px] text-[#8a919e]">
                 {operationType === 'delete' ? t('modelBrowser.operation.deleteConfirm') : t('modelBrowser.operation.configure')}
               </div>
 
-              <div className="p-3 bg-slate-50 dark:bg-slate-800 rounded-lg">
-                <div className="font-medium text-sm">{selectedModel.filename}</div>
-                <div className="text-xs text-slate-500">
+              <div className="p-3 bg-slate-50 dark:bg-[#14171e] rounded-lg">
+                <div className="font-medium text-[12px]">{selectedModel.filename}</div>
+                <div className="text-xs text-[#71798a]">
                   {selectedModel.folder_type}{selectedModel.subfolder ? `/${selectedModel.subfolder}` : ''}
                 </div>
               </div>
 
               {operationType === 'rename' && (
                 <div>
-                  <label className="text-sm font-medium">{t('modelBrowser.operation.newFilename')}</label>
+                  <label className="text-[12px] font-medium">{t('modelBrowser.operation.newFilename')}</label>
                   <Input
                     value={newFilename}
                     onChange={(e) => setNewFilename(e.target.value)}
@@ -847,7 +847,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
               {(operationType === 'copy' || operationType === 'move') && (
                 <>
                   <div>
-                    <label className="text-sm font-medium">{t('modelBrowser.operation.targetFolder')}</label>
+                    <label className="text-[12px] font-medium">{t('modelBrowser.operation.targetFolder')}</label>
                     <Select value={targetFolder} onValueChange={setTargetFolder}>
                       <SelectTrigger>
                         <SelectValue />
@@ -862,7 +862,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                     </Select>
                   </div>
                   <div>
-                    <label className="text-sm font-medium">{t('modelBrowser.operation.targetSubfolder')}</label>
+                    <label className="text-[12px] font-medium">{t('modelBrowser.operation.targetSubfolder')}</label>
                     <Input
                       value={targetSubfolder}
                       onChange={(e) => setTargetSubfolder(e.target.value)}
@@ -898,8 +898,8 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
             </DialogTitle>
           </DialogHeader>
 
-          <div className="space-y-4">
-            <div className="text-sm text-slate-600 dark:text-slate-400">
+          <div className="space-y-2.5">
+            <div className="text-[12px] text-[#8a919e]">
               <Trans i18nKey="modelBrowser.triggerWords.configureFor" values={{ name: selectedLora }}>
                 Configure trigger words for: <strong>{selectedLora}</strong>
               </Trans>
@@ -920,14 +920,14 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
 
             {/* Current trigger words */}
             <div className="space-y-2">
-              <label className="text-sm font-medium">{t('modelBrowser.triggerWords.current')}</label>
+              <label className="text-[12px] font-medium">{t('modelBrowser.triggerWords.current')}</label>
               <div className="max-h-32 overflow-y-auto space-y-1">
                 {currentTriggerWords.length === 0 ? (
-                  <div className="text-sm text-slate-500 italic">{t('modelBrowser.triggerWords.noWords')}</div>
+                  <div className="text-[12px] text-[#71798a] italic">{t('modelBrowser.triggerWords.noWords')}</div>
                 ) : (
                   currentTriggerWords.map((word, index) => (
-                    <div key={index} className="flex items-center justify-between p-2 bg-slate-50 dark:bg-slate-800 rounded">
-                      <span className="text-sm">{word}</span>
+                    <div key={index} className="flex items-center justify-between p-2 bg-slate-50 dark:bg-[#14171e] rounded">
+                      <span className="text-[12px]">{word}</span>
                       <Button
                         variant="ghost"
                         size="sm"
@@ -965,14 +965,14 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
             </DialogTitle>
           </DialogHeader>
 
-          <div className="space-y-4">
-            <div className="text-sm text-slate-600 dark:text-slate-400">
+          <div className="space-y-2.5">
+            <div className="text-[12px] text-[#8a919e]">
               {t('modelBrowser.uploadModal.desc')}
             </div>
 
             {/* File Selection */}
             <div>
-              <label className="text-sm font-medium block mb-2">{t('modelBrowser.uploadModal.selectFile')}</label>
+              <label className="text-[12px] font-medium block mb-2">{t('modelBrowser.uploadModal.selectFile')}</label>
               <Input
                 type="file"
                 onChange={handleFileSelect}
@@ -980,9 +980,9 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
                 accept="*/*"
               />
               {uploadFile && (
-                <div className="mt-2 p-2 bg-slate-50 dark:bg-slate-800 rounded text-sm">
+                <div className="mt-2 p-2 bg-slate-50 dark:bg-[#14171e] rounded text-[12px]">
                   <div className="font-medium truncate">{uploadFile.name}</div>
-                  <div className="text-xs text-slate-500">
+                  <div className="text-xs text-[#71798a]">
                     {formatFileSize(uploadFile.size)}
                   </div>
                 </div>
@@ -991,7 +991,7 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
 
             {/* Target Folder */}
             <div>
-              <label className="text-sm font-medium block mb-2">{t('modelBrowser.uploadModal.targetFolder')}</label>
+              <label className="text-[12px] font-medium block mb-2">{t('modelBrowser.uploadModal.targetFolder')}</label>
               <Select value={uploadFolder} onValueChange={setUploadFolder} disabled={isUploading}>
                 <SelectTrigger>
                   <SelectValue placeholder={t('modelBrowser.uploadModal.selectFolder')} />
@@ -1008,14 +1008,14 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
 
             {/* Subfolder (Optional) */}
             <div>
-              <label className="text-sm font-medium block mb-2">{t('modelBrowser.uploadModal.subfolder')}</label>
+              <label className="text-[12px] font-medium block mb-2">{t('modelBrowser.uploadModal.subfolder')}</label>
               <Input
                 value={uploadSubfolder}
                 onChange={(e) => setUploadSubfolder(e.target.value)}
                 placeholder="e.g., character, style..."
                 disabled={isUploading}
               />
-              <p className="text-xs text-slate-500 mt-1">
+              <p className="text-xs text-[#71798a] mt-1">
                 {t('modelBrowser.uploadModal.subfolderDesc')}
               </p>
             </div>
@@ -1025,11 +1025,11 @@ const ModelBrowser: React.FC<ModelBrowserProps> = ({ serverUrl: propServerUrl })
             {/* Upload Progress */}
             {isUploading && (
               <div className="space-y-2">
-                <div className="flex items-center justify-between text-sm">
+                <div className="flex items-center justify-between text-[12px]">
                   <span>Uploading...</span>
                   <span>{uploadProgress}%</span>
                 </div>
-                <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
+                <div className="w-full bg-white/[0.08] rounded-full h-2">
                   <div
                     className="bg-indigo-600 h-2 rounded-full transition-all duration-300"
                     style={{ width: `${uploadProgress}%` }}

--- a/src/components/models/ModelDownload.tsx
+++ b/src/components/models/ModelDownload.tsx
@@ -345,10 +345,7 @@ const ModelDownload: React.FC = () => {
       }}
     >
       {/* Main Background with Dark Theme */}
-      <div className="absolute inset-0 bg-[#374151]" />
-
-      {/* Glassmorphism Background Overlay */}
-      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
 
       {/* Main Scrollable Content Area */}
       <div
@@ -360,22 +357,22 @@ const ModelDownload: React.FC = () => {
         }}
       >
         {/* Header */}
-        <header className="sticky top-0 z-50 pwa-header bg-[#1e293b] border-b border-white/10 shadow-xl relative overflow-hidden">
+        <header className="sticky top-0 z-50 pwa-header bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
           <div className="relative z-10 flex items-center justify-between p-4">
             <div className="flex items-center space-x-3">
               <Button
                 onClick={handleBack}
                 variant="ghost"
                 size="sm"
-                className="bg-white/10 backdrop-blur-sm border border-white/10 shadow-lg hover:bg-white/20 transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg text-white"
+                className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] transition-all h-9 w-9 p-0 flex-shrink-0 rounded-[10px] text-[#c8ccd4]"
               >
                 <ArrowLeft className="h-4 w-4" />
               </Button>
               <div>
-                <h1 className="text-lg font-bold text-white/95 leading-none">
+                <h1 className="text-[15px] font-bold text-[#e9ebef] leading-none">
                   {t('modelDownload.title')}
                 </h1>
-                <p className="text-[11px] text-white/40 mt-1">
+                <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">
                   {t('modelDownload.subtitle')}
                 </p>
               </div>
@@ -392,25 +389,25 @@ const ModelDownload: React.FC = () => {
           </div>
         </header>
 
-        <div className="container mx-auto px-6 py-8 max-w-4xl space-y-6">
+        <div className="container mx-auto px-4 py-5 max-w-4xl space-y-2">
           {/* Server Requirements Card */}
-          <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+          <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none">
             <CardHeader>
               <CardTitle className="flex items-center space-x-2 text-white/90">
-                <AlertTriangle className="h-5 w-5 text-amber-400" />
+                <AlertTriangle className="h-4 w-4 text-[#ffa348]" />
                 <span>{t('modelDownload.serverRequirements')}</span>
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-2.5">
               <div className="flex items-center justify-between">
-                <span className="font-medium text-white/70">ComfyUI Server Connection</span>
+                <span className="text-[12.5px] text-[#9aa3b2]">ComfyUI Server Connection</span>
                 {isConnected ? (
-                  <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                  <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                     <CheckCircle className="w-3 h-3 mr-1" />
                     Connected
                   </Badge>
                 ) : (
-                  <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                  <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                     <X className="w-3 h-3 mr-1" />
                     Disconnected
                   </Badge>
@@ -418,19 +415,19 @@ const ModelDownload: React.FC = () => {
               </div>
 
               <div className="flex items-center justify-between">
-                <span className="font-medium text-white/70">Mobile UI API Extension</span>
+                <span className="text-[12.5px] text-[#9aa3b2]">Mobile UI API Extension</span>
                 {isCheckingExtension ? (
                   <Badge variant="outline" className="animate-pulse border-white/10 text-white/40">
                     <Loader2 className="w-3 h-3 mr-1 animate-spin" />
                     Checking...
                   </Badge>
                 ) : hasExtension ? (
-                  <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                  <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                     <CheckCircle className="w-3 h-3 mr-1" />
                     Available
                   </Badge>
                 ) : (
-                  <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                  <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                     <X className="w-3 h-3 mr-1" />
                     Not Available
                   </Badge>
@@ -438,8 +435,8 @@ const ModelDownload: React.FC = () => {
               </div>
 
               {!hasServerRequirements && (
-                <div className="p-4 bg-amber-500/10 border border-amber-500/20 rounded-lg">
-                  <p className="text-sm text-amber-400">
+                <div className="p-4 bg-[#ffa348]/10 border border-amber-500/20 rounded-lg">
+                  <p className="text-[12px] text-[#ffa348]">
                     {t('modelDownload.requirementsDesc')}
                   </p>
                 </div>
@@ -450,37 +447,37 @@ const ModelDownload: React.FC = () => {
           {hasServerRequirements && (
             <>
               {/* Download Form */}
-              <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+              <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none">
                 <CardHeader>
                   <CardTitle className="flex items-center space-x-2 text-white/90">
-                    <Download className="h-5 w-5 text-blue-400" />
+                    <Download className="h-4 w-4 text-[#5b8af5]" />
                     <span>{t('modelDownload.startDownload')}</span>
                   </CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-4">
+                <CardContent className="space-y-2.5">
                   <div className="space-y-2">
-                    <Label htmlFor="download-url" className="text-white/70">{t('modelDownload.modelUrl')}</Label>
+                    <Label htmlFor="download-url" className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase">{t('modelDownload.modelUrl')}</Label>
                     <Input
                       id="download-url"
                       type="url"
                       placeholder={t('modelDownload.modelUrlPlaceholder')}
                       value={downloadUrl}
                       onChange={(e) => setDownloadUrl(e.target.value)}
-                      className="bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl"
+                      className="h-[42px] px-3 font-mono text-[11.5px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] rounded-[10px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50"
                     />
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="target-folder" className="text-white/70">{t('modelDownload.targetFolder')}</Label>
+                    <Label htmlFor="target-folder" className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase">{t('modelDownload.targetFolder')}</Label>
                     <Input
                       id="target-folder"
                       placeholder={t('modelDownload.targetFolderPlaceholder')}
                       value={targetFolder}
                       onChange={(e) => setTargetFolder(e.target.value)}
-                      className="bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl"
+                      className="h-[42px] px-3 font-mono text-[11.5px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] rounded-[10px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50"
                     />
                     {isLoadingFolders ? (
-                      <p className="text-sm text-white/40">Loading folders...</p>
+                      <p className="text-[12px] text-white/40">Loading folders...</p>
                     ) : (
                       <div className="flex flex-wrap gap-2 mt-2">
                         {folders
@@ -497,7 +494,7 @@ const ModelDownload: React.FC = () => {
                               key={folder.name}
                               variant="outline"
                               className={`cursor-pointer border-white/10 bg-white/5 hover:bg-white/10 transition-all ${folder.file_count > 0
-                                ? 'text-blue-400 border-blue-500/20'
+                                ? 'text-[#5b8af5] border-[#3069f0]/20'
                                 : 'text-white/40'
                                 }`}
                               onClick={() => setTargetFolder(folder.name)}
@@ -516,13 +513,13 @@ const ModelDownload: React.FC = () => {
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="custom-filename" className="text-white/70">{t('modelDownload.customFilename')}</Label>
+                    <Label htmlFor="custom-filename" className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase">{t('modelDownload.customFilename')}</Label>
                     <Input
                       id="custom-filename"
                       placeholder={t('modelDownload.customFilenamePlaceholder')}
                       value={customFilename}
                       onChange={(e) => setCustomFilename(e.target.value)}
-                      className="bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl"
+                      className="h-[42px] px-3 font-mono text-[11.5px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] rounded-[10px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50"
                     />
                   </div>
 
@@ -534,7 +531,7 @@ const ModelDownload: React.FC = () => {
                       onChange={(e) => setOverwrite(e.target.checked)}
                       className="rounded bg-black/20 border-white/10"
                     />
-                    <Label htmlFor="overwrite" className="text-sm text-white/70">
+                    <Label htmlFor="overwrite" className="text-[12px] text-white/70">
                       {t('modelDownload.overwrite')}
                     </Label>
                   </div>
@@ -542,7 +539,7 @@ const ModelDownload: React.FC = () => {
                   <Button
                     onClick={handleStartDownload}
                     disabled={!downloadUrl.trim() || !targetFolder.trim() || isStartingDownload}
-                    className="w-full bg-gradient-to-r from-emerald-600 to-blue-600 hover:from-emerald-700 hover:to-blue-700 active:scale-98 transition-transform duration-75"
+                    className="w-full h-11 rounded-[10px] bg-[#3069f0] hover:bg-[#3f78f5] text-white text-[13px] font-semibold shadow-[0_2px_12px_rgba(48,105,240,0.3)] disabled:opacity-50"
                   >
                     {isStartingDownload ? (
                       <>
@@ -560,11 +557,11 @@ const ModelDownload: React.FC = () => {
               </Card>
 
               {/* Downloads List */}
-              <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+              <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none">
                 <CardHeader>
                   <CardTitle className="flex items-center justify-between text-white/90">
                     <div className="flex items-center space-x-2">
-                      <Package className="h-5 w-5 text-purple-400" />
+                      <Package className="h-5 w-5 text-[#9a8af0]" />
                       <span>{t('modelDownload.activeDownloads')}</span>
                     </div>
                     <div className="flex items-center space-x-2">
@@ -573,7 +570,7 @@ const ModelDownload: React.FC = () => {
                           onClick={handleRetryAllFailed}
                           variant="ghost"
                           size="sm"
-                          className="text-amber-400 hover:text-amber-300 hover:bg-white/5 active:scale-95 transition-all"
+                          className="text-[#ffa348] hover:text-amber-300 hover:bg-white/5 active:scale-95 transition-all"
                         >
                           <RotateCcw className="w-4 h-4 mr-1" />
                           <span className="hidden sm:inline">{t('modelDownload.retryAll')}</span>
@@ -585,7 +582,7 @@ const ModelDownload: React.FC = () => {
                           variant="ghost"
                           size="sm"
                           disabled={isClearingHistory}
-                          className="text-red-400 hover:text-red-300 hover:bg-white/5 active:scale-95 transition-all"
+                          className="text-[#f87c7c] hover:text-[#f8b3b3] hover:bg-white/5 active:scale-95 transition-all"
                         >
                           {isClearingHistory ? (
                             <Loader2 className="w-4 h-4 animate-spin" />
@@ -610,19 +607,19 @@ const ModelDownload: React.FC = () => {
                 </CardHeader>
                 <CardContent>
                   {downloads.length === 0 ? (
-                    <p className="text-slate-500 text-center py-8">
+                    <p className="text-[#71798a] text-center py-5">
                       {t('modelDownload.noDownloads')}
                     </p>
                   ) : (
-                    <div className="space-y-4">
+                    <div className="space-y-2.5">
                       {downloads.map((download) => (
                         <div
                           key={download.id}
-                          className="p-4 bg-black/20 border border-white/5 rounded-2xl space-y-3"
+                          className="p-4 bg-black/20 border border-white/5 rounded-xl space-y-2"
                         >
                           <div className="flex items-center gap-2">
                             <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-white/90 truncate">
+                              <p className="text-[12px] font-medium text-white/90 truncate">
                                 {download.filename}
                               </p>
                               <p className="text-xs text-white/40 truncate">
@@ -633,22 +630,22 @@ const ModelDownload: React.FC = () => {
                               {/* Status Icon */}
                               <div className="flex items-center" title={`${download.status}${download.retry_count && download.retry_count > 0 ? ` (${download.retry_count}/${download.max_retries || 3})` : ''}`}>
                                 {download.status === 'completed' && (
-                                  <CheckCircle className="h-5 w-5 text-green-400" />
+                                  <CheckCircle className="h-4 w-4 text-[#4ade80]" />
                                 )}
                                 {download.status === 'error' && (
-                                  <AlertTriangle className="h-5 w-5 text-red-400" />
+                                  <AlertTriangle className="h-4 w-4 text-[#f87c7c]" />
                                 )}
                                 {download.status === 'cancelled' && (
                                   <XCircle className="h-5 w-5 text-white/20" />
                                 )}
                                 {['downloading', 'starting'].includes(download.status) && (
-                                  <Loader2 className="h-5 w-5 text-blue-400 animate-spin" />
+                                  <Loader2 className="h-5 w-5 text-[#5b8af5] animate-spin" />
                                 )}
                                 {download.status === 'retrying' && (
                                   <div className="relative">
-                                    <Loader2 className="h-5 w-5 text-amber-400 animate-spin" />
+                                    <Loader2 className="h-5 w-5 text-[#ffa348] animate-spin" />
                                     {download.retry_count && download.retry_count > 0 && (
-                                      <div className="absolute -top-2 -right-1 bg-amber-500 text-white text-[10px] rounded-full h-4 w-4 flex items-center justify-center font-bold">
+                                      <div className="absolute -top-2 -right-1 bg-[#ffa348] text-white text-[10px] rounded-full h-4 w-4 flex items-center justify-center font-bold">
                                         {download.retry_count}
                                       </div>
                                     )}
@@ -660,7 +657,7 @@ const ModelDownload: React.FC = () => {
                                   onClick={() => handleCancelDownload(download.id)}
                                   variant="ghost"
                                   size="sm"
-                                  className="h-8 w-8 p-0 text-red-400 hover:text-red-300 hover:bg-white/5 flex-shrink-0 active:scale-90 transition-all"
+                                  className="h-8 w-8 p-0 text-[#f87c7c] hover:text-[#f8b3b3] hover:bg-white/5 flex-shrink-0 active:scale-90 transition-all"
                                   title="Cancel download"
                                 >
                                   <X className="h-4 w-4" />
@@ -671,7 +668,7 @@ const ModelDownload: React.FC = () => {
                                   onClick={() => handleResumeDownload(download.id)}
                                   variant="ghost"
                                   size="sm"
-                                  className="h-8 w-8 p-0 text-emerald-400 hover:text-emerald-300 hover:bg-white/5 flex-shrink-0 active:scale-90 transition-all"
+                                  className="h-8 w-8 p-0 text-[#4ade80] hover:text-[#6ee7a0] hover:bg-white/5 flex-shrink-0 active:scale-90 transition-all"
                                   title="Resume download"
                                 >
                                   <PlayCircle className="h-4 w-4" />
@@ -683,11 +680,11 @@ const ModelDownload: React.FC = () => {
                           {['downloading', 'retrying'].includes(download.status) && (
                             <div className="space-y-2">
                               <Progress value={download.progress} className="w-full" />
-                              <div className="flex justify-between text-xs text-slate-500">
+                              <div className="flex justify-between font-mono text-[9.5px] text-[#565d6b] mt-[5px]">
                                 <span>
                                   {formatFileSize(download.downloaded_size)} / {formatFileSize(download.total_size)}
                                   {download.progress > 0 && (
-                                    <span className="ml-2 text-blue-400">
+                                    <span className="ml-2 text-[#5b8af5]">
                                       {download.progress.toFixed(1)}%
                                     </span>
                                   )}
@@ -702,14 +699,14 @@ const ModelDownload: React.FC = () => {
                                     </>
                                   )}
                                   {download.status === 'retrying' && (
-                                    <span className="text-amber-400 ml-2">
+                                    <span className="text-[#ffa348] ml-2">
                                       {t('modelDownload.status.retrying')}
                                     </span>
                                   )}
                                 </span>
                               </div>
                               {download.supports_resume && (
-                                <div className="text-xs text-green-600 dark:text-green-400">
+                                <div className="text-xs text-green-600 dark:text-[#4ade80]">
                                   {t('modelDownload.status.resumable')}
                                 </div>
                               )}
@@ -719,14 +716,14 @@ const ModelDownload: React.FC = () => {
                           {download.status === 'error' && (
                             <div className="space-y-2">
                               {download.error && (
-                                <div className="p-2 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">
+                                <div className="p-2 bg-[#f25555]/10 border border-[#f25555]/20 rounded text-[12px] text-[#f87c7c]">
                                   {download.error}
                                 </div>
                               )}
                               {download.can_resume && download.downloaded_size > 0 && (
-                                <div className="p-2 bg-amber-500/10 border border-amber-500/20 rounded text-sm">
+                                <div className="p-2 bg-[#ffa348]/10 border border-amber-500/20 rounded text-[12px]">
                                   <div className="flex items-center justify-between">
-                                    <span className="text-amber-400">
+                                    <span className="text-[#ffa348]">
                                       {t('modelDownload.status.partial', { size: formatFileSize(download.downloaded_size) })}
                                     </span>
                                     <span className="text-xs text-amber-300/70">
@@ -739,7 +736,7 @@ const ModelDownload: React.FC = () => {
                           )}
 
                           {download.status === 'cancelled' && download.downloaded_size > 0 && (
-                            <div className="p-2 bg-white/5 border border-white/10 rounded text-sm text-white/40">
+                            <div className="p-2 bg-white/5 border border-white/10 rounded text-[12px] text-white/40">
                               📁 Partial download saved: {formatFileSize(download.downloaded_size)}
                               {download.can_resume && (
                                 <span className="ml-2 text-emerald-400">

--- a/src/components/server/AppUpdate.tsx
+++ b/src/components/server/AppUpdate.tsx
@@ -147,11 +147,11 @@ export const AppUpdate: React.FC = () => {
     if (!isConnected) {
         return (
             <div className="bg-black transition-colors duration-300 pwa-container h-[100dvh] flex items-center justify-center p-4">
-                <div className="absolute inset-0 bg-gradient-to-br from-slate-50 via-blue-50/30 to-cyan-50/30 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900" />
-                <div className="relative z-10 p-8 max-w-md w-full bg-white/40 dark:bg-slate-800/20 backdrop-blur-xl rounded-2xl border border-white/20 dark:border-slate-700/30 text-center shadow-xl">
-                    <Server className="w-12 h-12 mx-auto text-slate-400 mb-4" />
-                    <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 mb-2">ComfyUI Disconnected</h2>
-                    <p className="text-slate-600 dark:text-slate-400 mb-6 text-sm">Please connect to a ComfyUI server first to manage updates.</p>
+                <div className="absolute inset-0 bg-[#0b0c0f]" />
+                <div className="relative z-10 p-4 max-w-md w-full bg-[#101217] rounded-xl border border-white/10 text-center shadow-xl">
+                    <Server className="w-12 h-10 mx-auto text-[#565d6b] mb-4" />
+                    <h2 className="text-[15px] font-bold text-[#e9ebef] mb-2">ComfyUI Disconnected</h2>
+                    <p className="text-[#8a919e] mb-3 text-[12px]">Please connect to a ComfyUI server first to manage updates.</p>
                     <Button onClick={() => navigate(-1)} variant="outline" className="w-full">{t('common.back')}</Button>
                 </div>
             </div>
@@ -165,49 +165,49 @@ export const AppUpdate: React.FC = () => {
             className="bg-black transition-colors duration-300 pwa-container h-[100dvh] fixed inset-0 overflow-hidden"
             style={{ touchAction: 'none' }}
         >
-            <div className="absolute inset-0 bg-gradient-to-br from-slate-50 via-purple-50/20 to-blue-50/20 dark:from-slate-950 dark:via-purple-950/10 dark:to-slate-950" />
+            <div className="absolute inset-0 bg-[#0b0c0f]" />
 
             <div className="absolute inset-0 overflow-y-auto overflow-x-hidden safe-area-inset" style={{ touchAction: 'pan-y' }}>
-                <header className="sticky top-0 z-50 bg-white/40 dark:bg-slate-900/40 backdrop-blur-xl border-b border-white/20 dark:border-slate-800/50 p-4">
+                <header className="sticky top-0 z-50 bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] p-4">
                     <div className="max-w-2xl mx-auto flex items-center space-x-4">
-                        <Button onClick={() => navigate(-1)} variant="outline" size="icon" className="h-10 w-10 bg-white/20 dark:bg-slate-800/30">
+                        <Button onClick={() => navigate(-1)} variant="outline" size="icon" className="h-9 w-9 bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] rounded-[10px] text-[#c8ccd4]">
                             <ArrowLeft className="h-4 w-4" />
                         </Button>
                         <div>
-                            <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">{t('appUpdate.title')}</h1>
-                            <p className="text-xs text-slate-500 dark:text-slate-400">{t('appUpdate.subtitle')}</p>
+                            <h1 className="text-[15px] font-bold text-[#e9ebef]">{t('appUpdate.title')}</h1>
+                            <p className="text-xs text-[#71798a]">{t('appUpdate.subtitle')}</p>
                         </div>
                     </div>
                 </header>
 
-                <main className="container mx-auto px-4 py-8 max-w-2xl relative">
-                    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
+                <main className="container mx-auto px-4 py-5 max-w-2xl relative">
+                    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-2">
 
-                        <div className="bg-white/50 dark:bg-slate-800/40 backdrop-blur-md border border-slate-200 dark:border-slate-700/50 rounded-3xl p-6 shadow-xl overflow-hidden relative">
+                        <div className="border border-white/[0.08] rounded-xl bg-white/[0.025] p-4 shadow-xl overflow-hidden relative">
                             {/* Version Info Section */}
                             <div className="flex flex-col items-center mb-10 mt-4">
                                 <div className="flex items-center space-x-6">
                                     <div className="text-center group">
-                                        <p className="text-[10px] text-slate-400 uppercase font-bold tracking-widest mb-2">{t('appUpdate.current')}</p>
+                                        <p className="text-[10px] text-[#565d6b] uppercase font-bold tracking-widest mb-2">{t('appUpdate.current')}</p>
                                         <div className="relative">
-                                            <div className="absolute -inset-1 bg-blue-500/20 rounded-full blur opacity-0 group-hover:opacity-100 transition-opacity" />
-                                            <Badge variant="outline" className="relative text-xl px-4 py-2 font-mono bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700 shadow-sm">
+                                            <div className="absolute -inset-1 bg-[#3069f0]/20 rounded-full blur opacity-0 group-hover:opacity-100 transition-opacity" />
+                                            <Badge variant="outline" className="relative text-[15px] px-4 py-2 font-mono bg-[#101217] border-white/[0.08] shadow-sm">
                                                 {remoteVersion || 'dev'}
                                             </Badge>
                                         </div>
                                     </div>
 
                                     <div className="flex flex-col items-center py-4">
-                                        <div className="w-8 h-[2px] bg-gradient-to-r from-blue-400 to-purple-400 rounded-full opacity-30" />
+                                        <div className="w-8 h-[2px] bg-[#3069f0] rounded-full opacity-30" />
                                     </div>
 
                                     <div className="text-center group">
-                                        <p className="text-[10px] text-slate-400 uppercase font-bold tracking-widest mb-2">{t('appUpdate.latest')}</p>
+                                        <p className="text-[10px] text-[#565d6b] uppercase font-bold tracking-widest mb-2">{t('appUpdate.latest')}</p>
                                         <div className="relative">
-                                            <div className={`absolute -inset-1 rounded-full blur opacity-0 group-hover:opacity-100 transition-opacity ${updateInfo?.has_update ? 'bg-purple-500/20' : 'bg-green-500/20'}`} />
-                                            <Badge className={`relative text-xl px-4 py-2 font-mono text-white shadow-lg ${loading ? 'bg-slate-300 dark:bg-slate-700' :
-                                                updateInfo?.has_update ? 'bg-purple-600' :
-                                                    updateInfo ? 'bg-green-600' : 'bg-slate-300 dark:bg-slate-700'
+                                            <div className={`absolute -inset-1 rounded-full blur opacity-0 group-hover:opacity-100 transition-opacity ${updateInfo?.has_update ? 'bg-[#3069f0]/20' : 'bg-[#34c77b]/20'}`} />
+                                            <Badge className={`relative text-[15px] px-4 py-2 font-mono text-white shadow-lg ${loading ? 'bg-slate-300 dark:bg-slate-700' :
+                                                updateInfo?.has_update ? 'bg-[#3069f0]' :
+                                                    updateInfo ? 'bg-[#34c77b]' : 'bg-slate-300 dark:bg-slate-700'
                                                 }`}>
                                                 {loading ? '...' : updateInfo?.latest_version || '?'}
                                             </Badge>
@@ -217,75 +217,75 @@ export const AppUpdate: React.FC = () => {
                             </div>
 
                             {/* Status and Action Area */}
-                            <div className="space-y-6">
+                            <div className="space-y-2">
                                 <AnimatePresence mode="wait">
                                     {loading ? (
                                         <motion.div key="loading" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col items-center py-10">
                                             <div className="relative">
-                                                <div className="w-12 h-12 rounded-full border-4 border-purple-500/10 border-t-purple-500 animate-spin" />
+                                                <div className="w-10 h-10 rounded-full border-2 border-white/[0.08] border-t-[#3069f0] animate-spin" />
                                                 <div className="absolute inset-0 flex items-center justify-center">
-                                                    <div className="w-6 h-6 rounded-full border-2 border-blue-500/20 border-b-blue-500 animate-spin-reverse" />
+                                                    <div className="w-6 h-6 rounded-full border-2 border-[#3069f0]/20 border-b-[#5b8af5] animate-spin-reverse" />
                                                 </div>
                                             </div>
-                                            <p className="mt-4 text-sm font-medium text-slate-500 dark:text-slate-400 animate-pulse">{t('appUpdate.checking')}</p>
+                                            <p className="mt-4 text-[12px] font-medium text-[#71798a] animate-pulse">{t('appUpdate.checking')}</p>
                                         </motion.div>
                                     ) : error ? (
-                                        <motion.div key="error" initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="p-5 bg-red-50/50 dark:bg-red-950/20 border border-red-200/50 dark:border-red-900/30 rounded-2xl">
+                                        <motion.div key="error" initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="p-5 bg-red-50/50 dark:bg-red-950/20 border border-red-200/50 dark:border-red-900/30 rounded-xl">
                                             <div className="flex items-start space-x-3">
-                                                <AlertCircle className="w-5 h-5 text-red-500 mt-0.5" />
+                                                <AlertCircle className="w-5 h-5 text-[#f25555] mt-0.5" />
                                                 <div className="flex-1">
-                                                    <p className="text-sm font-bold text-red-900 dark:text-red-400">{t('appUpdate.checkFailed')}</p>
+                                                    <p className="text-[12px] font-bold text-red-900 dark:text-[#f87c7c]">{t('appUpdate.checkFailed')}</p>
                                                     <p className="text-xs text-red-700 dark:text-red-300/70 mt-1 leading-relaxed">{error}</p>
                                                 </div>
                                             </div>
-                                            <Button onClick={checkUpdate} variant="outline" size="sm" className="mt-4 w-full h-10 rounded-xl bg-white dark:bg-slate-900 border-red-200 dark:border-red-900 hover:bg-red-50">
+                                            <Button onClick={checkUpdate} variant="outline" size="sm" className="mt-4 w-full h-10 rounded-xl bg-[#f25555]/[0.1] border-[#f25555]/30 text-[#f87c7c] hover:bg-[#f25555]/[0.18]">
                                                 {t('appUpdate.tryAgain')}
                                             </Button>
                                         </motion.div>
                                     ) : updateInfo ? (
-                                        <motion.div key="info" initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6">
+                                        <motion.div key="info" initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2">
                                             {updateInfo.has_update ? (
-                                                <div className="space-y-4">
+                                                <div className="space-y-2.5">
                                                     <div className="flex items-center justify-between">
-                                                        <h3 className="text-sm font-bold text-slate-900 dark:text-slate-100">{t('appUpdate.releaseNotes')}</h3>
-                                                        <Badge variant="secondary" className="bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 px-2 py-0 text-[10px]">{t('appUpdate.newVersion')}</Badge>
+                                                        <h3 className="text-[12px] font-bold text-[#e9ebef]">{t('appUpdate.releaseNotes')}</h3>
+                                                        <Badge variant="secondary" className="bg-[#3069f0]/[0.12] text-[#7ba3f5] border border-[#3069f0]/30 px-2 py-0 font-mono text-[9px]">{t('appUpdate.newVersion')}</Badge>
                                                     </div>
-                                                    <div className="bg-slate-100/50 dark:bg-black/30 p-4 rounded-2xl max-h-60 overflow-y-auto text-sm text-slate-600 dark:text-slate-400 leading-relaxed scrollbar-thin scrollbar-thumb-slate-300 dark:scrollbar-thumb-slate-700">
+                                                    <div className="bg-slate-100/50 dark:bg-black/30 p-4 rounded-xl max-h-60 overflow-y-auto text-[12px] text-[#8a919e] leading-relaxed scrollbar-thin scrollbar-thumb-slate-300 dark:scrollbar-thumb-slate-700">
                                                         {updateInfo.release_notes || t('appUpdate.noNotes')}
                                                     </div>
                                                 </div>
                                             ) : (
-                                                <div className="py-10 flex flex-col items-center bg-green-50/30 dark:bg-green-950/10 rounded-2xl border border-green-100 dark:border-green-900/20">
-                                                    <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center mb-4">
-                                                        <CheckCircle className="w-8 h-8 text-green-600 dark:text-green-400" />
+                                                <div className="py-10 flex flex-col items-center bg-green-50/30 dark:bg-green-950/10 rounded-xl border border-green-100 dark:border-green-900/20">
+                                                    <div className="w-10 h-10 rounded-full bg-[#34c77b]/[0.12] border border-[#34c77b]/30 flex items-center justify-center mb-4">
+                                                        <CheckCircle className="w-8 h-8 text-green-600 dark:text-[#4ade80]" />
                                                     </div>
-                                                    <h3 className="text-lg font-bold text-green-800 dark:text-green-400">{t('appUpdate.upToDate')}</h3>
-                                                    <p className="text-sm text-green-600 dark:text-green-500/70">{t('appUpdate.upToDateDesc')}</p>
+                                                    <h3 className="text-[14px] font-bold text-green-800 dark:text-[#4ade80]">{t('appUpdate.upToDate')}</h3>
+                                                    <p className="text-[12px] text-green-600 dark:text-[#4ade80]/70">{t('appUpdate.upToDateDesc')}</p>
                                                 </div>
                                             )}
 
                                             {/* Progress / Actions */}
                                             {(downloading || updateComplete) && (
-                                                <div className="space-y-3 p-4 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800">
+                                                <div className="space-y-2 p-4 bg-[#101217] rounded-xl border border-white/[0.08]">
                                                     <div className="flex justify-between items-center text-[10px] font-bold uppercase tracking-wider">
-                                                        <span className="text-purple-600 dark:text-purple-400">{downloadStatus}</span>
-                                                        <span className="text-slate-400">{progress.toFixed(0)}%</span>
+                                                        <span className="text-[#9a8af0]">{downloadStatus}</span>
+                                                        <span className="text-[#565d6b]">{progress.toFixed(0)}%</span>
                                                     </div>
-                                                    <Progress value={progress} className="h-2 bg-slate-100 dark:bg-slate-800" />
+                                                    <Progress value={progress} className="h-1 bg-white/[0.06]" />
                                                 </div>
                                             )}
 
                                             <div className="pt-2">
                                                 {updateComplete ? (
-                                                    <Button onClick={handleRestart} className="w-full h-14 rounded-2xl bg-green-600 hover:bg-green-700 text-white shadow-lg shadow-green-500/20 font-bold transition-transform active:scale-95">
+                                                    <Button onClick={handleRestart} className="w-full h-10 rounded-xl bg-[#34c77b] hover:bg-[#3fd08a] text-white font-semibold transition-transform active:scale-95">
                                                         <RotateCcw className="w-5 h-5 mr-3" /> {t('appUpdate.finishRestart')}
                                                     </Button>
                                                 ) : updateInfo.has_update ? (
-                                                    <div className="space-y-4">
+                                                    <div className="space-y-2.5">
                                                         <Button
                                                             onClick={startUpdate}
                                                             disabled={downloading || isDev}
-                                                            className="w-full h-14 rounded-2xl bg-purple-600 hover:bg-purple-700 text-white shadow-lg shadow-purple-500/20 font-bold transition-transform active:scale-95 disabled:opacity-50"
+                                                            className="w-full h-10 rounded-xl bg-[#3069f0] hover:bg-[#3f78f5] text-white font-semibold shadow-[0_2px_12px_rgba(48,105,240,0.3)] transition-transform active:scale-95 disabled:opacity-50"
                                                         >
                                                             {downloading ? (
                                                                 <div className="flex items-center">
@@ -297,13 +297,13 @@ export const AppUpdate: React.FC = () => {
                                                             )}
                                                         </Button>
                                                         {isDev && (
-                                                            <p className="text-center text-xs text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-900/50 p-2 rounded-lg border border-dashed border-slate-300 dark:border-slate-700">
+                                                            <p className="text-center text-xs text-[#71798a] bg-slate-100 dark:bg-[#101217]/50 p-2 rounded-lg border border-dashed border-slate-300 dark:border-white/[0.08]">
                                                                 {t('appUpdate.devVersionNotice')}
                                                             </p>
                                                         )}
                                                     </div>
                                                 ) : (
-                                                    <Button onClick={checkUpdate} variant="outline" className="w-full h-12 rounded-2xl border-slate-200 dark:border-slate-800 text-slate-500">
+                                                    <Button onClick={checkUpdate} variant="outline" className="w-full h-10 rounded-xl border-white/[0.08] text-[#71798a]">
                                                         {t('appUpdate.recheck')}
                                                     </Button>
                                                 )}
@@ -315,16 +315,16 @@ export const AppUpdate: React.FC = () => {
                         </div>
 
                         {/* Additional Links Card */}
-                        <div className="bg-slate-100/50 dark:bg-slate-900/40 rounded-3xl p-6 border border-slate-200 dark:border-slate-800 flex items-center justify-between">
-                            <div className="flex items-center space-x-3 text-slate-600 dark:text-slate-400">
+                        <div className="bg-slate-100/50 dark:bg-[#101217]/40 rounded-xl p-4 border border-white/[0.08] flex items-center justify-between">
+                            <div className="flex items-center space-x-3 text-[#8a919e]">
                                 <ExternalLink className="w-5 h-5" />
-                                <span className="text-sm font-medium">GitHub Repository</span>
+                                <span className="text-[12px] font-medium">GitHub Repository</span>
                             </div>
                             <Button
                                 variant="ghost"
                                 size="sm"
                                 onClick={() => window.open('https://github.com/jaeone94/comfy-mobile-ui', '_blank')}
-                                className="text-blue-500 hover:text-blue-600"
+                                className="text-[#5b8af5] hover:text-blue-600"
                             >
                                 {t('common.open')}
                             </Button>

--- a/src/components/server/ServerReboot.tsx
+++ b/src/components/server/ServerReboot.tsx
@@ -495,21 +495,21 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
 
   const getStatusColor = (phase: string) => {
     switch (phase) {
-      case 'success': return 'text-green-600 dark:text-green-400';
-      case 'failed': return 'text-red-600 dark:text-red-400';
+      case 'success': return 'text-green-600 dark:text-[#4ade80]';
+      case 'failed': return 'text-red-600 dark:text-[#f87c7c]';
       case 'rebooting':
-      case 'waiting': return 'text-blue-600 dark:text-blue-400';
-      default: return 'text-slate-600 dark:text-slate-400';
+      case 'waiting': return 'text-blue-600 dark:text-[#5b8af5]';
+      default: return 'text-[#8a919e]';
     }
   };
 
   const getStatusIcon = (phase: string) => {
     switch (phase) {
-      case 'success': return <CheckCircle className="h-5 w-5 text-green-500" />;
-      case 'failed': return <XCircle className="h-5 w-5 text-red-500" />;
+      case 'success': return <CheckCircle className="h-4 w-4 text-[#4ade80]" />;
+      case 'failed': return <XCircle className="h-5 w-5 text-[#f25555]" />;
       case 'rebooting':
-      case 'waiting': return <Loader2 className="h-5 w-5 text-blue-500 animate-spin" />;
-      default: return <Server className="h-5 w-5 text-slate-500" />;
+      case 'waiting': return <Loader2 className="h-5 w-5 text-[#5b8af5] animate-spin" />;
+      default: return <Server className="h-5 w-5 text-[#71798a]" />;
     }
   };
 
@@ -545,10 +545,7 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
       }}
     >
       {/* Main Background with Dark Theme */}
-      <div className="absolute inset-0 bg-[#374151]" />
-
-      {/* Glassmorphism Background Overlay */}
-      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
 
       {/* Main Scrollable Content Area */}
       <div
@@ -560,22 +557,22 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
         }}
       >
         {/* Header */}
-        <header className="sticky top-0 z-50 pwa-header bg-[#1e293b] border-b border-white/10 shadow-xl relative overflow-hidden">
+        <header className="sticky top-0 z-50 pwa-header bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
           <div className="relative z-10 flex items-center justify-between p-4">
             <div className="flex items-center space-x-3">
               <Button
                 onClick={handleBackNavigation}
                 variant="ghost"
                 size="sm"
-                className="bg-white/10 backdrop-blur-sm border border-white/10 shadow-lg hover:bg-white/20 transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg text-white"
+                className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] transition-all h-9 w-9 p-0 flex-shrink-0 rounded-[10px] text-[#c8ccd4]"
               >
                 <ArrowLeft className="h-4 w-4" />
               </Button>
               <div>
-                <h1 className="text-lg font-bold text-white/95 leading-none">
+                <h1 className="text-[15px] font-bold text-[#e9ebef] leading-none">
                   {t('serverReboot.title')}
                 </h1>
-                <p className="text-[11px] text-white/40 mt-1">
+                <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">
                   {t('serverReboot.subtitle')}
                 </p>
               </div>
@@ -584,23 +581,23 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
         </header>
 
         {/* Content Area */}
-        <div className="container mx-auto px-6 py-8 max-w-4xl space-y-6">
+        <div className="container mx-auto px-4 py-5 max-w-4xl space-y-2">
           {/* Server Requirements Check */}
           <Card className={`border backdrop-blur-sm shadow-xl ${isConnected && hasExtension
-            ? 'border-green-500/20 bg-green-500/5'
-            : 'border-amber-500/20 bg-amber-500/5'
+            ? 'border-[#34c77b]/20 bg-[#34c77b]/5'
+            : 'border-amber-500/20 bg-[#ffa348]/5'
             }`}>
             <CardHeader className="pb-3">
               <CardTitle className="flex items-center space-x-2 text-white/90">
-                <Server className="h-5 w-5 text-blue-400" />
+                <Server className="h-4 w-4 text-[#5b8af5]" />
                 <span>{t('serverReboot.cardTitle')}</span>
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-2.5">
               {isCheckingExtension ? (
                 <div className="flex items-center space-x-3">
-                  <Loader2 className="h-4 w-4 animate-spin text-blue-400" />
-                  <span className="text-sm text-white/70">
+                  <Loader2 className="h-4 w-4 animate-spin text-[#5b8af5]" />
+                  <span className="text-[12px] text-white/70">
                     {t('serverReboot.checking')}
                   </span>
                 </div>
@@ -610,12 +607,12 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                   <div className="flex items-center justify-between">
                     <span className="font-medium text-white/70">{t('serverReboot.serverStatus')}</span>
                     {isConnected ? (
-                      <Badge className="bg-green-500/20 text-green-300 border-green-500/30">
+                      <Badge className="bg-[#34c77b]/[0.12] text-[#4ade80] border-[#34c77b]/[0.28]">
                         <CheckCircle className="h-3 w-3 mr-1" />
                         {t('common.connected')}
                       </Badge>
                     ) : (
-                      <Badge variant="destructive" className="bg-red-500/20 text-red-300 border-red-500/30">
+                      <Badge variant="destructive" className="bg-[#f25555]/[0.12] text-[#f87c7c] border-[#f25555]/30">
                         <AlertCircle className="h-3 w-3 mr-1" />
                         {t('common.disconnected')}
                       </Badge>
@@ -627,12 +624,12 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                     <div className="flex items-center justify-between">
                       <span className="font-medium text-white/70">{t('serverReboot.extensionStatus')}</span>
                       {hasExtension ? (
-                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">
+                        <Badge className="bg-[#34c77b]/[0.12] text-[#4ade80] border-[#34c77b]/[0.28]">
                           <CheckCircle className="h-3 w-3 mr-1" />
                           {t('common.available')}
                         </Badge>
                       ) : (
-                        <Badge variant="destructive" className="bg-red-500/20 text-red-300 border-red-500/30">
+                        <Badge variant="destructive" className="bg-[#f25555]/[0.12] text-[#f87c7c] border-[#f25555]/30">
                           <AlertCircle className="h-3 w-3 mr-1" />
                           {t('common.notFound')}
                         </Badge>
@@ -647,10 +644,10 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
 
                   {/* Status Summary */}
                   {isConnected && hasExtension && !error && !isRebooting && (
-                    <div className="p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
+                    <div className="p-3 bg-[#34c77b]/10 border border-[#34c77b]/20 rounded-lg">
                       <div className="flex items-center space-x-2">
-                        <CheckCircle className="h-4 w-4 text-green-400" />
-                        <span className="text-sm font-medium text-green-300">
+                        <CheckCircle className="h-4 w-4 text-[#4ade80]" />
+                        <span className="text-[12px] font-medium text-[#4ade80]">
                           {t('serverReboot.ready')}
                         </span>
                       </div>
@@ -659,20 +656,20 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
 
                   {/* Error Messages */}
                   {(!isConnected || !hasExtension || error) && (
-                    <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg space-y-2">
-                      <h4 className="text-sm font-medium text-red-300">{t('serverReboot.issues')}</h4>
-                      <ul className="text-sm text-red-300/80 space-y-1 list-disc list-inside">
+                    <div className="p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg space-y-2">
+                      <h4 className="text-[12px] font-medium text-[#f87c7c]">{t('serverReboot.issues')}</h4>
+                      <ul className="text-[11.5px] text-[#f87c7c]/80 space-y-1 list-disc list-inside">
                         {!isConnected && <li>{t('serverReboot.issueConnection')}</li>}
                         {isConnected && !hasExtension && <li>{t('serverReboot.issueExtension')}</li>}
                         {error && !isRebooting && <li>{error}</li>}
                       </ul>
 
                       {!hasExtension && isConnected && (
-                        <div className="mt-2 p-2 bg-blue-500/10 border border-blue-500/20 rounded">
-                          <p className="text-xs text-blue-300">
+                        <div className="mt-2 p-2 bg-[#3069f0]/10 border border-[#3069f0]/20 rounded">
+                          <p className="text-xs text-[#7ba3f5]">
                             <strong>To fix:</strong> {t('serverReboot.fixInstall')}
                           </p>
-                          <p className="text-xs text-blue-300/80 mt-1 font-mono bg-black/20 p-1 rounded">
+                          <p className="text-xs text-[#7ba3f5]/80 mt-1 font-mono bg-black/20 p-1 rounded">
                             {t('serverReboot.path')} ComfyUI/custom_nodes/comfyui-mobile-ui-api-extension/
                           </p>
                         </div>
@@ -707,13 +704,13 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
 
           {/* Watchdog Service - Independent Card */}
           <Card className={`border backdrop-blur-sm shadow-xl ${watchdogStatus.available && watchdogStatus.running
-            ? 'border-blue-500/20 bg-blue-500/5'
+            ? 'border-[#3069f0]/20 bg-[#3069f0]/5'
             : 'border-white/10 bg-black/20'
             }`}>
             <CardHeader className="pb-3">
               <CardTitle className="flex items-center justify-between text-white/90">
                 <div className="flex items-center space-x-2">
-                  <AlertCircle className="h-5 w-5 text-yellow-400" />
+                  <AlertCircle className="h-4 w-4 text-[#ffa348]" />
                   <span>Watchdog Service</span>
                 </div>
                 {watchdogStatus.lastChecked && (
@@ -723,11 +720,11 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                 )}
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-2.5">
               {isCheckingWatchdog ? (
                 <div className="flex items-center space-x-3">
-                  <Loader2 className="h-4 w-4 animate-spin text-blue-400" />
-                  <span className="text-sm text-white/70">
+                  <Loader2 className="h-4 w-4 animate-spin text-[#5b8af5]" />
+                  <span className="text-[12px] text-white/70">
                     {t('serverReboot.checkingWatchdog')}
                   </span>
                 </div>
@@ -737,12 +734,12 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                   <div className="flex items-center justify-between">
                     <span className="font-medium text-white/70">Watchdog Service</span>
                     {watchdogStatus.available && watchdogStatus.running ? (
-                      <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30">
+                      <Badge className="bg-[#3069f0]/[0.12] text-[#7ba3f5] border-[#3069f0]/30">
                         <CheckCircle className="h-3 w-3 mr-1" />
                         Active & Running
                       </Badge>
                     ) : watchdogStatus.available ? (
-                      <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">
+                      <Badge className="bg-[#ffa348]/[0.12] text-[#ffa348] border-[#ffa348]/30">
                         <AlertCircle className="h-3 w-3 mr-1" />
                         Available (Stopped)
                       </Badge>
@@ -759,12 +756,12 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                     <div className="flex items-center justify-between">
                       <span className="font-medium text-white/70">{t('serverReboot.monitorStatus')}</span>
                       {watchdogStatus.comfyuiResponsive ? (
-                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">
+                        <Badge className="bg-[#34c77b]/[0.12] text-[#4ade80] border-[#34c77b]/[0.28]">
                           <CheckCircle className="h-3 w-3 mr-1" />
                           {t('serverReboot.responsive')}
                         </Badge>
                       ) : (
-                        <Badge variant="destructive" className="bg-red-500/20 text-red-300 border-red-500/30">
+                        <Badge variant="destructive" className="bg-[#f25555]/[0.12] text-[#f87c7c] border-[#f25555]/30">
                           <XCircle className="h-3 w-3 mr-1" />
                           {t('serverReboot.notResponding')}
                         </Badge>
@@ -774,18 +771,18 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
 
                   {/* Restart Capability Info */}
                   <div className={`p-3 border rounded-lg ${watchdogStatus.available
-                    ? 'bg-blue-500/10 border-blue-500/20'
+                    ? 'bg-[#3069f0]/10 border-[#3069f0]/20'
                     : 'bg-white/5 border-white/10'
                     }`}>
                     <div className="flex items-start space-x-3">
                       {watchdogStatus.available ? (
-                        <CheckCircle className="h-4 w-4 text-blue-400 mt-0.5" />
+                        <CheckCircle className="h-4 w-4 text-[#5b8af5] mt-0.5" />
                       ) : (
                         <AlertCircle className="h-4 w-4 text-white/40 mt-0.5" />
                       )}
                       <div>
-                        <p className={`text-sm font-medium ${watchdogStatus.available && watchdogStatus.running
-                          ? 'text-blue-300'
+                        <p className={`text-[12px] font-medium ${watchdogStatus.available && watchdogStatus.running
+                          ? 'text-[#7ba3f5]'
                           : 'text-white/60'
                           }`}>
                           {
@@ -806,7 +803,7 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                           }
                         </p>
                         {watchdogStatus.available && !watchdogStatus.comfyuiResponsive && (
-                          <p className="text-xs mt-1 text-orange-400">
+                          <p className="text-xs mt-1 text-[#ffa348]">
                             {t('serverReboot.downWarning')}
                           </p>
                         )}
@@ -856,7 +853,7 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
           </Card>
 
           {/* Reboot Control */}
-          <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+          <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none">
             <CardHeader>
               <CardTitle className="text-white/90">
                 {t('serverReboot.controlTitle')}
@@ -865,7 +862,7 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
             <CardContent>
               {/* Reboot Status */}
               {rebootStatus.phase !== 'idle' && (
-                <div className="mb-6 p-4 bg-white/5 rounded-lg border border-white/10">
+                <div className="mb-3 p-4 bg-white/5 rounded-lg border border-white/10">
                   <div className="flex items-center space-x-3 mb-2">
                     {getStatusIcon(rebootStatus.phase)}
                     <span className={`font-medium ${getStatusColor(rebootStatus.phase)}`}>
@@ -873,7 +870,7 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                     </span>
                   </div>
                   {rebootStatus.details && (
-                    <p className="text-sm text-white/60 ml-8">
+                    <p className="text-[12px] text-white/60 ml-8">
                       {rebootStatus.details}
                     </p>
                   )}
@@ -882,18 +879,18 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                   {rebootStatus.logs && rebootStatus.logs.length > 0 && (
                     <div className="mt-4 ml-8">
                       <details className="group">
-                        <summary className="cursor-pointer text-sm font-medium text-white/70 hover:text-white transition-colors">
+                        <summary className="cursor-pointer text-[12px] font-medium text-white/70 hover:text-white transition-colors">
                           {t('serverReboot.recentLogs', { count: rebootStatus.logs.length })}
                         </summary>
-                        <div className="mt-2 p-3 bg-black/50 text-green-400 text-xs font-mono rounded border border-white/10 max-h-64 overflow-y-auto custom-scrollbar">
+                        <div className="mt-2 p-3 rounded-lg border border-white/[0.08] font-mono text-[10px] leading-[1.5] max-h-64 overflow-y-auto custom-scrollbar" style={{ background: '#08090c' }}>
                           {rebootStatus.logs.map((log: any, idx: number) => (
                             <div key={idx} className="mb-1 break-all">
-                              <span className="text-white/40">[{log.timestamp}]</span>{' '}
-                              <span className={`font-bold ${log.level === 'error' ? 'text-red-400' :
-                                log.level === 'warning' ? 'text-yellow-400' :
-                                  log.level === 'success' ? 'text-green-400' :
-                                    log.level === 'restart' ? 'text-blue-400' :
-                                      log.level === 'api' ? 'text-purple-400' :
+                              <span className="text-[#3d4450]">[{log.timestamp}]</span>{' '}
+                              <span className={`font-bold ${log.level === 'error' ? 'text-[#f87c7c]' :
+                                log.level === 'warning' ? 'text-[#ffa348]' :
+                                  log.level === 'success' ? 'text-[#4ade80]' :
+                                    log.level === 'restart' ? 'text-[#5b8af5]' :
+                                      log.level === 'api' ? 'text-[#9a8af0]' :
                                         'text-white/40'
                                 }`}>
                                 [{log.level?.toUpperCase() || 'INFO'}]
@@ -908,34 +905,35 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
                 </div>
               )}
 
-              <div className="space-y-6">
-                <div className="space-y-2">
-                  <p className="text-sm font-medium text-white/80">
-                    {t('serverReboot.confirmMessage')}
-                  </p>
-                  <ul className="text-sm text-white/60 space-y-1 ml-4 list-disc list-outside">
-                    <li>{t('serverReboot.confirmList.interrupt')}</li>
-                    <li>{t('serverReboot.confirmList.reload')}</li>
-                    <li>{t('serverReboot.confirmList.clear')}</li>
-                    <li>{t('serverReboot.confirmList.time')}</li>
-                  </ul>
+              <div className="space-y-3">
+                <div className="rounded-xl p-3 border" style={{ background: 'rgba(240,171,82,0.05)', borderColor: 'rgba(240,171,82,0.22)' }}>
+                  <div className="flex items-center gap-2 mb-2">
+                    <AlertCircle className="h-3.5 w-3.5 text-[#e0a860]" strokeWidth={1.8} />
+                    <span className="text-[12.5px] font-semibold text-[#e8c496]">{t('serverReboot.confirmMessage')}</span>
+                  </div>
+                  <div className="flex flex-col gap-1.5 text-[11.5px] leading-[1.5] text-[#a89478]">
+                    <div>· {t('serverReboot.confirmList.interrupt')}</div>
+                    <div>· {t('serverReboot.confirmList.reload')}</div>
+                    <div>· {t('serverReboot.confirmList.clear')}</div>
+                    <div>· {t('serverReboot.confirmList.time')}</div>
+                  </div>
                 </div>
 
                 <Button
                   onClick={handleReboot}
                   disabled={!canReboot}
-                  className="w-full h-12 bg-gradient-to-r from-red-600 to-orange-600 hover:from-red-700 hover:to-orange-700 text-white shadow-lg shadow-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="w-full h-[46px] rounded-[10px] border text-[13.5px] font-semibold bg-[#f25555]/[0.12] border-[#f25555]/[0.32] text-[#f87c7c] hover:bg-[#f25555]/[0.2] shadow-none disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isRebooting ? (
                     <>
-                      <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+                      <Loader2 className="h-[15px] w-[15px] mr-2 animate-spin" />
                       {rebootStatus.phase === 'rebooting' ? 'Rebooting...' :
                         rebootStatus.phase === 'waiting' ? t('serverReboot.waiting') :
                           t('serverReboot.processing')}
                     </>
                   ) : (
                     <>
-                      <RotateCcw className="h-5 w-5 mr-2" />
+                      <RotateCcw className="h-[15px] w-[15px] mr-2" strokeWidth={1.8} />
                       {t('serverReboot.button')}
                     </>
                   )}
@@ -943,8 +941,8 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
 
                 {!canReboot && !isRebooting && (
                   <div className="p-3 bg-white/5 border border-white/10 rounded-lg">
-                    <p className="text-sm font-medium text-white/70 mb-2">{t('serverReboot.unavailableReasons.title')}</p>
-                    <div className="text-sm text-white/50 space-y-1 ml-2">
+                    <p className="text-[12px] font-medium text-white/70 mb-2">{t('serverReboot.unavailableReasons.title')}</p>
+                    <div className="text-[12px] text-white/50 space-y-1 ml-2">
                       {!(isConnected && hasExtension) &&
                         !(watchdogStatus.available && watchdogStatus.running) && (
                           <p>• {t('serverReboot.unavailableReasons.noService')}</p>
@@ -964,23 +962,19 @@ const ServerReboot: React.FC<ServerRebootProps> = ({ onBack }) => {
           </Card>
 
           {/* Help Information */}
-          <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-2 text-white/90">
-                <Info className="h-5 w-5 text-cyan-400" />
-                <span>{t('serverReboot.helpTitle')}</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2 text-sm text-white/60">
-                <p>• {t('serverReboot.helpList.1')}</p>
-                <p>• {t('serverReboot.helpList.2')}</p>
-                <p>• {t('serverReboot.helpList.3')}</p>
-                <p>• {t('serverReboot.helpList.4')}</p>
-                <p>• {t('serverReboot.helpList.5')}</p>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="border border-white/[0.08] rounded-xl p-3.5" style={{ background: 'rgba(255,255,255,0.025)' }}>
+            <div className="flex items-center gap-2 mb-2.5">
+              <Info className="h-3.5 w-3.5 text-[#5b8af5]" strokeWidth={1.8} />
+              <span className="text-[13px] font-semibold text-[#e9ebef]">{t('serverReboot.helpTitle')}</span>
+            </div>
+            <div className="flex flex-col gap-[7px] text-[11.5px] leading-[1.55] text-[#8a919e]">
+              <div>· {t('serverReboot.helpList.1')}</div>
+              <div>· {t('serverReboot.helpList.2')}</div>
+              <div>· {t('serverReboot.helpList.3')}</div>
+              <div>· {t('serverReboot.helpList.4')}</div>
+              <div>· {t('serverReboot.helpList.5')}</div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/server/ServerSettings.tsx
+++ b/src/components/server/ServerSettings.tsx
@@ -111,10 +111,7 @@ const ServerSettings: React.FC<ServerSettingsProps> = ({ onBack }) => {
       }}
     >
       {/* Main Background with Dark Theme */}
-      <div className="absolute inset-0 bg-[#374151]" />
-
-      {/* Glassmorphism Background Overlay */}
-      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
 
       {/* Main Scrollable Content Area */}
       <div
@@ -128,22 +125,22 @@ const ServerSettings: React.FC<ServerSettingsProps> = ({ onBack }) => {
         }}
       >
         {/* Header */}
-        <header className="sticky top-0 z-50 pwa-header bg-[#1e293b] border-b border-white/10 shadow-xl relative overflow-hidden">
+        <header className="sticky top-0 z-50 pwa-header bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
           <div className="relative z-10 flex items-center justify-between p-4">
             <div className="flex items-center space-x-3">
               <Button
                 onClick={handleBackNavigation}
                 variant="ghost"
                 size="sm"
-                className="bg-white/10 backdrop-blur-sm border border-white/10 shadow-lg hover:bg-white/20 transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg text-white"
+                className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] transition-all h-9 w-9 p-0 flex-shrink-0 rounded-[10px] text-[#c8ccd4]"
               >
                 <ArrowLeft className="h-4 w-4" />
               </Button>
               <div>
-                <h1 className="text-lg font-bold text-white/95 leading-none">
+                <h1 className="text-[15px] font-bold text-[#e9ebef] leading-none">
                   {t('serverSettings.title')}
                 </h1>
-                <p className="text-[11px] text-white/40 mt-1">
+                <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">
                   {t('serverSettings.subtitle')}
                 </p>
               </div>
@@ -152,166 +149,133 @@ const ServerSettings: React.FC<ServerSettingsProps> = ({ onBack }) => {
         </header>
 
         {/* Content */}
-        <div className="container mx-auto px-6 py-8 max-w-4xl space-y-6">
+        <div className="container mx-auto px-4 py-4 max-w-xl space-y-3">
           {/* Connection Status Card */}
-          <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-2 text-white/90">
-                <Server className="h-5 w-5 text-blue-400" />
-                <span>{t('serverSettings.statusTitle')}</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-white/70">{t('common.status')}</span>
-                {isConnected ? (
-                  <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
-                    <Wifi className="w-3 h-3 mr-1" />
-                    {t('common.connected')}
-                  </Badge>
-                ) : (
-                  <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
-                    <WifiOff className="w-3 h-3 mr-1" />
-                    {t('common.disconnected')}
-                  </Badge>
-                )}
-              </div>
-
-              {/* Enhanced verification steps */}
-              <div className="space-y-3 pt-2 border-t border-white/5">
-                {[
-                  { label: 'ComfyUI API', status: (isConnected || isConnecting) ? apiStatus : 'idle', icon: Server },
-                  { label: t('common.extension'), status: (isConnected || isConnecting) ? extensionStatus : 'idle', icon: Info }
-                ].map((step, idx) => (
-                  <div key={idx} className="flex items-center justify-between text-sm">
-                    <div className="flex items-center space-x-2 text-white/60">
-                      <step.icon className="h-4 w-4" />
-                      <span>{step.label}</span>
-                    </div>
-                    <div>
-                      {step.status === 'checking' && <Loader2 className="h-4 w-4 text-blue-400 animate-spin" />}
-                      {step.status === 'success' && <CheckCircle className="h-4 w-4 text-green-400" />}
-                      {step.status === 'failed' && <XCircle className="h-4 w-4 text-red-400" />}
-                      {step.status === 'idle' && <div className="h-4 w-4 rounded-full border border-white/10" />}
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {error && (
-                <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg">
-                  <div className="flex items-start space-x-3">
-                    <XCircle className="h-5 w-5 text-red-400 flex-shrink-0 mt-0.5" />
-                    <div className="text-sm text-red-400">
-                      {error}
-                    </div>
-                  </div>
-                </div>
+          <div className="border border-white/[0.08] rounded-xl px-3.5" style={{ background: 'rgba(255,255,255,0.025)' }}>
+            <div className="h-11 flex items-center justify-between">
+              <span className="text-[13px] font-semibold text-[#e9ebef]">{t('serverSettings.statusTitle')}</span>
+              {isConnected ? (
+                <span className="flex items-center gap-[7px] px-2.5 py-[5px] rounded-lg border text-[11.5px] font-semibold" style={{ background: 'rgba(52,199,123,.12)', borderColor: 'rgba(52,199,123,.28)', color: '#4ade80' }}>
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#4ade80]" />
+                  {t('common.connected')}
+                </span>
+              ) : (
+                <span className="flex items-center gap-[7px] px-2.5 py-[5px] rounded-lg border text-[11.5px] font-semibold" style={{ background: 'rgba(242,85,85,.12)', borderColor: 'rgba(242,85,85,.3)', color: '#f87c7c' }}>
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#f25555]" />
+                  {t('common.disconnected')}
+                </span>
               )}
-            </CardContent>
-          </Card>
+            </div>
+            <div className="h-px bg-white/[0.06]" />
+            {[
+              { label: 'ComfyUI API', status: (isConnected || isConnecting) ? apiStatus : 'idle' },
+              { label: t('common.extension'), status: (isConnected || isConnecting) ? extensionStatus : 'idle' }
+            ].map((step, idx) => (
+              <div key={idx} className="h-10 flex items-center justify-between">
+                <span className="text-[12.5px] text-[#9aa3b2]">{step.label}</span>
+                <span>
+                  {step.status === 'checking' && <Loader2 className="h-4 w-4 text-[#5b8af5] animate-spin" />}
+                  {step.status === 'success' && <CheckCircle className="h-4 w-4 text-[#4ade80]" strokeWidth={1.9} />}
+                  {step.status === 'failed' && <XCircle className="h-4 w-4 text-[#f87c7c]" strokeWidth={1.9} />}
+                  {step.status === 'idle' && <span className="block h-4 w-4 rounded-full border border-white/10" />}
+                </span>
+              </div>
+            ))}
+            {error && (
+              <div className="mb-3 p-2.5 bg-[#f25555]/10 border border-[#f25555]/25 rounded-lg flex items-start gap-2">
+                <XCircle className="h-3.5 w-3.5 text-[#f87c7c] flex-shrink-0 mt-0.5" strokeWidth={1.9} />
+                <div className="text-[11.5px] leading-relaxed text-[#f87c7c]">{error}</div>
+              </div>
+            )}
+          </div>
 
           {/* Server Configuration Card */}
-          <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-2 text-white/90">
-                <TestTube className="h-5 w-5 text-purple-400" />
-                <span>{t('serverSettings.configTitle')}</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {/* URL Input */}
-              <div className="space-y-2">
-                <Label className="text-white/70">
-                  {t('serverSettings.urlLabel')}
-                </Label>
-                <Input
-                  type="url"
-                  value={inputUrl}
-                  onChange={(e) => {
-                    setInputUrl(e.target.value);
-                    setError(null);
-                  }}
-                  placeholder="http://127.0.0.1:8188"
-                  className="bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl"
-                />
-                <p className="text-xs text-white/40">
-                  {t('serverSettings.urlDesc')}
-                </p>
-              </div>
+          <div className="border border-white/[0.08] rounded-xl p-3.5" style={{ background: 'rgba(255,255,255,0.025)' }}>
+            <div className="text-[13px] font-semibold text-[#e9ebef] mb-2.5">{t('serverSettings.configTitle')}</div>
 
-              {/* Quick URL Options */}
-              <div className="space-y-2">
-                <Label className="text-white/70 block">
-                  {t('serverSettings.quickOptions')}
-                </Label>
-                <div className="flex flex-wrap gap-2">
-                  {getDefaultUrls().map((defaultUrl) => (
-                    <Button
-                      key={defaultUrl}
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        setInputUrl(defaultUrl);
-                        setError(null);
-                      }}
-                      className="text-xs border-white/10 text-white/60 hover:bg-white/10 hover:text-white bg-transparent"
-                    >
-                      {defaultUrl}
-                    </Button>
-                  ))}
-                </div>
-              </div>
+            <div className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mb-[7px]">
+              {t('serverSettings.urlLabel')}
+            </div>
+            <Input
+              type="url"
+              value={inputUrl}
+              onChange={(e) => {
+                setInputUrl(e.target.value);
+                setError(null);
+              }}
+              placeholder="http://127.0.0.1:8188"
+              className="h-[42px] px-3 font-mono text-[13px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] rounded-[10px] focus-visible:ring-0 focus-visible:border-[#5b8af5]/40 focus-visible:shadow-[0_0_0_3px_rgba(48,105,240,0.1)]"
+            />
+            <p className="text-[11px] leading-relaxed text-[#66758a] mt-[7px]">
+              {t('serverSettings.urlDesc')}
+            </p>
 
-              {/* Action Buttons removed - integrated into Connect */}
-
-              {/* Connect/Disconnect Button */}
-              <div className="pt-2">
-                {isConnected ? (
-                  <Button
-                    onClick={handleDisconnect}
-                    variant="destructive"
-                    className="w-full bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30"
+            <div className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-3.5 mb-[7px]">
+              {t('serverSettings.quickOptions')}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {getDefaultUrls().map((defaultUrl) => {
+                const active = inputUrl === defaultUrl;
+                return (
+                  <button
+                    key={defaultUrl}
+                    onClick={() => {
+                      setInputUrl(defaultUrl);
+                      setError(null);
+                    }}
+                    className={`px-[11px] py-2 rounded-lg border font-mono text-[11px] whitespace-nowrap transition-colors ${active
+                      ? 'text-[#7ba3f5] border-[#3069f0]/30'
+                      : 'text-[#9aa3b2] border-white/[0.08] hover:text-[#c8ccd4]'
+                      }`}
+                    style={{ background: active ? 'rgba(61,123,253,.1)' : 'rgba(255,255,255,.04)' }}
                   >
-                    <WifiOff className="h-4 w-4 mr-2" />
-                    {t('serverSettings.disconnect')}
-                  </Button>
-                ) : (
-                  <Button
-                    onClick={handleConnect}
-                    disabled={isConnecting}
-                    className="w-full bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700 text-white shadow-lg shadow-blue-900/20"
-                  >
-                    {isConnecting ? (
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    ) : (
-                      <Power className="h-4 w-4 mr-2" />
-                    )}
-                    {isConnecting ? t('serverSettings.connecting') : t('serverSettings.connect')}
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+                    {defaultUrl}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-4">
+              {isConnected ? (
+                <button
+                  onClick={handleDisconnect}
+                  className="w-full h-11 flex items-center justify-center gap-2 rounded-[10px] border text-[13px] font-semibold transition-colors"
+                  style={{ background: 'rgba(242,85,85,.1)', borderColor: 'rgba(242,85,85,.3)', color: '#f87c7c' }}
+                >
+                  <WifiOff className="h-[15px] w-[15px]" strokeWidth={1.8} />
+                  {t('serverSettings.disconnect')}
+                </button>
+              ) : (
+                <button
+                  onClick={handleConnect}
+                  disabled={isConnecting}
+                  className="w-full h-11 flex items-center justify-center gap-2 rounded-[10px] bg-[#3069f0] hover:bg-[#3f78f5] text-white text-[13px] font-semibold transition-colors disabled:opacity-60"
+                >
+                  {isConnecting ? (
+                    <Loader2 className="h-[15px] w-[15px] animate-spin" />
+                  ) : (
+                    <Power className="h-[15px] w-[15px]" strokeWidth={1.8} />
+                  )}
+                  {isConnecting ? t('serverSettings.connecting') : t('serverSettings.connect')}
+                </button>
+              )}
+            </div>
+          </div>
 
           {/* Connection Help Card */}
-          <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-2 text-white/90">
-                <Info className="h-5 w-5 text-cyan-400" />
-                <span>{t('serverSettings.helpTitle')}</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2 text-sm text-white/60">
-                <p>• {t('serverSettings.helpList.1')}</p>
-                <p>• {t('serverSettings.helpList.2')}</p>
-                <p>• {t('serverSettings.helpList.3')}</p>
-                <p>• {t('serverSettings.helpList.4')}</p>
-                <p>• {t('serverSettings.helpList.5')}</p>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="border border-white/[0.08] rounded-xl p-3.5" style={{ background: 'rgba(255,255,255,0.025)' }}>
+            <div className="flex items-center gap-2 mb-2.5">
+              <Info className="h-3.5 w-3.5 text-[#5b8af5]" strokeWidth={1.8} />
+              <span className="text-[13px] font-semibold text-[#e9ebef]">{t('serverSettings.helpTitle')}</span>
+            </div>
+            <div className="flex flex-col gap-[7px] text-[11.5px] leading-[1.55] text-[#8a919e]">
+              <div>· {t('serverSettings.helpList.1')}</div>
+              <div>· {t('serverSettings.helpList.2')}</div>
+              <div>· {t('serverSettings.helpList.3')}</div>
+              <div>· {t('serverSettings.helpList.4')}</div>
+              <div>· {t('serverSettings.helpList.5')}</div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ui/GroupModeModal.tsx
+++ b/src/components/ui/GroupModeModal.tsx
@@ -138,19 +138,19 @@ export const GroupModeModal: React.FC<GroupModeModalProps> = ({
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.96, y: 15 }}
           transition={{ type: "spring", duration: 0.45, bounce: 0.15 }}
-          className="relative w-[90vw] h-[85vh] pointer-events-auto flex flex-col"
+          className="relative w-[92vw] max-w-md h-[70vh] pointer-events-auto flex flex-col"
         >
           {/* Main Card */}
           <div
-            style={{ backgroundColor: '#374151' }}
-            className="relative w-full h-full rounded-3xl shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white"
+            style={{ backgroundColor: '#101217' }}
+            className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
             {/* Dynamic Sticky Header */}
             <div
               className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] transition-all duration-300 ease-in-out
                 ${isHeaderCompact
-                  ? 'pt-2 pb-[13px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10'
-                  : 'pt-6 pb-6 pl-6 pr-16 border-transparent bg-black/20 backdrop-blur-0'
+                  ? 'pt-1.5 pb-[11px] pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]'
+                  : 'pt-4 pb-3.5 pl-4 pr-12 border-transparent bg-black/20 backdrop-blur-0'
                 }`}
             >
               {/* Floating Close Button */}
@@ -159,33 +159,33 @@ export const GroupModeModal: React.FC<GroupModeModalProps> = ({
               >
                 <button
                   onClick={onClose}
-                  className="p-2 rounded-full bg-black/20 text-white hover:bg-black/40 transition-all"
+                  className="p-1.5 rounded-lg bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1] transition-all"
                 >
-                  <X className="w-5 h-5" />
+                  <X className="w-4 h-4" />
                 </button>
               </div>
 
               <div className="flex flex-col justify-center flex-1 min-w-0">
                 <div
-                  className={`flex items-center space-x-2 transition-all duration-300 origin-left ${isHeaderCompact ? 'mb-1 scale-90' : 'mb-3 scale-100'}`}
+                  className={`flex items-center space-x-2 transition-all duration-300 origin-left ${isHeaderCompact ? 'mb-0.5 scale-90' : 'mb-2 scale-100'}`}
                 >
-                  <Badge variant="secondary" className="text-[10px] font-mono px-2 py-0.5 rounded-full bg-black/20 text-white/80 border-transparent">
+                  <Badge variant="secondary" className="text-[9px] font-mono px-1.5 py-0.5 rounded-md bg-black/20 text-white/80 border-transparent">
                     {t('node.group.batch', 'BATCH')}
                   </Badge>
-                  <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">
+                  <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-white/60">
                     {title}
                   </span>
                 </div>
 
                 <div
                   className="flex items-center min-w-0 transition-all duration-300"
-                  style={{ height: isHeaderCompact ? '13px' : '2rem' }}
+                  style={{ height: isHeaderCompact ? '12px' : '1.125rem' }}
                 >
                   <h2
                     style={{
-                      fontSize: baseTitleSize,
+                      fontSize: '1.125rem',
                       lineHeight: '1',
-                      transform: isHeaderCompact ? `scale(${0.8125 / 1.875})` : 'scale(1)',
+                      transform: isHeaderCompact ? `scale(${0.75 / 1.125})` : 'scale(1)',
                       transformOrigin: 'left center',
                     }}
                     className="font-extrabold tracking-tight leading-tight text-white/95 transition-transform duration-300 will-change-transform truncate pr-4"
@@ -195,10 +195,10 @@ export const GroupModeModal: React.FC<GroupModeModalProps> = ({
                 </div>
 
                 <div
-                  className={`inline-flex self-start items-center text-xs font-medium px-2 rounded-md border m-0 transition-all duration-300 overflow-hidden text-white/80 bg-black/20 border-white/10
+                  className={`inline-flex self-start items-center text-[10px] font-medium px-1.5 rounded-md border m-0 transition-all duration-300 overflow-hidden text-white/80 bg-black/20 border-white/10
                     ${isHeaderCompact
                       ? 'opacity-0 scale-75 h-0 mt-0 py-0 border-transparent'
-                      : 'opacity-100 scale-100 h-6 mt-3 py-1'
+                      : 'opacity-100 scale-100 h-5 mt-2 py-0.5'
                     }`}
                 >
                   {t('node.group.totalGroups', { count: groups.length, defaultValue: `${groups.length} Groups Active` })}
@@ -209,13 +209,13 @@ export const GroupModeModal: React.FC<GroupModeModalProps> = ({
             {/* Content Area */}
             <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
               {/* Static Top Bumper */}
-              <div className="h-[150px] relative pointer-events-none">
+              <div className="h-[96px] relative pointer-events-none">
                 <div ref={sentinelRef} className="absolute top-[10px] left-0 h-px w-full" />
               </div>
 
               <div className="px-5 py-6 sm:px-6">
                 {groups.length === 0 ? (
-                  <div className="text-center py-12 rounded-3xl bg-black/10 border border-dashed border-white/10">
+                  <div className="text-center py-12 rounded-xl bg-black/10 border border-dashed border-white/10">
                     <p className="text-white/40 text-sm">{t('node.group.noGroups')}</p>
                   </div>
                 ) : (
@@ -226,16 +226,16 @@ export const GroupModeModal: React.FC<GroupModeModalProps> = ({
                         {t('node.group.availableGroups', 'Groups Available')}
                       </span>
                     </div>
-                    <div className="grid grid-cols-1 gap-4">
+                    <div className="grid grid-cols-1 gap-2">
                       {groups.map((group) => {
                         const currentMode = getGroupCurrentMode(group);
 
                         return (
                           <div
                             key={group.id}
-                            className="group relative p-4 rounded-2xl bg-black/10 border border-white/5 hover:bg-black/20 hover:border-white/10 transition-all duration-300"
+                            className="group relative px-2.5 py-2 rounded-[10px] bg-white/[0.03] border border-white/[0.07] hover:bg-white/[0.05] hover:border-white/[0.12] transition-all duration-300"
                           >
-                            <div className="flex items-center justify-between gap-4">
+                            <div className="flex items-center justify-between gap-2.5">
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-2 mb-1.5">
                                   {group.color && (
@@ -244,7 +244,7 @@ export const GroupModeModal: React.FC<GroupModeModalProps> = ({
                                       style={{ backgroundColor: group.color }}
                                     />
                                   )}
-                                  <h4 className="font-bold text-sm text-white/90 truncate">
+                                  <h4 className="font-semibold text-[12px] text-[#e9ebef] truncate">
                                     {group.title}
                                   </h4>
                                 </div>
@@ -256,20 +256,20 @@ export const GroupModeModal: React.FC<GroupModeModalProps> = ({
                                 </div>
                               </div>
 
-                              <div className="flex items-center gap-1 bg-black/30 p-1 rounded-xl ring-1 ring-white/5 flex-shrink-0">
+                              <div className="flex items-center gap-0.5 bg-black/30 p-0.5 rounded-lg ring-1 ring-white/[0.06] flex-shrink-0">
                                 {modeButtons.map((config) => {
                                   const isActive = currentMode === config.mode;
                                   return (
                                     <button
                                       key={config.mode}
                                       onClick={() => onGroupModeChange(group.id, config.mode)}
-                                      className={`px-2.5 py-2 rounded-lg transition-all active:scale-95 flex items-center gap-1.5 group/btn ${isActive
+                                      className={`px-2 py-1.5 rounded-[7px] transition-all active:scale-95 flex items-center gap-1.5 group/btn ${isActive
                                         ? `${config.color} ${config.bg} ring-1 ${config.activeBorder} shadow-lg shadow-black/20`
                                         : 'text-white/20 hover:text-white/60 hover:bg-white/5'
                                         }`}
                                       title={config.label}
                                     >
-                                      <config.icon className={`w-4 h-4 ${isActive ? 'scale-110' : 'scale-100'} transition-transform`} />
+                                      <config.icon className={`w-3.5 h-3.5 ${isActive ? 'scale-110' : 'scale-100'} transition-transform`} />
                                       {isActive && (
                                         <span className="text-[9px] font-bold uppercase tracking-wider">
                                           {config.label}

--- a/src/components/ui/SimpleConfirmDialog.tsx
+++ b/src/components/ui/SimpleConfirmDialog.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { AlertCircle } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 
 interface SimpleConfirmDialogProps {
     isOpen: boolean;
@@ -40,53 +39,51 @@ export const SimpleConfirmDialog: React.FC<SimpleConfirmDialogProps> = ({
                     onClick={onClose}
                 >
                     <motion.div
-                        initial={{ scale: 0.9, opacity: 0 }}
+                        initial={{ scale: 0.95, opacity: 0 }}
                         animate={{ scale: 1, opacity: 1 }}
-                        exit={{ scale: 0.9, opacity: 0 }}
-                        className="relative w-full max-w-sm bg-[#374151] rounded-3xl shadow-2xl overflow-hidden p-8 space-y-6 text-white"
+                        exit={{ scale: 0.95, opacity: 0 }}
+                        className="relative w-full max-w-[300px] bg-[#101217] border border-white/10 rounded-xl shadow-2xl overflow-hidden p-4 text-[#e9ebef]"
                         onClick={(e) => e.stopPropagation()}
                     >
-                        <div className="relative z-10 flex flex-col items-center text-center space-y-5">
-                            <div className={`w-16 h-16 rounded-full flex items-center justify-center ${isDestructive ? 'bg-black/20' : 'bg-white/20'
-                                } shadow-sm`}>
-                                <AlertCircle className="w-8 h-8 text-white" />
+                        <div className="flex flex-col items-center text-center gap-2.5">
+                            <div
+                                className="w-9 h-9 rounded-[10px] flex items-center justify-center border"
+                                style={isDestructive
+                                    ? { background: 'rgba(242,85,85,0.1)', borderColor: 'rgba(242,85,85,0.3)' }
+                                    : { background: 'rgba(48,105,240,0.1)', borderColor: 'rgba(48,105,240,0.3)' }}
+                            >
+                                <AlertCircle className={`w-4 h-4 ${isDestructive ? 'text-[#f25555]' : 'text-[#5b8af5]'}`} strokeWidth={1.8} />
                             </div>
-                            <div className="space-y-3">
-                                <h3 className="text-2xl font-black tracking-tight text-white">
-                                    {title}
-                                </h3>
 
-                                {nodeInfo && (
-                                    <div className="inline-block px-3 py-1 rounded-full text-xs font-bold border bg-black/20 text-white/90 border-white/20 mb-1">
-                                        {nodeInfo}
-                                    </div>
-                                )}
+                            <h3 className="text-[14px] font-bold leading-tight">{title}</h3>
 
-                                <p className="leading-relaxed font-bold px-2 text-white/80">
-                                    {message}
-                                </p>
-                            </div>
+                            {nodeInfo && (
+                                <div className="inline-block px-2 py-0.5 rounded-md font-mono text-[10px] border bg-white/[0.05] text-[#c8ccd4] border-white/[0.08]">
+                                    {nodeInfo}
+                                </div>
+                            )}
+
+                            <p className="text-[11.5px] leading-relaxed text-[#8a919e]">{message}</p>
                         </div>
 
-                        <div className="relative z-10 flex gap-3 pt-4">
-                            <Button
+                        <div className="flex gap-2 pt-3.5">
+                            <button
                                 onClick={onClose}
-                                variant="outline"
-                                className="flex-1 h-14 rounded-2xl font-bold transition-all bg-black/20 border-white/10 text-white hover:bg-black/40"
+                                className="flex-1 h-9 rounded-[10px] text-[12px] font-semibold border border-white/[0.08] text-[#c8ccd4] transition-colors hover:bg-white/[0.07]"
+                                style={{ background: 'rgba(255,255,255,0.05)' }}
                             >
                                 {cancelText || t('common.cancel')}
-                            </Button>
-                            <Button
+                            </button>
+                            <button
                                 onClick={() => {
                                     onConfirm();
                                     onClose();
                                 }}
-                                variant={isDestructive ? 'destructive' : 'default'}
-                                className={`flex-1 h-14 rounded-2xl font-bold shadow-lg transition-transform active:scale-95 ${isDestructive ? 'bg-red-500 hover:bg-red-600 shadow-black/20' : ''
+                                className={`flex-1 h-9 rounded-[10px] text-[12px] font-semibold text-white transition-all active:scale-95 ${isDestructive ? 'bg-[#f25555] hover:bg-[#f36d6d]' : 'bg-[#3069f0] hover:bg-[#3f78f5]'
                                     }`}
                             >
                                 {confirmText || (isDestructive ? t('common.delete') : t('common.confirm'))}
-                            </Button>
+                            </button>
                         </div>
                     </motion.div>
                 </motion.div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-1 rounded-xl border py-6 shadow-sm",
+        "text-card-foreground flex flex-col gap-1 rounded-xl border border-white/[0.08] bg-white/[0.025] py-3.5 shadow-none",
         className
       )}
       {...props}
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1 px-3.5 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-3.5",
         className
       )}
       {...props}
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("leading-none font-semibold text-[13px] text-[#e9ebef]", className)}
       {...props}
     />
   )
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted-foreground text-[11px]", className)}
       {...props}
     />
   )
@@ -65,7 +65,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn("px-3.5", className)}
       {...props}
     />
   )
@@ -75,7 +75,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn("flex items-center px-3.5 [.border-t]:pt-3.5", className)}
       {...props}
     />
   )

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -12,7 +12,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        "bg-white/[0.06] relative h-1 w-full overflow-hidden rounded-[2px]",
         className
       )}
       {...props}

--- a/src/components/videos/VideoDownloader.tsx
+++ b/src/components/videos/VideoDownloader.tsx
@@ -260,10 +260,10 @@ const VideoDownloader: React.FC = () => {
       }}
     >
       {/* Main Background with Dark Theme */}
-      <div className="absolute inset-0 bg-[#374151]" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
 
       {/* Glassmorphism Background Overlay */}
-      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+      <div className="hidden" />
 
       {/* Main Scrollable Content Area */}
       <div
@@ -275,22 +275,22 @@ const VideoDownloader: React.FC = () => {
         }}
       >
         {/* Header */}
-        <header className="sticky top-0 z-50 pwa-header bg-[#1e293b] border-b border-white/10 shadow-xl relative overflow-hidden">
+        <header className="sticky top-0 z-50 pwa-header bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
           <div className="relative z-10 flex items-center justify-between p-4">
             <div className="flex items-center space-x-3">
               <Button
                 onClick={handleBack}
                 variant="ghost"
                 size="sm"
-                className="bg-white/10 backdrop-blur-sm border border-white/10 shadow-lg hover:bg-white/20 transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg text-white"
+                className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] transition-all h-9 w-9 p-0 flex-shrink-0 rounded-[10px] text-[#c8ccd4]"
               >
                 <ArrowLeft className="h-4 w-4" />
               </Button>
               <div>
-                <h1 className="text-lg font-bold text-white/95 leading-none">
+                <h1 className="text-[15px] font-bold text-[#e9ebef] leading-none">
                   {t('videoDownloader.title')}
                 </h1>
-                <p className="text-[11px] text-white/40 mt-1">
+                <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">
                   {t('videoDownloader.subtitle')}
                 </p>
               </div>
@@ -307,25 +307,25 @@ const VideoDownloader: React.FC = () => {
           </div>
         </header>
 
-        <div className="container mx-auto px-6 py-8 max-w-4xl space-y-6">
+        <div className="container mx-auto px-4 py-5 max-w-4xl space-y-2">
           {/* Server Requirements Card */}
-          <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+          <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none">
             <CardHeader>
               <CardTitle className="flex items-center space-x-2 text-white/90">
-                <AlertTriangle className="h-5 w-5 text-amber-400" />
+                <AlertTriangle className="h-4 w-4 text-[#ffa348]" />
                 <span>{t('videoDownloader.requirements')}</span>
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-2.5">
               <div className="flex items-center justify-between">
-                <span className="font-medium text-white/70">{t('videoDownloader.serverConnection')}</span>
+                <span className="text-[12.5px] text-[#9aa3b2]">{t('videoDownloader.serverConnection')}</span>
                 {isConnected ? (
-                  <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                  <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                     <CheckCircle className="w-3 h-3 mr-1" />
                     {t('common.connected')}
                   </Badge>
                 ) : (
-                  <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                  <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                     <X className="w-3 h-3 mr-1" />
                     {t('common.disconnected')}
                   </Badge>
@@ -333,19 +333,19 @@ const VideoDownloader: React.FC = () => {
               </div>
 
               <div className="flex items-center justify-between">
-                <span className="font-medium text-white/70">{t('videoDownloader.mobileExtension')}</span>
+                <span className="text-[12.5px] text-[#9aa3b2]">{t('videoDownloader.mobileExtension')}</span>
                 {isCheckingExtension ? (
                   <Badge variant="outline" className="animate-pulse border-white/10 text-white/40">
                     <Loader2 className="w-3 h-3 mr-1 animate-spin" />
                     {t('gallery.server.checking')}
                   </Badge>
                 ) : hasExtension ? (
-                  <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                  <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                     <CheckCircle className="w-3 h-3 mr-1" />
                     {t('gallery.server.available')}
                   </Badge>
                 ) : (
-                  <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                  <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                     <X className="w-3 h-3 mr-1" />
                     {t('gallery.server.notFound')}
                   </Badge>
@@ -355,14 +355,14 @@ const VideoDownloader: React.FC = () => {
               {downloadStatus && (
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-2">
-                    <span className="font-medium text-white/70">{t('videoDownloader.ytDlp')}</span>
+                    <span className="text-[12.5px] text-[#9aa3b2]">{t('videoDownloader.ytDlp')}</span>
                     {downloadStatus.yt_dlp_available && (
                       <Button
                         onClick={handleUpgradeYtDlp}
                         disabled={isUpgrading}
                         variant="ghost"
                         size="sm"
-                        className="h-6 px-2 text-xs text-blue-400 hover:text-blue-300 hover:bg-blue-500/10"
+                        className="h-6 px-2 text-xs text-[#5b8af5] hover:text-[#7ba3f5] hover:bg-[#3069f0]/10"
                         title={t('videoDownloader.upgradeYtDlp')}
                       >
                         {isUpgrading ? (
@@ -374,12 +374,12 @@ const VideoDownloader: React.FC = () => {
                     )}
                   </div>
                   {downloadStatus.yt_dlp_available ? (
-                    <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                    <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                       <CheckCircle className="w-3 h-3 mr-1" />
                       v{downloadStatus.yt_dlp_version}
                     </Badge>
                   ) : (
-                    <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                    <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                       <X className="w-3 h-3 mr-1" />
                       {t('common.notConfigured')}
                     </Badge>
@@ -388,8 +388,8 @@ const VideoDownloader: React.FC = () => {
               )}
 
               {!hasServerRequirements && (
-                <div className="p-4 bg-amber-500/10 border border-amber-500/20 rounded-lg">
-                  <p className="text-sm text-amber-400">
+                <div className="p-4 bg-[#ffa348]/10 border border-amber-500/20 rounded-lg">
+                  <p className="text-[12px] text-[#ffa348]">
                     {t('videoDownloader.toast.providedUrl')}
                   </p>
                 </div>
@@ -397,10 +397,10 @@ const VideoDownloader: React.FC = () => {
 
               {hasServerRequirements && downloadStatus && !downloadStatus.yt_dlp_available && (
                 <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-                  <p className="text-sm text-red-700 dark:text-red-300 font-medium mb-2">
+                  <p className="text-[12px] text-red-700 dark:text-red-300 font-medium mb-2">
                     {t('videoDownloader.ytDlpMissing')}
                   </p>
-                  <p className="text-sm text-red-600 dark:text-red-400">
+                  <p className="text-[12px] text-red-600 dark:text-[#f87c7c]">
                     <code className="bg-red-100 dark:bg-red-900/30 px-1 rounded">pip install yt-dlp</code>
                   </p>
                 </div>
@@ -411,15 +411,15 @@ const VideoDownloader: React.FC = () => {
           {hasServerRequirements && downloadStatus?.yt_dlp_available && (
             <>
               {/* Supported Sites Card */}
-              <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+              <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none">
                 <CardHeader>
                   <CardTitle className="flex items-center space-x-2 text-white/90">
-                    <Globe className="h-5 w-5 text-purple-400" />
+                    <Globe className="h-5 w-5 text-[#9a8af0]" />
                     <span>{t('videoDownloader.supportedSites')}</span>
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-sm text-white/40 mb-3">
+                  <p className="text-[12px] text-white/40 mb-3">
                     {t('videoDownloader.supportedSitesDesc')}
                   </p>
                   {getSupportedSitesDisplay(downloadStatus.supported_sites)}
@@ -427,23 +427,23 @@ const VideoDownloader: React.FC = () => {
               </Card>
 
               {/* Download Form */}
-              <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+              <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none">
                 <CardHeader>
                   <CardTitle className="flex items-center space-x-2 text-white/90">
-                    <Download className="h-5 w-5 text-blue-400" />
+                    <Download className="h-4 w-4 text-[#5b8af5]" />
                     <span>{t('videoDownloader.downloadVideo')}</span>
                   </CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-4">
+                <CardContent className="space-y-2.5">
                   <div className="space-y-2">
-                    <Label htmlFor="video-url" className="text-white/70">{t('videoDownloader.videoUrl')}</Label>
+                    <Label htmlFor="video-url" className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase">{t('videoDownloader.videoUrl')}</Label>
                     <Input
                       id="video-url"
                       type="url"
                       placeholder={t('videoDownloader.videoUrlPlaceholder')}
                       value={videoUrl}
                       onChange={(e) => setVideoUrl(e.target.value)}
-                      className="bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl"
+                      className="h-[42px] px-3 font-mono text-[11.5px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] rounded-[10px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50"
                     />
                     <p className="text-xs text-white/40">
                       {t('videoDownloader.videoUrlDesc')}
@@ -451,13 +451,13 @@ const VideoDownloader: React.FC = () => {
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="custom-filename" className="text-white/70">{t('videoDownloader.filename')}</Label>
+                    <Label htmlFor="custom-filename" className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase">{t('videoDownloader.filename')}</Label>
                     <Input
                       id="custom-filename"
                       placeholder={t('videoDownloader.filenamePlaceholder')}
                       value={customFilename}
                       onChange={(e) => setCustomFilename(e.target.value)}
-                      className="bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl"
+                      className="h-[42px] px-3 font-mono text-[11.5px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] rounded-[10px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50"
                     />
                     <p className="text-xs text-white/40">
                       {t('videoDownloader.filenameDesc')}
@@ -465,28 +465,28 @@ const VideoDownloader: React.FC = () => {
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="subfolder" className="text-white/70">{t('videoDownloader.subfolder')}</Label>
+                    <Label htmlFor="subfolder" className="font-mono text-[10px] font-medium text-[#565d6b] tracking-[0.12em] uppercase">{t('videoDownloader.subfolder')}</Label>
                     <Input
                       id="subfolder"
                       placeholder={t('videoDownloader.subfolderPlaceholder')}
                       value={subfolder}
                       onChange={(e) => setSubfolder(e.target.value)}
-                      className="bg-black/20 border-white/10 text-white/90 placeholder:text-white/20 rounded-xl"
+                      className="h-[42px] px-3 font-mono text-[11.5px] bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] rounded-[10px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50"
                     />
                     <p className="text-xs text-white/40">
                       {t('videoDownloader.subfolderDesc')}
                     </p>
                   </div>
 
-                  <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg">
+                  <div className="p-3 bg-[#3069f0]/10 border border-[#3069f0]/20 rounded-lg">
                     <div className="flex items-center space-x-2 mb-2">
-                      <Video className="h-4 w-4 text-blue-400" />
-                      <span className="text-sm font-medium text-blue-300">
+                      <Video className="h-4 w-4 text-[#5b8af5]" />
+                      <span className="text-[12px] font-medium text-[#7ba3f5]">
                         {t('videoDownloader.downloadInfo')}
                       </span>
                     </div>
-                    <ul className="text-xs text-blue-300/70 space-y-1">
-                      <li>• {t('videoDownloader.infoSave')} <code className="bg-blue-500/20 px-1 rounded text-blue-300">{downloadStatus.input_directory}</code></li>
+                    <ul className="text-xs text-[#7ba3f5]/70 space-y-1">
+                      <li>• {t('videoDownloader.infoSave')} <code className="bg-[#3069f0]/20 px-1 rounded text-[#7ba3f5]">{downloadStatus.input_directory}</code></li>
                       <li>• {t('videoDownloader.infoFormat')}</li>
                       <li>• {t('videoDownloader.infoQuality')}</li>
                       <li>• {t('videoDownloader.infoPlayback')}</li>
@@ -496,7 +496,7 @@ const VideoDownloader: React.FC = () => {
                   <Button
                     onClick={handleStartDownload}
                     disabled={!videoUrl.trim() || isDownloading}
-                    className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 active:scale-98 transition-transform duration-75"
+                    className="w-full h-11 rounded-[10px] bg-[#3069f0] hover:bg-[#3f78f5] text-white text-[13px] font-semibold shadow-[0_2px_12px_rgba(48,105,240,0.3)] active:scale-98 transition-transform duration-75 disabled:opacity-50"
                   >
                     {isDownloading ? (
                       <>
@@ -513,20 +513,20 @@ const VideoDownloader: React.FC = () => {
 
                   {/* Log Display - Only shown when download is active or has logs */}
                   {(isDownloadActive || logMessages.length > 0) && (
-                    <Card className="border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl mt-4">
+                    <Card className="border border-white/[0.08] bg-white/[0.025] shadow-none mt-4">
                       <CardHeader>
-                        <CardTitle className="flex items-center space-x-2 text-sm text-white/90">
-                          <Video className="h-4 w-4 text-blue-400" />
+                        <CardTitle className="flex items-center space-x-2 text-[12px] text-white/90">
+                          <Video className="h-4 w-4 text-[#5b8af5]" />
                           <span>{t('videoDownloader.downloadProgress')}</span>
                           {isDownloading && (
-                            <Loader2 className="w-4 h-4 animate-spin text-blue-400 ml-auto" />
+                            <Loader2 className="w-4 h-4 animate-spin text-[#5b8af5] ml-auto" />
                           )}
                         </CardTitle>
                       </CardHeader>
                       <CardContent>
                         <div
                           ref={logContainerRef}
-                          className="max-h-64 overflow-y-auto bg-black/40 rounded-xl p-3 custom-scrollbar"
+                          className="max-h-64 overflow-y-auto rounded-lg border border-white/[0.08] p-3 custom-scrollbar" style={{ background: '#08090c' }}
                         >
                           {logMessages.length === 0 ? (
                             <div className="text-xs text-white/20 font-mono">

--- a/src/components/workflow/FolderDetailModal.tsx
+++ b/src/components/workflow/FolderDetailModal.tsx
@@ -77,23 +77,23 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
                         animate={{ opacity: 1, scale: 1, y: 0 }}
                         exit={{ opacity: 0, scale: 0.95, y: 20 }}
                         transition={{ duration: 0.2, ease: 'easeOut' }}
-                        className="relative w-full max-w-md bg-white/90 dark:bg-slate-900/90 backdrop-blur-3xl rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 overflow-hidden"
+                        className="relative w-full max-w-md bg-[#101217] rounded-xl shadow-2xl border border-white/10 overflow-hidden"
                         onClick={(e) => e.stopPropagation()}
                     >
                         {/* Gradient Overlay */}
-                        <div className="absolute inset-0 bg-gradient-to-br from-amber-500/5 via-transparent to-slate-900/5 pointer-events-none rounded-3xl" />
+                        <div className="absolute inset-0 bg-gradient-to-br from-amber-500/5 via-transparent to-transparent pointer-events-none rounded-xl" />
 
                         {showDeleteConfirm ? (
                             // Delete Confirmation View
-                            <div className="p-6 space-y-6">
-                                <div className="flex flex-col items-center text-center space-y-4">
-                                    <div className="w-16 h-16 rounded-full bg-red-500/10 flex items-center justify-center">
-                                        <AlertTriangle className="w-8 h-8 text-red-600 dark:text-red-400" />
+                            <div className="p-4 space-y-6">
+                                <div className="flex flex-col items-center text-center space-y-2.5">
+                                    <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center">
+                                        <AlertTriangle className="w-8 h-8 text-[#f87c7c]" />
                                     </div>
-                                    <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+                                    <h3 className="text-[14px] font-bold text-[#e9ebef]">
                                         {t('folder.deleteConfirm')}
                                     </h3>
-                                    <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                                    <p className="text-[12px] text-[#8a919e] leading-relaxed">
                                         {t('folder.deleteMessage', { workflowCount, subfolderCount })}
                                         <br /><br />
                                         {t('folder.deleteConfirmQuery')}
@@ -104,7 +104,7 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
                                     <Button
                                         onClick={() => setShowDeleteConfirm(false)}
                                         variant="outline"
-                                        className="flex-1 py-3 rounded-xl border-slate-200 dark:border-slate-700"
+                                        className="flex-1 py-3 rounded-xl border-white/[0.08]"
                                     >
                                         {t('common.cancel')}
                                     </Button>
@@ -120,46 +120,46 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
                             // Normal Detail View
                             <>
                                 {/* Header */}
-                                <div className="relative z-10 flex items-center justify-between px-6 py-4 border-b border-white/10 dark:border-slate-600/10">
+                                <div className="relative z-10 flex items-center justify-between px-4 py-4 border-b border-white/[0.08]">
                                     <div className="flex items-center gap-3 min-w-0 flex-1">
                                         <div className="w-10 h-10 rounded-xl bg-amber-500/15 dark:bg-amber-500/20 border border-amber-400/30 flex items-center justify-center shadow-lg">
                                             <Folder className="w-5 h-5 text-amber-600 dark:text-amber-400" />
                                         </div>
                                         <div className="min-w-0 flex-1">
-                                            <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 truncate">
+                                            <h2 className="text-[14px] font-bold text-[#e9ebef] truncate">
                                                 {folder.name}
                                             </h2>
-                                            <p className="text-xs text-slate-600 dark:text-slate-400">
+                                            <p className="text-xs text-[#8a919e]">
                                                 {t('folder.details')}
                                             </p>
                                         </div>
                                     </div>
                                     <button
                                         onClick={onClose}
-                                        className="flex-shrink-0 ml-3 p-2 bg-white/30 dark:bg-slate-700/30 backdrop-blur-sm border border-white/20 dark:border-slate-600/20 hover:bg-white/50 dark:hover:bg-slate-700/50 transition-all duration-200 rounded-xl"
+                                        className="flex-shrink-0 ml-3 p-2 bg-white/[0.06] border border-white/[0.08] hover:bg-white/[0.1] transition-all duration-200 rounded-xl"
                                         aria-label={t('common.close')}
                                     >
-                                        <X className="w-5 h-5 text-slate-700 dark:text-slate-300" />
+                                        <X className="w-5 h-5 text-[#c8ccd4]" />
                                     </button>
                                 </div>
 
                                 {/* Content */}
-                                <div className="p-6 space-y-6 relative z-10">
+                                <div className="p-4 space-y-6 relative z-10">
                                     {/* Stats */}
-                                    <div className="grid grid-cols-2 gap-4">
-                                        <div className="bg-white/40 dark:bg-slate-800/40 backdrop-blur-md rounded-2xl p-4 border border-white/20 dark:border-slate-600/20 flex flex-col items-center justify-center text-center">
-                                            <span className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-1">
+                                    <div className="grid grid-cols-2 gap-2.5">
+                                        <div className="bg-white/[0.03] rounded-[10px] p-3 border border-white/[0.08] flex flex-col items-center justify-center text-center">
+                                            <span className="text-[15px] font-bold text-[#e9ebef] mb-1">
                                                 {workflowCount}
                                             </span>
-                                            <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">
+                                            <span className="text-xs text-[#71798a] font-medium">
                                                 {t('workflow.listTitle')}
                                             </span>
                                         </div>
-                                        <div className="bg-white/40 dark:bg-slate-800/40 backdrop-blur-md rounded-2xl p-4 border border-white/20 dark:border-slate-600/20 flex flex-col items-center justify-center text-center">
-                                            <span className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-1">
+                                        <div className="bg-white/[0.03] rounded-[10px] p-3 border border-white/[0.08] flex flex-col items-center justify-center text-center">
+                                            <span className="text-[15px] font-bold text-[#e9ebef] mb-1">
                                                 {subfolderCount}
                                             </span>
-                                            <span className="text-xs text-slate-500 dark:text-slate-400 font-medium">
+                                            <span className="text-xs text-[#71798a] font-medium">
                                                 {t('folder.subfolders')}
                                             </span>
                                         </div>
@@ -167,15 +167,15 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
 
                                     {/* Preview Grid */}
                                     {previewWorkflows.length > 0 && (
-                                        <div className="space-y-3">
-                                            <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                                        <div className="space-y-2">
+                                            <p className="text-[12px] font-medium text-[#c8ccd4]">
                                                 {t('common.preview')}
                                             </p>
                                             <div className="grid grid-cols-2 gap-2">
                                                 {previewWorkflows.map((wf) => (
                                                     <div
                                                         key={wf.id}
-                                                        className="aspect-square rounded-xl overflow-hidden bg-slate-100/50 dark:bg-slate-800/50 border border-slate-200/30 dark:border-slate-600/30 relative"
+                                                        className="aspect-square rounded-xl overflow-hidden bg-white/[0.04] border border-white/[0.07] relative"
                                                     >
                                                         {wf.thumbnail ? (
                                                             <img
@@ -185,7 +185,7 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
                                                             />
                                                         ) : (
                                                             <div className="w-full h-full flex items-center justify-center">
-                                                                <FileText className="w-6 h-6 text-slate-400" />
+                                                                <FileText className="w-6 h-6 text-[#565d6b]" />
                                                             </div>
                                                         )}
                                                     </div>
@@ -195,21 +195,21 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
                                     )}
 
                                     {/* Created Date */}
-                                    <div className="bg-white/40 dark:bg-slate-800/40 backdrop-blur-md rounded-2xl p-4 border border-white/20 dark:border-slate-600/20 flex items-center justify-between">
-                                        <span className="text-sm text-slate-600 dark:text-slate-400">{t('workflow.created')}</span>
-                                        <span className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                                    <div className="bg-white/[0.03] rounded-[10px] p-3 border border-white/[0.08] flex items-center justify-between">
+                                        <span className="text-[12px] text-[#8a919e]">{t('workflow.created')}</span>
+                                        <span className="text-[12px] font-medium text-[#e9ebef]">
                                             {new Date(folder.createdAt).toLocaleDateString()}
                                         </span>
                                     </div>
                                 </div>
 
                                 {/* Footer */}
-                                <div className="relative z-10 px-6 py-4 border-t border-white/10 dark:border-slate-600/10 bg-white/30 dark:bg-slate-900/30 backdrop-blur-xl flex gap-3">
+                                <div className="relative z-10 px-4 py-4 border-t border-white/[0.08] bg-[#0f1116]/90 backdrop-blur-xl flex gap-3">
                                     {onMove && (
                                         <Button
                                             onClick={() => onMove(folder)}
                                             variant="ghost"
-                                            className="flex-1 py-3 rounded-2xl bg-blue-500/10 border border-blue-400/30 text-blue-600 dark:text-blue-400 hover:bg-blue-500/20 hover:text-blue-700 dark:hover:text-blue-300 flex items-center justify-center gap-2"
+                                            className="flex-1 py-3 rounded-[10px] bg-blue-500/10 border border-blue-400/30 text-[#5b8af5] hover:bg-blue-500/20 hover:text-blue-700 dark:hover:text-blue-300 flex items-center justify-center gap-2"
                                         >
                                             <FolderInput className="w-5 h-5" />
                                             {t('folder.moveTitle')}
@@ -218,7 +218,7 @@ const FolderDetailModal: React.FC<FolderDetailModalProps> = ({
                                     <Button
                                         onClick={handleDeleteClick}
                                         variant="ghost"
-                                        className="flex-1 py-3 rounded-2xl bg-red-500/10 border border-red-400/30 text-red-600 dark:text-red-400 hover:bg-red-500/20 hover:text-red-700 dark:hover:text-red-300 flex items-center justify-center gap-2"
+                                        className="flex-1 py-3 rounded-[10px] bg-red-500/10 border border-red-400/30 text-[#f87c7c] hover:bg-red-500/20 hover:text-red-700 dark:hover:text-red-300 flex items-center justify-center gap-2"
                                     >
                                         <Trash2 className="w-5 h-5" />
                                         {t('folder.deleteFolder')}

--- a/src/components/workflow/FolderGridItem.tsx
+++ b/src/components/workflow/FolderGridItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Folder, ChevronRight, Check } from 'lucide-react';
+import { Folder, Check } from 'lucide-react';
 import { FolderItem } from '@/types/folder';
 import { useLongPress } from '@/hooks/useLongPress';
 
@@ -21,61 +20,33 @@ const FolderGridItem: React.FC<FolderGridItemProps> = ({
   selectionMode = false,
   workflowCount = 0,
 }) => {
-  const { t } = useTranslation();
   const longPressProps = useLongPress(onLongPress, onClick, { threshold: 500 });
 
   return (
     <div
-      className={`relative group overflow-hidden rounded-xl transition-all duration-300 cursor-pointer border h-[72px] ${isSelected
-        ? 'bg-blue-500/20 border-blue-500/50 shadow-[0_0_20px_rgba(59,130,246,0.3)]'
-        : 'bg-white/5 hover:bg-white/10 border-white/10 hover:border-white/20'
+      className={`h-10 flex items-center gap-[9px] px-3 rounded-[9px] border cursor-pointer transition-colors min-w-[150px] ${isSelected
+        ? 'border-[#3069f0]/60'
+        : 'border-white/[0.08] hover:border-white/[0.16]'
         }`}
+      style={{ background: isSelected ? 'rgba(48,105,240,0.1)' : 'rgba(255,255,255,0.035)' }}
       {...longPressProps}
     >
-      {/* Glass Effect Background */}
-      <div className="absolute inset-0 backdrop-blur-md" />
-
-      {/* Content Container */}
-      <div className="relative z-10 p-3 h-full flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3 min-w-0 flex-1">
-          {/* Icon Container */}
-          <div
-            className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${isSelected
-              ? 'bg-blue-500/20 text-blue-400'
-              : 'bg-amber-500/10 text-amber-500 group-hover:bg-amber-500/20 group-hover:text-amber-400'
-              }`}
-          >
-            <Folder className="w-5 h-5 fill-current opacity-80" />
-          </div>
-
-          {/* Text Info */}
-          <div className="flex flex-col min-w-0 flex-1 justify-center">
-            <h3 className="text-sm font-semibold text-slate-200 truncate group-hover:text-white transition-colors w-full">
-              {folder.name}
-            </h3>
-            <span className="text-xs text-slate-500 group-hover:text-slate-400 transition-colors truncate">
-              {workflowCount} {workflowCount === 1 ? t('common.item') : t('common.items')}
-            </span>
-          </div>
-        </div>
-
-        {/* Selection checkbox / Arrow Icon */}
-        {selectionMode ? (
-          <div
-            className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center border-2 transition-colors ${isSelected
-              ? 'bg-blue-500 border-blue-500 text-white'
-              : 'bg-transparent border-slate-500 text-transparent'
-              }`}
-          >
-            <Check className="w-3.5 h-3.5" />
-          </div>
-        ) : (
-          <ChevronRight className="w-4 h-4 text-slate-600 group-hover:text-slate-400 transition-colors flex-shrink-0" />
-        )}
-      </div>
-
-      {/* Hover Gradient Overlay */}
-      <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-1000 pointer-events-none" />
+      <Folder className="w-[15px] h-[15px] shrink-0 text-[#5b8af5]" strokeWidth={1.8} />
+      <span className="flex-1 min-w-0 truncate text-[12.5px] font-medium text-[#e9ebef]">
+        {folder.name}
+      </span>
+      {selectionMode ? (
+        <span
+          className={`w-[18px] h-[18px] shrink-0 rounded flex items-center justify-center border transition-colors ${isSelected
+            ? 'bg-[#3069f0] border-[#3069f0] text-white'
+            : 'border-white/40 text-transparent'
+            }`}
+        >
+          <Check className="w-3 h-3" strokeWidth={2.5} />
+        </span>
+      ) : (
+        <span className="shrink-0 font-mono text-[10px] text-[#565d6b]">{workflowCount}</span>
+      )}
     </div>
   );
 };

--- a/src/components/workflow/MoveToFolderSheet.tsx
+++ b/src/components/workflow/MoveToFolderSheet.tsx
@@ -135,18 +135,18 @@ const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 40, scale: 0.98 }}
             transition={{ duration: 0.22, ease: 'easeOut' }}
-            className="relative w-full sm:max-w-md max-h-[82vh] flex flex-col bg-white/95 dark:bg-slate-900/95 backdrop-blur-3xl rounded-t-3xl sm:rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 overflow-hidden"
+            className="relative w-full sm:max-w-md max-h-[82vh] flex flex-col bg-[#101217] rounded-t-xl sm:rounded-xl shadow-2xl border border-white/10 overflow-hidden"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Grabber */}
             <div className="sm:hidden pt-2 flex justify-center">
-              <div className="w-9 h-1 rounded-full bg-slate-300 dark:bg-slate-600" />
+              <div className="w-9 h-1 rounded-full bg-white/[0.15]" />
             </div>
 
             {/* Header */}
-            <div className="flex items-center justify-between gap-2 px-5 pt-3 pb-3 border-b border-slate-200/60 dark:border-slate-700/60">
+            <div className="flex items-center justify-between gap-2 px-5 pt-3 pb-3 border-b border-white/[0.08]">
               <div className="flex items-center gap-2 min-w-0">
-                <h2 className="text-base font-bold text-slate-900 dark:text-slate-100 shrink-0">
+                <h2 className="text-[13px] font-bold text-[#e9ebef] shrink-0">
                   {t('folder.moveTitle')}
                 </h2>
                 <span className="inline-flex items-center gap-1.5 min-w-0 px-2.5 py-1 rounded-full bg-blue-500/15 text-blue-600 dark:text-blue-300 text-xs font-medium">
@@ -160,24 +160,24 @@ const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
               </div>
               <button
                 onClick={onClose}
-                className="shrink-0 p-2 rounded-xl bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+                className="shrink-0 p-2 rounded-xl bg-white/[0.06] hover:bg-white/[0.08] transition-colors"
                 aria-label={t('common.close')}
               >
-                <X className="w-4 h-4 text-slate-600 dark:text-slate-300" />
+                <X className="w-4 h-4 text-[#9aa3b2]" />
               </button>
             </div>
 
             {/* Breadcrumb */}
-            <div className="flex items-center gap-1 px-5 py-2.5 overflow-x-auto scrollbar-hide text-sm whitespace-nowrap border-b border-slate-200/40 dark:border-slate-800/60">
+            <div className="flex items-center gap-1 px-5 py-2.5 overflow-x-auto scrollbar-hide text-[12px] whitespace-nowrap border-b border-white/[0.07]">
               {crumbs.map((c, i) => (
                 <React.Fragment key={c.id || 'root'}>
-                  {i > 0 && <ChevronRight className="w-3.5 h-3.5 text-slate-400 shrink-0" />}
+                  {i > 0 && <ChevronRight className="w-3.5 h-3.5 text-[#565d6b] shrink-0" />}
                   <button
                     onClick={() => setPickerFolderId(c.id)}
                     className={`inline-flex items-center gap-1 transition-colors ${
                       i === crumbs.length - 1
-                        ? 'text-slate-900 dark:text-slate-100 font-semibold'
-                        : 'text-slate-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400'
+                        ? 'text-[#e9ebef] font-semibold'
+                        : 'text-[#71798a] hover:text-blue-600 dark:hover:text-blue-400'
                     }`}
                   >
                     {c.id === null && <Home className="w-3.5 h-3.5" />}
@@ -195,22 +195,22 @@ const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
                   onClick={() =>
                     setPickerFolderId(folderStructure.folders[pickerFolderId]?.parentId ?? null)
                   }
-                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800/60 transition-colors"
+                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-white/[0.06]/60 transition-colors"
                 >
-                  <div className="w-9 h-9 rounded-lg bg-slate-500/10 text-slate-400 flex items-center justify-center shrink-0">
+                  <div className="w-9 h-9 rounded-lg bg-white/[0.05] text-[#565d6b] flex items-center justify-center shrink-0">
                     <CornerLeftUp className="w-4.5 h-4.5" />
                   </div>
-                  <span className="text-sm text-slate-500 dark:text-slate-400">{t('folder.goUp')}</span>
+                  <span className="text-[12px] text-[#71798a]">{t('folder.goUp')}</span>
                 </button>
               )}
 
               {childFolders.length === 0 && !pickerFolderId && (
-                <div className="py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+                <div className="py-8 text-center text-[12px] text-[#565d6b]">
                   {t('folder.noFolders')}
                 </div>
               )}
               {childFolders.length === 0 && pickerFolderId && (
-                <div className="py-8 text-center text-sm text-slate-400 dark:text-slate-500">
+                <div className="py-8 text-center text-[12px] text-[#565d6b]">
                   {t('folder.noSubfolders')}
                 </div>
               )}
@@ -227,17 +227,17 @@ const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
                     className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl transition-colors ${
                       blocked
                         ? 'opacity-40 cursor-not-allowed'
-                        : 'hover:bg-slate-100 dark:hover:bg-slate-800/60'
+                        : 'hover:bg-white/[0.06]/60'
                     }`}
                   >
                     <div className="w-9 h-9 rounded-lg bg-amber-500/10 text-amber-500 flex items-center justify-center shrink-0">
                       <Folder className="w-4.5 h-4.5 fill-current opacity-80" />
                     </div>
                     <div className="flex-1 min-w-0 text-left">
-                      <div className="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">
+                      <div className="text-[12px] font-medium text-[#d5d9e0] truncate">
                         {folder.name}
                       </div>
-                      <div className="text-xs text-slate-400 dark:text-slate-500 truncate">
+                      <div className="text-xs text-[#565d6b] truncate">
                         {blocked
                           ? t('folder.movingItems', { count: 1 })
                           : isSource
@@ -245,7 +245,7 @@ const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
                           : `${count} ${count === 1 ? t('common.item') : t('common.items')}`}
                       </div>
                     </div>
-                    {!blocked && <ChevronRight className="w-4 h-4 text-slate-400 shrink-0" />}
+                    {!blocked && <ChevronRight className="w-4 h-4 text-[#565d6b] shrink-0" />}
                   </button>
                 );
               })}
@@ -253,7 +253,7 @@ const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
 
             {/* New folder inline input */}
             {isCreating && (
-              <div className="flex items-center gap-2 px-4 py-2.5 border-t border-slate-200/60 dark:border-slate-700/60">
+              <div className="flex items-center gap-2 px-4 py-2.5 border-t border-white/[0.08]">
                 <Folder className="w-5 h-5 text-amber-500 shrink-0" />
                 <Input
                   value={newName}
@@ -276,7 +276,7 @@ const MoveToFolderSheet: React.FC<MoveToFolderSheetProps> = ({
             )}
 
             {/* Footer actions */}
-            <div className="flex items-center gap-2 px-4 py-3 border-t border-slate-200/60 dark:border-slate-700/60 bg-white/40 dark:bg-slate-900/40">
+            <div className="flex items-center gap-2 px-4 py-3 border-t border-white/[0.08] bg-[#0f1116]/90">
               <Button
                 variant="outline"
                 onClick={() => setIsCreating((v) => !v)}

--- a/src/components/workflow/WorkflowDetailModal.tsx
+++ b/src/components/workflow/WorkflowDetailModal.tsx
@@ -227,23 +227,23 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             transition={{ duration: 0.2, ease: 'easeOut' }}
-            className="relative w-full max-w-2xl bg-white/90 dark:bg-slate-900/90 backdrop-blur-3xl rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 overflow-hidden flex flex-col max-h-[85vh]"
+            className="relative w-full max-w-md bg-[#101217] rounded-xl shadow-2xl border border-white/10 overflow-hidden flex flex-col max-h-[80vh]"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Gradient Overlay */}
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-slate-900/5 pointer-events-none rounded-3xl" />
+            <div className="absolute inset-0 bg-gradient-to-br from-white/[0.02] via-transparent to-transparent pointer-events-none rounded-xl" />
 
             {/* Header with Close Button */}
-            <div className="relative z-50 flex items-center justify-between px-6 py-4 border-b border-white/10 dark:border-slate-600/10 flex-shrink-0">
+            <div className="relative z-50 flex items-center justify-between px-4 py-4 border-b border-white/[0.08] flex-shrink-0">
               <div className="flex items-center gap-3 min-w-0 flex-1">
                 <div className={`w-10 h-10 rounded-xl flex items-center justify-center shadow-lg ${workflow.isValid
                   ? 'bg-blue-500/15 dark:bg-blue-500/20 border border-blue-400/30'
                   : 'bg-red-500/15 dark:bg-red-500/20 border border-red-400/30'
                   }`}>
                   {workflow.isValid ? (
-                    <FileText className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                    <FileText className="w-5 h-5 text-[#5b8af5]" />
                   ) : (
-                    <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400" />
+                    <AlertCircle className="w-5 h-5 text-[#f87c7c]" />
                   )}
                 </div>
                 <div className="min-w-0 flex-1">
@@ -251,29 +251,29 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     onBlur={handleNameBlur}
-                    className="text-lg font-bold text-slate-900 dark:text-slate-100 bg-transparent border-none p-0 h-auto focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-slate-400"
+                    className="text-[14px] font-bold text-[#e9ebef] bg-transparent border-none p-0 h-auto focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-[#565d6b]"
                     placeholder={t('workflow.namePlaceholder')}
                   />
-                  <p className="text-xs text-slate-600 dark:text-slate-400 mt-0.5">
+                  <p className="text-xs text-[#8a919e] mt-0.5">
                     {t('workflow.details')}
                   </p>
                 </div>
               </div>
               <button
                 onClick={onClose}
-                className="flex-shrink-0 ml-3 p-2 bg-white/30 dark:bg-slate-700/30 backdrop-blur-sm border border-white/20 dark:border-slate-600/20 hover:bg-white/50 dark:hover:bg-slate-700/50 transition-all duration-200 rounded-xl"
+                className="flex-shrink-0 ml-3 p-1.5 bg-white/[0.06] border border-white/[0.08] hover:bg-white/[0.1] transition-all duration-200 rounded-lg"
                 aria-label="Close"
               >
-                <X className="w-5 h-5 text-slate-700 dark:text-slate-300" />
+                <X className="w-4 h-4 text-[#c8ccd4]" />
               </button>
             </div>
 
             {/* Content - Scrollable */}
             <div className="relative z-10 overflow-y-auto flex-1">
-              <div className="p-6 space-y-6">
+              <div className="p-4 space-y-6">
                 {/* Thumbnail */}
                 <div
-                  className="w-full aspect-video rounded-2xl overflow-hidden bg-slate-100/50 dark:bg-slate-800/50 border border-slate-200/30 dark:border-slate-600/30 flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity"
+                  className="w-full aspect-video rounded-[10px] overflow-hidden bg-white/[0.04] border border-white/[0.07] flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity"
                   onClick={handleOpenClick}
                 >
                   {thumbnailUrl ? (
@@ -283,9 +283,9 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                       className="w-full h-full object-cover"
                     />
                   ) : workflow.isValid ? (
-                    <FileText className="w-16 h-16 text-slate-400 dark:text-slate-500" />
+                    <FileText className="w-10 h-10 text-[#565d6b]" />
                   ) : (
-                    <AlertCircle className="w-16 h-16 text-red-500" />
+                    <AlertCircle className="w-10 h-10 text-red-500" />
                   )}
                 </div>
 
@@ -318,8 +318,8 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
 
                 {/* Description */}
                 <div className="space-y-2">
-                  <div className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-300">
-                    <FileText className="w-4 h-4 text-slate-400" />
+                  <div className="flex items-center gap-2 text-[12px] font-medium text-[#c8ccd4]">
+                    <FileText className="w-4 h-4 text-[#565d6b]" />
                     <span>{t('workflow.description')}</span>
                   </div>
                   <Textarea
@@ -327,14 +327,14 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                     onChange={(e) => setDescription(e.target.value)}
                     onBlur={handleDescriptionBlur}
                     placeholder={t('workflow.descriptionPlaceholder')}
-                    className="bg-white/40 dark:bg-slate-800/40 backdrop-blur-md rounded-2xl border-white/20 dark:border-slate-600/20 resize-none min-h-[80px]"
+                    className="bg-white/[0.03] rounded-[10px] border-white/[0.08] resize-none min-h-[80px]"
                   />
                 </div>
 
                 {/* Tags */}
                 <div className="space-y-2">
-                  <div className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-300">
-                    <Tag className="w-4 h-4 text-slate-400" />
+                  <div className="flex items-center gap-2 text-[12px] font-medium text-[#c8ccd4]">
+                    <Tag className="w-4 h-4 text-[#565d6b]" />
                     <span>{t('workflow.tags')}</span>
                   </div>
                   <div className="flex flex-wrap gap-2 mb-2">
@@ -342,12 +342,12 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                       <Badge
                         key={index}
                         variant="secondary"
-                        className="px-2 py-1 text-xs bg-slate-100/50 dark:bg-slate-700/50 backdrop-blur-md border border-slate-200/30 dark:border-slate-600/30 text-slate-700 dark:text-slate-300 pr-1"
+                        className="px-2 py-1 text-xs bg-white/[0.05] backdrop-blur-md border border-white/[0.07] text-[#c8ccd4] pr-1"
                       >
                         {tag}
                         <button
                           onClick={() => handleRemoveTag(tag)}
-                          className="ml-1 p-0.5 hover:bg-slate-200 dark:hover:bg-slate-600 rounded-full transition-colors"
+                          className="ml-1 p-0.5 hover:bg-white/[0.08] rounded-full transition-colors"
                         >
                           <X className="w-3 h-3" />
                         </button>
@@ -360,7 +360,7 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                       onChange={(e) => setNewTag(e.target.value)}
                       onKeyDown={handleKeyDown}
                       placeholder={t('workflow.tagPlaceholder')}
-                      className="bg-white/40 dark:bg-slate-800/40 backdrop-blur-md border-white/20 dark:border-slate-600/20 h-9"
+                      className="bg-white/[0.045] dark:bg-transparent border-white/[0.08] text-[#e9ebef] h-9"
                     />
                     <Button
                       onClick={handleAddTag}
@@ -375,15 +375,15 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                 </div>
 
                 {/* Metadata Section */}
-                <div className="bg-white/40 dark:bg-slate-800/40 backdrop-blur-md rounded-2xl p-4 border border-white/20 dark:border-slate-600/20 space-y-3">
+                <div className="bg-white/[0.03] rounded-[10px] p-3 border border-white/[0.08] space-y-2">
                   {/* Created At */}
                   <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-lg bg-slate-100/50 dark:bg-slate-700/50 flex items-center justify-center">
-                      <Calendar className="w-4 h-4 text-slate-600 dark:text-slate-400" />
+                    <div className="w-8 h-8 rounded-lg bg-white/[0.05] flex items-center justify-center">
+                      <Calendar className="w-4 h-4 text-[#8a919e]" />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-xs text-slate-500 dark:text-slate-400">{t('workflow.created')}</p>
-                      <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                      <p className="text-xs text-[#71798a]">{t('workflow.created')}</p>
+                      <p className="text-[12px] font-medium text-[#e9ebef]">
                         {new Date(workflow.createdAt).toLocaleDateString(undefined, {
                           year: 'numeric',
                           month: 'short',
@@ -395,12 +395,12 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
 
                   {/* Author */}
                   <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-lg bg-slate-100/50 dark:bg-slate-700/50 flex items-center justify-center">
-                      <User className="w-4 h-4 text-slate-600 dark:text-slate-400" />
+                    <div className="w-8 h-8 rounded-lg bg-white/[0.05] flex items-center justify-center">
+                      <User className="w-4 h-4 text-[#8a919e]" />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-xs text-slate-500 dark:text-slate-400">{t('workflow.author')}</p>
-                      <p className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
+                      <p className="text-xs text-[#71798a]">{t('workflow.author')}</p>
+                      <p className="text-[12px] font-medium text-[#e9ebef] truncate">
                         {workflow.author || t('common.unknown')}
                       </p>
                     </div>
@@ -409,12 +409,12 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                   {/* Modified At */}
                   {workflow.modifiedAt && (
                     <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-lg bg-slate-100/50 dark:bg-slate-700/50 flex items-center justify-center">
-                        <Calendar className="w-4 h-4 text-slate-600 dark:text-slate-400" />
+                      <div className="w-8 h-8 rounded-lg bg-white/[0.05] flex items-center justify-center">
+                        <Calendar className="w-4 h-4 text-[#8a919e]" />
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="text-xs text-slate-500 dark:text-slate-400">{t('workflow.modified')}</p>
-                        <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                        <p className="text-xs text-[#71798a]">{t('workflow.modified')}</p>
+                        <p className="text-[12px] font-medium text-[#e9ebef]">
                           {new Date(workflow.modifiedAt).toLocaleDateString(undefined, {
                             year: 'numeric',
                             month: 'short',
@@ -431,11 +431,11 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
             </div>
 
             {/* Footer - Action Buttons */}
-            <div className="relative z-50 px-6 py-4 border-t border-white/10 dark:border-slate-600/10 bg-white/30 dark:bg-slate-900/30 backdrop-blur-xl flex-shrink-0">
+            <div className="relative z-50 px-4 py-4 border-t border-white/[0.08] bg-[#0f1116]/90 backdrop-blur-xl flex-shrink-0">
               <div className="flex gap-3">
                 <Button
                   onClick={handleOpenClick}
-                  className="flex-[2] bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700 text-white font-medium py-6 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center gap-2"
+                  className="flex-[2] bg-[#3069f0] hover:bg-[#3f78f5] text-white font-medium h-10 py-0 rounded-[10px] shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center gap-2"
                 >
                   <Play className="w-5 h-5" />
                   {t('common.open')}
@@ -443,7 +443,7 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                 <Button
                   onClick={handleCopyWorkflow}
                   variant="outline"
-                  className="flex-1 py-6 rounded-2xl bg-white/50 dark:bg-slate-700/50 backdrop-blur-md border border-slate-200/50 dark:border-slate-600/50 hover:bg-white/70 dark:hover:bg-slate-700/70 transition-all duration-200 flex items-center justify-center gap-2"
+                  className="flex-1 h-10 py-0 rounded-[10px] bg-white/[0.05] border border-white/[0.08] text-[#c8ccd4] hover:bg-white/[0.08] hover:text-white transition-all duration-200 flex items-center justify-center gap-2"
                   title={t('workflow.copyWorkflow')}
                   disabled={isLoading}
                 >
@@ -453,7 +453,7 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                   <Button
                     onClick={() => onMove(workflow)}
                     variant="outline"
-                    className="flex-1 py-6 rounded-2xl bg-white/50 dark:bg-slate-700/50 backdrop-blur-md border border-slate-200/50 dark:border-slate-600/50 hover:bg-white/70 dark:hover:bg-slate-700/70 transition-all duration-200 flex items-center justify-center gap-2"
+                    className="flex-1 h-10 py-0 rounded-[10px] bg-white/[0.05] border border-white/[0.08] text-[#c8ccd4] hover:bg-white/[0.08] hover:text-white transition-all duration-200 flex items-center justify-center gap-2"
                     title={t('workflow.move')}
                     disabled={isLoading}
                   >
@@ -463,7 +463,7 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                 <Button
                   onClick={() => setShowDeleteConfirm(true)}
                   variant="outline"
-                  className="flex-1 py-6 rounded-2xl bg-white/50 dark:bg-slate-700/50 backdrop-blur-md border border-slate-200/50 dark:border-slate-600/50 hover:bg-red-500/10 hover:text-red-600 hover:border-red-500/30 transition-all duration-200 flex items-center justify-center gap-2"
+                  className="flex-1 h-10 py-0 rounded-[10px] border border-[#f25555]/30 bg-[#f25555]/[0.1] text-[#f87c7c] hover:bg-[#f25555]/[0.18] transition-all duration-200 flex items-center justify-center gap-2"
                   title={t('workflow.deleteWorkflow')}
                   disabled={isLoading}
                 >
@@ -478,21 +478,21 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
-                  className="absolute inset-0 z-[60] bg-white/60 dark:bg-slate-900/60 backdrop-blur-md flex items-center justify-center p-6"
+                  className="absolute inset-0 z-[60] bg-black/60 backdrop-blur-md flex items-center justify-center p-4"
                   onClick={(e) => e.stopPropagation()}
                 >
                   <motion.div
                     initial={{ scale: 0.9, opacity: 0 }}
                     animate={{ scale: 1, opacity: 1 }}
                     exit={{ scale: 0.9, opacity: 0 }}
-                    className="w-full max-w-sm bg-white dark:bg-slate-900 rounded-3xl shadow-2xl border border-slate-200 dark:border-slate-700 p-6 space-y-6"
+                    className="w-full max-w-[300px] bg-[#101217] rounded-xl shadow-2xl border border-white/10 p-4 space-y-4"
                   >
                     <div className="flex flex-col items-center text-center space-y-2">
-                      <div className="w-12 h-12 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center mb-2">
-                        <AlertCircle className="w-6 h-6 text-red-600 dark:text-red-400" />
+                      <div className="w-9 h-9 rounded-[10px] border flex items-center justify-center mb-1" style={{ background: 'rgba(242,85,85,0.1)', borderColor: 'rgba(242,85,85,0.3)' }}>
+                        <AlertCircle className="w-4 h-4 text-[#f25555]" strokeWidth={1.8} />
                       </div>
-                      <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100">{t('workflow.deleteConfirmTitle')}</h3>
-                      <p className="text-slate-500 dark:text-slate-400">
+                      <h3 className="text-[14px] font-bold text-[#e9ebef]">{t('workflow.deleteConfirmTitle')}</h3>
+                      <p className="text-[11.5px] leading-relaxed text-[#8a919e]">
                         {t('workflow.deleteConfirmMessage')}
                       </p>
                     </div>
@@ -501,14 +501,14 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({
                       <Button
                         onClick={() => setShowDeleteConfirm(false)}
                         variant="outline"
-                        className="flex-1 h-12 rounded-xl border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
+                        className="flex-1 h-9 rounded-[10px] text-[12px] bg-white/[0.05] border-white/[0.08] text-[#c8ccd4] hover:bg-white/[0.07]"
                       >
                         {t('common.cancel')}
                       </Button>
                       <Button
                         onClick={handleDelete}
                         variant="destructive"
-                        className="flex-1 h-12 rounded-xl bg-red-600 hover:bg-red-700 text-white shadow-lg shadow-red-500/20"
+                        className="flex-1 h-9 rounded-[10px] text-[12px] bg-[#f25555] hover:bg-[#f36d6d] text-white"
                         disabled={isLoading}
                       >
                         {isLoading ? t('common.loading') : t('common.delete')}

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -3482,10 +3482,18 @@ const WorkflowEditor: React.FC = () => {
   // Render loading state
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50/30 to-cyan-50/30 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900" style={{ height: '100dvh' }}>
+      <div
+        className="flex items-center justify-center"
+        style={{
+          height: '100dvh',
+          background: '#0b0c0f',
+          backgroundImage: 'radial-gradient(rgba(255,255,255,.05) 1px, transparent 1px)',
+          backgroundSize: '22px 22px',
+        }}
+      >
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">{t('workflow.loading')}</p>
+          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-white/[0.08] border-t-[#3069f0]" />
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[#565d6b]">{t('workflow.loading')}</p>
         </div>
       </div>
     );
@@ -3494,18 +3502,29 @@ const WorkflowEditor: React.FC = () => {
   // Render error state
   if (error && !workflow) {
     return (
-      <div className="flex items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50/30 to-cyan-50/30 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900" style={{ height: '100dvh' }}>
-        <div className="text-center max-w-md">
-          <div className="text-red-500 mb-4">
-            <svg className="w-16 h-16 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      <div
+        className="flex items-center justify-center px-6"
+        style={{
+          height: '100dvh',
+          background: '#0b0c0f',
+          backgroundImage: 'radial-gradient(rgba(255,255,255,.05) 1px, transparent 1px)',
+          backgroundSize: '22px 22px',
+        }}
+      >
+        <div className="text-center max-w-xs">
+          <div
+            className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-[10px] border"
+            style={{ background: 'rgba(242,85,85,0.1)', borderColor: 'rgba(242,85,85,0.3)' }}
+          >
+            <svg className="h-[18px] w-[18px] text-[#f25555]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
-          <h2 className="text-xl font-semibold mb-2">{t('workflow.loadFailed')}</h2>
-          <p className="text-muted-foreground mb-4">{error}</p>
+          <h2 className="mb-1.5 text-[14px] font-bold text-[#e9ebef]">{t('workflow.loadFailed')}</h2>
+          <p className="mb-4 text-[11.5px] leading-relaxed text-[#8a919e]">{error}</p>
           <button
             onClick={() => navigate('/')}
-            className="px-4 py-2 bg-primary text-white rounded hover:bg-primary/90"
+            className="h-9 rounded-[10px] bg-[#3069f0] px-4 text-[12px] font-semibold text-white transition-colors hover:bg-[#3f78f5]"
           >
             {t('workflow.backToList')}
           </button>
@@ -3516,7 +3535,7 @@ const WorkflowEditor: React.FC = () => {
 
   // Main render
   return (
-    <div className="pwa-container relative w-full via-blue-50/30 to-cyan-50/30">
+    <div className="pwa-container relative w-full">
       {/* Header */}
       <WorkflowHeader
         workflow={workflow!}

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -3590,32 +3590,32 @@ const WorkflowEditor: React.FC = () => {
       <div
         role="group"
         aria-label="Canvas mode"
-        className="flex w-48 items-stretch overflow-hidden rounded-xl border border-slate-500/70 bg-slate-900/85 shadow-xl backdrop-blur"
+        className="flex w-48 items-stretch gap-[3px] rounded-[10px] border border-white/10 p-1"
+        style={{ background: 'rgba(15,17,22,0.88)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}
       >
         <button
           onClick={() => {
             if (officialCanvasEnabled) handleToggleCanvasMode();
           }}
           className={cn(
-            'flex-1 basis-0 px-2 py-2 text-center text-[11px] font-semibold transition-colors',
+            'flex-1 basis-0 py-1.5 text-center font-mono text-[10px] tracking-[0.12em] uppercase rounded-[7px] transition-colors',
             !officialCanvasEnabled
-              ? 'bg-slate-600 text-white'
-              : 'text-slate-400 hover:bg-slate-700/60 hover:text-slate-200 active:bg-slate-700'
+              ? 'bg-[#e9ebef] text-[#0b0c0f] font-bold'
+              : 'text-[#71798a] font-semibold hover:text-[#9aa3b2]'
           )}
           title="Switch to the mobile canvas"
         >
           Mobile
         </button>
-        <div className="w-px self-stretch bg-slate-500/60" />
         <button
           onClick={() => {
             if (!officialCanvasEnabled) handleToggleCanvasMode();
           }}
           className={cn(
-            'flex-1 basis-0 px-2 py-2 text-center text-[11px] font-semibold transition-colors',
+            'flex-1 basis-0 py-1.5 text-center font-mono text-[10px] tracking-[0.12em] uppercase rounded-[7px] transition-colors',
             officialCanvasEnabled
-              ? 'bg-sky-600 text-white'
-              : 'text-slate-400 hover:bg-slate-700/60 hover:text-slate-200 active:bg-slate-700'
+              ? 'bg-[#3069f0] text-white font-bold'
+              : 'text-[#71798a] font-semibold hover:text-[#9aa3b2]'
           )}
           title="Switch to the official canvas (beta)"
         >
@@ -3629,32 +3629,32 @@ const WorkflowEditor: React.FC = () => {
         <div
           role="group"
           aria-label="Official node renderer"
-          className="flex w-48 items-stretch overflow-hidden rounded-xl border border-slate-500/70 bg-slate-900/85 shadow-xl backdrop-blur"
+          className="flex w-48 items-stretch gap-[3px] rounded-[10px] border border-white/10 p-1"
+          style={{ background: 'rgba(15,17,22,0.88)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}
         >
           <button
             onClick={() => {
               if (!vueNodesEnabled) handleSetNodesRenderer(true);
             }}
             className={cn(
-              'flex-1 basis-0 px-2 py-2 text-center text-[11px] font-semibold transition-colors',
+              'flex-1 basis-0 py-1.5 text-center font-mono text-[10px] tracking-[0.12em] uppercase rounded-[7px] transition-colors',
               vueNodesEnabled
-                ? 'bg-sky-600 text-white'
-                : 'text-slate-400 hover:bg-slate-700/60 hover:text-slate-200 active:bg-slate-700'
+                ? 'bg-[#e9ebef] text-[#0b0c0f] font-bold'
+                : 'text-[#71798a] font-semibold hover:text-[#9aa3b2]'
             )}
             title="Modern DOM-based node rendering"
           >
             Nodes 2.0
           </button>
-          <div className="w-px self-stretch bg-slate-500/60" />
           <button
             onClick={() => {
               if (vueNodesEnabled) handleSetNodesRenderer(false);
             }}
             className={cn(
-              'flex-1 basis-0 px-2 py-2 text-center text-[11px] font-semibold transition-colors',
+              'flex-1 basis-0 py-1.5 text-center font-mono text-[10px] tracking-[0.12em] uppercase rounded-[7px] transition-colors',
               !vueNodesEnabled
-                ? 'bg-slate-600 text-white'
-                : 'text-slate-400 hover:bg-slate-700/60 hover:text-slate-200 active:bg-slate-700'
+                ? 'bg-[#e9ebef] text-[#0b0c0f] font-bold'
+                : 'text-[#71798a] font-semibold hover:text-[#9aa3b2]'
             )}
             title="Traditional canvas node rendering"
           >

--- a/src/components/workflow/WorkflowGridItem.tsx
+++ b/src/components/workflow/WorkflowGridItem.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { FileText, AlertCircle, Clock, Check } from 'lucide-react';
+import { FileText, AlertCircle, Check } from 'lucide-react';
 import { Workflow } from '@/shared/types/app/IComfyWorkflow';
 import { generateWorkflowThumbnail } from '@/shared/utils/rendering/CanvasRendererService';
 import { useLongPress } from '@/hooks/useLongPress';
@@ -20,7 +19,6 @@ const WorkflowGridItem: React.FC<WorkflowGridItemProps> = ({
   isSelected = false,
   selectionMode = false,
 }) => {
-  const { t } = useTranslation();
   const [thumbnailUrl, setThumbnailUrl] = useState<string | undefined>(workflow.thumbnail);
 
   useEffect(() => {
@@ -47,76 +45,63 @@ const WorkflowGridItem: React.FC<WorkflowGridItemProps> = ({
 
   const longPressProps = useLongPress(onLongPress, onClick, { threshold: 500 });
 
-  // Format date relative or short
+  // Monospace MM.DD meta, matching the design spec.
   const formatDate = (date: Date | string) => {
     const d = new Date(date);
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${m}.${day}`;
   };
 
   return (
     <div
-      className={`relative group rounded-xl overflow-hidden cursor-pointer transition-all duration-300 border ${isSelected
-        ? 'ring-2 ring-blue-500 border-blue-500/50 shadow-[0_0_20px_rgba(59,130,246,0.3)]'
-        : 'border-white/10 hover:border-white/20 hover:shadow-xl'
+      className={`relative rounded-[10px] overflow-hidden cursor-pointer border transition-colors ${isSelected
+        ? 'border-[#3069f0]/70 ring-1 ring-[#3069f0]/40'
+        : 'border-white/[0.07] hover:border-white/[0.14]'
         }`}
+      style={{ background: '#101217' }}
       {...longPressProps}
     >
-      {/* Thumbnail Container - Full Bleed */}
-      <div className="aspect-[4/3] w-full bg-slate-900 relative overflow-hidden">
+      {/* Thumbnail */}
+      <div className="relative aspect-[16/10] border-b border-white/[0.06]" style={{ background: '#0c0e12' }}>
         {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
             alt={workflow.name}
-            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+            className="w-full h-full object-cover"
           />
         ) : (
-          <div className="w-full h-full flex flex-col items-center justify-center bg-slate-800/50 p-4">
+          <div className="w-full h-full flex items-center justify-center">
             {workflow.isValid ? (
-              <FileText className="w-12 h-12 text-slate-600 mb-2" />
+              <FileText className="w-8 h-8 text-white/15" strokeWidth={1.6} />
             ) : (
-              <AlertCircle className="w-12 h-12 text-red-500 mb-2" />
+              <AlertCircle className="w-8 h-8 text-[#f25555]/60" strokeWidth={1.6} />
             )}
-            <span className="text-xs text-slate-500 text-center">{t('workflow.noThumbnail')}</span>
           </div>
-        )}
-
-        {/* Gradient Overlay for Text Readability */}
-        <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-slate-950/40 to-transparent opacity-80" />
-
-        {/* Selected Overlay */}
-        {isSelected && (
-          <div className="absolute inset-0 bg-blue-500/20 backdrop-blur-[1px]" />
         )}
 
         {/* Selection checkbox */}
         {selectionMode && (
           <div
-            className={`absolute top-2 left-2 z-20 w-6 h-6 rounded-full flex items-center justify-center border-2 transition-colors ${isSelected
-              ? 'bg-blue-500 border-blue-500 text-white'
-              : 'bg-black/40 border-white/70 text-transparent'
+            className={`absolute top-2 left-2 z-10 w-[22px] h-[22px] rounded-md flex items-center justify-center border transition-colors ${isSelected
+              ? 'bg-[#3069f0] border-[#3069f0] text-white'
+              : 'bg-black/45 border-white/45 text-transparent'
               }`}
           >
-            <Check className="w-3.5 h-3.5" />
+            <Check className="w-3.5 h-3.5" strokeWidth={2.5} />
           </div>
         )}
       </div>
 
-      {/* Content Overlay */}
-      <div className="absolute inset-x-0 bottom-0 p-3 flex flex-col justify-end">
-        <div className="flex items-start justify-between gap-2">
-          <h3 className="text-sm font-semibold text-white leading-tight line-clamp-2 drop-shadow-md">
-            {workflow.name}
-          </h3>
+      {/* Meta */}
+      <div className="px-[11px] pt-[9px] pb-[10px]">
+        <div className="text-[12.5px] font-semibold leading-[1.35] text-[#e9ebef] line-clamp-1">
+          {workflow.name}
         </div>
-
-        <div className="flex items-center justify-between mt-2 text-[10px] text-slate-400">
-          <div className="flex items-center gap-1">
-            <Clock className="w-3 h-3" />
-            <span>{formatDate(workflow.modifiedAt || workflow.createdAt)}</span>
-          </div>
-          <div className="px-1.5 py-0.5 rounded-full bg-white/10 backdrop-blur-sm border border-white/5">
-            {workflow.nodeCount} {t('workflow.nodes')}
-          </div>
+        <div className="flex items-center gap-1.5 mt-[5px] font-mono text-[10px] text-[#565d6b]">
+          <span>{formatDate(workflow.modifiedAt || workflow.createdAt)}</span>
+          <span className="text-[#31363f]">·</span>
+          <span className="text-[#5b8af5]">{workflow.nodeCount}N</span>
         </div>
       </div>
     </div>

--- a/src/components/workflow/WorkflowHeader.tsx
+++ b/src/components/workflow/WorkflowHeader.tsx
@@ -125,58 +125,63 @@ export const WorkflowHeader: React.FC<WorkflowHeaderProps> = ({
 
   return (
     <header className="absolute top-0 left-0 right-0 z-10 pwa-header">
-      <div className="bg-slate-600/20 backdrop-blur-3xl shadow-xl border-b border-white/30 px-4 py-5 space-y-2 relative overflow-hidden">
-        <div className="flex items-center space-x-4 relative z-10">
-          <Button
+      <div
+        className="border-b border-white/[0.08] relative"
+        style={{ background: 'rgba(11,12,15,0.86)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
+      >
+        <div className="h-14 flex items-center gap-[11px] px-3 relative z-10">
+          <button
             onClick={onNavigateBack}
-            variant="ghost"
-            size="sm"
-            className="bg-white/10 hover:bg-white/20 border border-white/20 transition-all duration-300 h-10 w-10 p-0 flex-shrink-0 rounded-xl"
+            className="w-9 h-9 shrink-0 flex items-center justify-center rounded-[10px] border border-white/[0.08] text-[#c8ccd4] hover:text-white transition-colors"
+            style={{ background: 'rgba(255,255,255,0.045)' }}
           >
-            <ArrowLeft className="w-5 h-5 text-white" />
-          </Button>
+            <ArrowLeft className="w-[17px] h-[17px]" strokeWidth={1.8} />
+          </button>
 
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <Network className="h-4 w-4 text-blue-400 shrink-0" />
-              {sessionStack && sessionStack.length > 1 ? (
-                <div
-                  ref={breadcrumbRef}
-                  className="flex items-center space-x-1 overflow-x-auto no-scrollbar mask-gradient-left"
-                >
-                  {sessionStack.map((session, index) => {
-                    const isLast = index === sessionStack.length - 1;
-                    const isRoot = index === 0;
-                    return (
-                      <div key={index} className="flex items-center flex-shrink-0">
-                        {index > 0 && <ChevronRight className="w-4 h-4 text-slate-400 mx-1 flex-shrink-0" />}
-                        <button
-                          onClick={() => !isLast && onNavigateBreadcrumb?.(index)}
-                          disabled={isLast}
-                          className={`flex items-center space-x-1 font-bold truncate transition-colors ${isLast
-                            ? 'text-base text-slate-900 dark:text-slate-100 cursor-default'
-                            : 'text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'
-                            }`}
-                        >
-                          <span className="truncate max-w-[300px]">{session.title || (isRoot ? workflow?.name : 'Subgraph')}</span>
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : (
-                <h1 className="text-base font-bold text-white tracking-tight truncate">
-                  {workflow?.name || t('workflow.newWorkflowName')}
-                </h1>
+            {sessionStack && sessionStack.length > 1 ? (
+              <div
+                ref={breadcrumbRef}
+                className="flex items-center space-x-1 overflow-x-auto no-scrollbar mask-gradient-left"
+              >
+                {sessionStack.map((session, index) => {
+                  const isLast = index === sessionStack.length - 1;
+                  const isRoot = index === 0;
+                  return (
+                    <div key={index} className="flex items-center flex-shrink-0">
+                      {index > 0 && <ChevronRight className="w-3.5 h-3.5 text-[#4a5261] mx-0.5 flex-shrink-0" strokeWidth={2} />}
+                      <button
+                        onClick={() => !isLast && onNavigateBreadcrumb?.(index)}
+                        disabled={isLast}
+                        className={`flex items-center space-x-1 truncate transition-colors ${isLast
+                          ? 'text-[14px] font-semibold text-[#e9ebef] cursor-default'
+                          : 'text-[12.5px] font-medium text-[#71798a] hover:text-[#c8ccd4]'
+                          }`}
+                      >
+                        <span className="truncate max-w-[300px]">{session.title || (isRoot ? workflow?.name : 'Subgraph')}</span>
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <h1 className="text-[14px] font-semibold text-[#e9ebef] leading-[1.25] truncate">
+                {workflow?.name || t('workflow.newWorkflowName')}
+              </h1>
+            )}
+            <div className="flex items-center gap-1.5 font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-[3px]">
+              <span>{t('menu.graphView')}</span>
+              {typeof workflow?.nodeCount === 'number' && workflow.nodeCount > 0 && (
+                <>
+                  <span className="text-[#31363f]">·</span>
+                  <span className="text-[#5b8af5]">{workflow.nodeCount}N</span>
+                </>
               )}
-            </div>
-            <div className="text-[10px] text-white/40 font-medium uppercase tracking-widest mt-0.5">
-              {t('menu.graphView')}
             </div>
           </div>
 
           {/* Save Button Slot - Reserved space to prevent breadcrumb invasion */}
-          <div className="w-10 h-10 flex items-center justify-end flex-shrink-0">
+          <div className="w-9 h-9 flex items-center justify-end flex-shrink-0">
             <AnimatePresence>
               {(hasUnsavedChanges || showCheckmark) && (
                 <motion.div
@@ -185,24 +190,24 @@ export const WorkflowHeader: React.FC<WorkflowHeaderProps> = ({
                   exit={{ opacity: 0, scale: 0.8, transition: { duration: 0.4 } }}
                   transition={{ duration: 0.3, ease: "backOut" }}
                 >
-                  <Button
+                  <button
                     onClick={onSaveChanges}
                     disabled={isSaving || showCheckmark}
-                    size="sm"
-                    className={`text-white border border-white/20 backdrop-blur-sm shadow-lg transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg ${showCheckmark
-                      ? 'bg-emerald-500/80'
+                    className={`w-9 h-9 flex items-center justify-center rounded-[10px] text-white transition-all ${showCheckmark
+                      ? 'bg-[#34c77b]'
                       : isSaving
-                        ? 'bg-gray-500/80 cursor-not-allowed'
-                        : 'bg-green-500/80 hover:bg-green-600/90 hover:shadow-xl'
+                        ? 'bg-[#34c77b]/60 cursor-not-allowed'
+                        : 'bg-[#34c77b] hover:bg-[#3fd08a]'
                       }`}
+                    style={showCheckmark ? undefined : { boxShadow: '0 2px 10px rgba(52,199,123,0.35)' }}
                     title={showCheckmark ? t('common.saved') : isSaving ? t('common.saving') : t('workflow.saveChanges')}
                   >
                     <SaveToCheckIcon
                       isSaving={isSaving}
                       isSuccess={showCheckmark}
-                      size={24}
+                      size={16}
                     />
-                  </Button>
+                  </button>
                 </motion.div>
               )}
             </AnimatePresence>

--- a/src/components/workflow/WorkflowImport.tsx
+++ b/src/components/workflow/WorkflowImport.tsx
@@ -326,7 +326,7 @@ const WorkflowImport: React.FC = () => {
         }}
       >
         {/* Main Background with Dark Theme */}
-        <div className="absolute inset-0 bg-[#374151]" />
+        <div className="absolute inset-0 bg-[#0b0c0f]" />
 
         {/* Main Scrollable Content Area */}
         <div
@@ -337,10 +337,10 @@ const WorkflowImport: React.FC = () => {
             WebkitOverflowScrolling: 'touch'
           }}
         >
-          <div className="container mx-auto px-4 py-6 max-w-4xl">
+          <div className="container mx-auto px-4 py-4 max-w-4xl">
             <div className="flex items-center justify-center min-h-[60vh]">
               <div className="text-center">
-                <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-indigo-400" />
+                <Loader2 className="h-10 w-12 animate-spin mx-auto mb-4 text-indigo-400" />
                 <p className="text-white/70">{t('common.checkingServer')}</p>
               </div>
             </div>
@@ -366,10 +366,7 @@ const WorkflowImport: React.FC = () => {
       }}
     >
       {/* Main Background with Dark Theme */}
-      <div className="absolute inset-0 bg-[#374151]" />
-
-      {/* Glassmorphism Background Overlay */}
-      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
 
       {/* Main Scrollable Content Area */}
       <div
@@ -383,7 +380,7 @@ const WorkflowImport: React.FC = () => {
         }}
       >
         {/* Header */}
-        <header className="sticky top-0 z-50 pwa-header bg-[#1e293b] border-b border-white/10 shadow-xl relative overflow-hidden">
+        <header className="sticky top-0 z-50 pwa-header bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
           <div className="relative z-10 p-4">
             <div className="flex items-center space-x-3">
               <Button
@@ -393,16 +390,16 @@ const WorkflowImport: React.FC = () => {
                 }}
                 variant="ghost"
                 size="sm"
-                className="bg-white/10 backdrop-blur-sm border border-white/10 shadow-lg hover:bg-white/20 transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg text-white"
+                className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] transition-all h-9 w-9 p-0 flex-shrink-0 rounded-[10px] text-[#c8ccd4]"
                 style={{ touchAction: 'manipulation' }}
               >
                 <ArrowLeft className="w-4 h-4" />
               </Button>
               <div>
-                <h1 className="text-lg font-bold text-white/95 leading-none">
+                <h1 className="text-[15px] font-bold text-[#e9ebef] leading-none">
                   {t('workflow.import.title')}
                 </h1>
-                <p className="text-[11px] text-white/40 mt-1">
+                <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">
                   {t('workflow.import.subtitle')}
                 </p>
               </div>
@@ -411,21 +408,21 @@ const WorkflowImport: React.FC = () => {
         </header>
 
         {/* Content */}
-        <div className="container mx-auto px-6 py-8 max-w-4xl">
+        <div className="container mx-auto px-4 py-5 max-w-4xl">
 
           {/* Server Requirements Check */}
           {(isCheckingExtension || !isConnected || !hasExtension) && (
-            <Card className="mb-6 border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+            <Card className="mb-3 border border-white/[0.08] bg-white/[0.025] shadow-none">
               <CardHeader>
                 <CardTitle className="text-white/90 flex items-center gap-2">
-                  <Server className="h-5 w-5 text-blue-400" />
+                  <Server className="h-4 w-4 text-[#5b8af5]" />
                   {t('common.serverRequirements')}
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-2.5">
                 {isCheckingExtension ? (
                   <div className="flex items-center space-x-3">
-                    <Loader2 className="h-4 w-4 animate-spin text-blue-400" />
+                    <Loader2 className="h-4 w-4 animate-spin text-[#5b8af5]" />
                     <span className="text-white/70">
                       {t('common.checkingServer')}
                     </span>
@@ -434,15 +431,15 @@ const WorkflowImport: React.FC = () => {
                   <>
                     {/* Server Connection Status */}
                     <div className="flex items-center justify-between">
-                      <span className="text-white/70 font-medium">{t('common.serverConnection')}</span>
+                      <span className="text-[12.5px] text-[#9aa3b2]">{t('common.serverConnection')}</span>
                       <div className="flex items-center gap-2">
                         {isConnected ? (
-                          <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                          <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                             <CheckCircle className="h-3 w-3 mr-1" />
                             {t('common.connected')}
                           </Badge>
                         ) : (
-                          <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                          <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                             <AlertCircle className="h-3 w-3 mr-1" />
                             {t('common.disconnected')}
                           </Badge>
@@ -452,15 +449,15 @@ const WorkflowImport: React.FC = () => {
 
                     {/* Extension Status */}
                     <div className="flex items-center justify-between">
-                      <span className="text-white/70 font-medium">{t('common.extension')}</span>
+                      <span className="text-[12.5px] text-[#9aa3b2]">{t('common.extension')}</span>
                       <div className="flex items-center gap-2">
                         {hasExtension ? (
-                          <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                          <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                             <CheckCircle className="h-3 w-3 mr-1" />
                             {t('common.available')}
                           </Badge>
                         ) : (
-                          <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                          <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                             <AlertCircle className="h-3 w-3 mr-1" />
                             {t('common.notFound')}
                           </Badge>
@@ -472,25 +469,25 @@ const WorkflowImport: React.FC = () => {
                     {(!isConnected || !hasExtension) && (
                       <div className="space-y-2">
                         {!serverUrl && (
-                          <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-                            <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-                            <span className="text-red-400 text-sm">
+                          <div className="p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+                            <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+                            <span className="text-[#f87c7c] text-[12px]">
                               {t('common.noServerUrl')}
                             </span>
                           </div>
                         )}
                         {!isConnected && serverUrl && (
-                          <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-                            <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-                            <span className="text-red-400 text-sm">
+                          <div className="p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+                            <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+                            <span className="text-[#f87c7c] text-[12px]">
                               {connectionError ? `${t('workflow.import.failedTitle')}: ${connectionError}` : t('common.notConnected')}
                             </span>
                           </div>
                         )}
                         {isConnected && !hasExtension && (
-                          <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-                            <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-                            <span className="text-red-400 text-sm">
+                          <div className="p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+                            <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+                            <span className="text-[#f87c7c] text-[12px]">
                               {t('common.extensionNotFound')}
                             </span>
                           </div>
@@ -549,9 +546,9 @@ const WorkflowImport: React.FC = () => {
 
           {/* Error Display */}
           {error && (
-            <div className="mb-6 p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-              <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-              <span className="text-red-400 text-sm">
+            <div className="mb-3 p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+              <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+              <span className="text-[#f87c7c] text-[12px]">
                 {error}
               </span>
             </div>
@@ -559,9 +556,9 @@ const WorkflowImport: React.FC = () => {
 
           {/* Server Workflows List */}
           {isConnected && hasExtension && (
-            <div className="space-y-4">
+            <div className="space-y-2.5">
               {/* Search Bar and Count */}
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-white/40" />
                   <input
@@ -569,7 +566,7 @@ const WorkflowImport: React.FC = () => {
                     placeholder={t('workflow.searchPlaceholder')}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="w-full pl-9 pr-9 py-2 bg-black/20 border border-white/10 rounded-xl text-white/90 placeholder:text-white/20 focus:outline-none focus:ring-1 focus:ring-white/20 transition-all text-sm h-10"
+                    className="w-full pl-9 pr-9 bg-white/[0.045] border border-white/[0.08] rounded-[10px] text-[#e9ebef] placeholder:text-[#71798a] focus:outline-none focus:border-[#3069f0]/50 transition-all text-[12.5px] h-[42px]"
                   />
                   {searchQuery && (
                     <button
@@ -580,10 +577,11 @@ const WorkflowImport: React.FC = () => {
                     </button>
                   )}
                 </div>
-                <div className="flex items-center justify-between px-1">
-                  <h2 className="text-sm font-medium text-white/70">
+                <div className="flex items-center gap-2 px-0.5">
+                  <h2 className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] uppercase whitespace-nowrap">
                     {searchQuery ? t('workflow.import.foundCount', { count: filteredWorkflows.length }) : t('workflow.import.serverWorkflows', { count: serverWorkflows.length })}
                   </h2>
+                  <div className="flex-1 h-px bg-white/[0.06]" />
                   <Button
                     variant="ghost"
                     size="sm"
@@ -601,57 +599,50 @@ const WorkflowImport: React.FC = () => {
               {filteredWorkflows.length === 0 ? (
                 <Card className="bg-black/20 border-white/5">
                   <CardContent className="py-12 text-center">
-                    <Server className="h-12 w-12 mx-auto mb-4 text-white/20" />
+                    <Server className="h-10 w-12 mx-auto mb-4 text-white/20" />
                     <p className="text-white/60">
                       {searchQuery ? t('workflow.import.noResultsQuery') : t('workflow.import.noWorkflowsOnServer')}
                     </p>
-                    <p className="text-white/30 text-sm mt-2">
+                    <p className="text-white/30 text-[12px] mt-2">
                       {searchQuery ? t('workflow.import.tryDifferent') : t('workflow.import.saveFirst')}
                     </p>
                   </CardContent>
                 </Card>
               ) : (
-                <div className="grid gap-2">
+                <div className="grid grid-cols-[minmax(0,1fr)] gap-2">
                   {filteredWorkflows.map((workflow, index) => (
                     <div
                       key={workflow.filename}
-                      className="transition-all duration-300 ease-in-out"
+                      className="min-w-0 transition-all duration-300 ease-in-out"
                     >
-                      <Card className={`border border-white/5 bg-black/20 backdrop-blur-sm hover:bg-white/5 transition-all group ${isImporting === workflow.filename ? 'opacity-70 pointer-events-none' : ''
+                      <Card className={`border border-white/5 bg-white/[0.025] hover:bg-white/5 transition-all group ${isImporting === workflow.filename ? 'opacity-70 pointer-events-none' : ''
                         }`}>
-                        <CardContent className="p-3">
+                        <CardContent className="px-3 py-3">
                           <div className="flex gap-3 items-center w-full">
                             <div className="flex-1 min-w-0">
-                              <h3 className="font-medium text-white/95 mb-1 break-all text-sm leading-tight">
+                              <h3 className="text-[13px] font-semibold text-[#e9ebef] leading-[1.35] line-clamp-1 break-all">
                                 {workflow.filename?.replace(/\.json$/i, '') || t('workflow.newWorkflowName')}
                               </h3>
-                              <div className="flex flex-wrap items-center gap-1.5 text-xs text-white/40 font-mono">
-                                <Badge variant="outline" className="bg-white/5 border-white/5 text-white/40 text-[10px] h-4 px-1.5 min-h-[16px] flex items-center">
-                                  {formatFileSize(workflow.size || 0)}
-                                </Badge>
-                                <span className="truncate text-[10px]">
-                                  {formatDate(workflow.modified?.getTime() || Date.now())}
-                                </span>
+                              <div className="flex items-center gap-1.5 mt-1 font-mono text-[10px] text-[#565d6b] whitespace-nowrap">
+                                <span>{formatDate(workflow.modified?.getTime() || Date.now())}</span>
+                                <span className="text-[#31363f]">·</span>
+                                <span>{formatFileSize(workflow.size || 0)}</span>
                               </div>
                             </div>
 
-                            <Button
+                            <button
                               onClick={() => importWorkflow(workflow)}
                               disabled={isImporting === workflow.filename}
-                              size="sm"
-                              className="bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 text-white disabled:opacity-70 whitespace-nowrap flex-shrink-0 touch-manipulation min-h-[32px] h-8 px-3 rounded-lg shadow-lg hover:shadow-indigo-500/20 transition-all"
-                              style={{ touchAction: 'manipulation' }}
+                              className="h-8 px-[13px] flex items-center gap-1.5 rounded-lg border text-[11.5px] font-semibold whitespace-nowrap flex-shrink-0 transition-colors disabled:opacity-60"
+                              style={{ background: 'rgba(61,123,253,0.12)', borderColor: 'rgba(61,123,253,0.3)', color: '#7ba3f5', touchAction: 'manipulation' }}
                             >
                               {isImporting === workflow.filename ? (
-                                <>
-                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                </>
+                                <Loader2 className="h-3 w-3 animate-spin" />
                               ) : (
-                                <>
-                                  <Download className="h-4 w-4" />
-                                </>
+                                <Download className="h-3 w-3" strokeWidth={1.9} />
                               )}
-                            </Button>
+                              {t('workflow.import.importButton', 'Import')}
+                            </button>
                           </div>
                         </CardContent>
                       </Card>
@@ -667,17 +658,17 @@ const WorkflowImport: React.FC = () => {
       {/* Override Confirmation Dialog */}
       {overrideDialog.isOpen && (
         <div className="fixed inset-0 pwa-modal z-[65] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-          <div className="relative max-w-md w-full bg-white/20 dark:bg-slate-800/20 backdrop-blur-xl rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 flex flex-col overflow-hidden">
+          <div className="relative max-w-[320px] w-full bg-[#101217] rounded-xl shadow-2xl border border-white/10 flex flex-col overflow-hidden">
             {/* Gradient Overlay for Enhanced Glass Effect */}
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-slate-900/10 pointer-events-none" />
+            <div className="absolute inset-0 bg-transparent pointer-events-none" />
 
             {/* Dialog Header */}
-            <div className="relative flex items-center justify-between p-4 border-b border-white/10 dark:border-slate-600/10 flex-shrink-0">
+            <div className="relative flex items-center justify-between px-4 h-11 border-b border-white/[0.08] flex-shrink-0">
               <div className="flex items-center space-x-2">
-                <div className="w-6 h-6 bg-yellow-500/20 backdrop-blur-sm rounded-full flex items-center justify-center border border-yellow-400/30">
-                  <AlertCircle className="w-4 h-4 text-yellow-300" />
+                <div className="w-6 h-6 rounded-md flex items-center justify-center border" style={{ background: 'rgba(255,163,72,0.12)', borderColor: 'rgba(255,163,72,0.3)' }}>
+                  <AlertCircle className="w-3.5 h-3.5 text-[#ffa348]" strokeWidth={1.8} />
                 </div>
-                <h3 className="text-lg font-semibold text-white">
+                <h3 className="text-[14px] font-semibold text-white">
                   {t('workflow.import.existsTitle')}
                 </h3>
               </div>
@@ -685,16 +676,16 @@ const WorkflowImport: React.FC = () => {
 
             {/* Dialog Content */}
             <div className="relative p-4">
-              <p className="text-white/90 mb-4">
+              <p className="text-[11.5px] leading-relaxed text-[#8a919e] mb-4">
                 {t('workflow.import.existsDesc', { name: overrideDialog.filename })}
               </p>
-              <p className="text-white/70 text-sm mb-4">
+              <p className="text-white/70 text-[12px] mb-4">
                 {t('workflow.import.existsPrompt')}
               </p>
             </div>
 
             {/* Dialog Footer */}
-            <div className="relative flex justify-end gap-2 p-4 border-t border-white/10 dark:border-slate-600/10 flex-shrink-0">
+            <div className="relative flex justify-end gap-2 p-4 border-t border-white/10 dark:border-white/[0.1]/10 flex-shrink-0">
               <Button
                 onClick={handleOverrideCancel}
                 variant="outline"
@@ -704,7 +695,7 @@ const WorkflowImport: React.FC = () => {
               </Button>
               <Button
                 onClick={handleOverrideConfirm}
-                className="bg-blue-600 hover:bg-blue-700 text-white shadow-sm hover:shadow-md transition-all duration-300"
+                className="bg-[#3069f0] hover:bg-[#3f78f5] text-white shadow-sm hover:shadow-md transition-all duration-300"
               >
                 {t('workflow.import.importAnyway')}
               </Button>

--- a/src/components/workflow/WorkflowList.tsx
+++ b/src/components/workflow/WorkflowList.tsx
@@ -15,16 +15,17 @@ import {
   X,
   ArrowRightLeft,
   FolderInput,
-  FolderPlus,
   Trash2,
-  AlertTriangle
+  AlertTriangle,
+  CornerLeftUp,
+  Check
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Workflow } from '@/shared/types/app/IComfyWorkflow';
+import { useConnectionStore } from '@/ui/store/connectionStore';
 import WorkflowGridItem from './WorkflowGridItem';
 import FolderGridItem from './FolderGridItem';
-import ParentFolderGridItem from './ParentFolderGridItem';
 import FolderDetailModal from './FolderDetailModal';
 import WorkflowDetailModal from './WorkflowDetailModal';
 import WorkflowEditModal from './WorkflowEditModal';
@@ -421,251 +422,245 @@ const WorkflowList: React.FC = () => {
     navigate(path);
   };
 
+  const serverUrl = useConnectionStore((s) => s.url);
+  const serverHost = useMemo(
+    () => (serverUrl || '').replace(/^https?:\/\//, '').replace(/\/+$/, ''),
+    [serverUrl]
+  );
+
   return (
-    <div className="h-full flex flex-col bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-sans selection:bg-blue-100 dark:selection:bg-blue-900/30 overflow-hidden">
-      {/* Fixed Header */}
-      <header className="flex-none z-40 bg-white/80 dark:bg-slate-950/80 backdrop-blur-xl border-b border-slate-200/60 dark:border-slate-800/60 shadow-sm transition-all duration-300">
-        <div className="max-w-[1600px] mx-auto px-4 h-16 flex items-center justify-between gap-2">
-          {/* Left: Menu & Breadcrumbs */}
-          <div className="flex items-center gap-2 min-w-0 flex-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="shrink-0 h-10 w-10 rounded-xl"
-              onClick={() => setIsSideMenuOpen(true)}
-            >
-              <Menu className="w-6 h-6" />
-            </Button>
+    <div className="h-full flex flex-col text-[#e9ebef] overflow-hidden" style={{ background: '#0b0c0f' }}>
+      {/* Header (52px, tool aesthetic) */}
+      <header className="flex-none z-40 border-b border-white/[0.08]" style={{ background: '#0b0c0f' }}>
+        <div className="max-w-[1600px] mx-auto h-[52px] px-4 flex items-center gap-2.5">
+          <button
+            onClick={() => setIsSideMenuOpen(true)}
+            className="shrink-0 -ml-1 p-1.5 text-[#c8ccd4] hover:text-white transition-colors"
+            aria-label={t('common.menu', 'Menu')}
+          >
+            <Menu className="w-5 h-5" strokeWidth={1.7} />
+          </button>
 
-            {/* App Icon 흰색 처리 */}
-            <div className="w-8 h-8 bg-blue-600 rounded-xl flex items-center justify-center shadow-lg shadow-blue-500/20 shrink-0 relative overflow-hidden group">
-              <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-blue-700" />
-              <img
-                src="/icons/icon-monochrome.svg"
-                alt="ComfyUI"
-                className="w-5 h-5 object-contain relative z-10 drop-shadow-md transform transition-transform group-hover:scale-110"
-                style={{ filter: 'brightness(0) invert(1)' }}
-              />
-            </div>
-
-            {/* Breadcrumbs - Scrollable on mobile */}
-            <nav className="flex items-center gap-1 overflow-x-auto scrollbar-hide text-sm font-medium whitespace-nowrap mask-linear-fade">
-              {breadcrumbs.map((item, index) => (
-                <React.Fragment key={item.id || 'root'}>
-                  {index > 0 && <ChevronRight className="w-4 h-4 text-slate-400 shrink-0" />}
-                  <button
-                    onClick={() => setCurrentFolderId(item.id)}
-                    className={`hover:text-blue-600 dark:hover:text-blue-400 transition-colors ${index === breadcrumbs.length - 1
-                      ? 'text-slate-900 dark:text-slate-100 font-semibold'
-                      : 'text-slate-500 dark:text-slate-500'
-                      }`}
-                  >
-                    {item.name}
-                  </button>
-                </React.Fragment>
-              ))}
-            </nav>
+          {/* App icon tile */}
+          <div className="w-[26px] h-[26px] shrink-0 rounded-[7px] bg-[#3069f0] flex items-center justify-center">
+            <img
+              src="/icons/icon-monochrome.svg"
+              alt="ComfyUI"
+              className="w-4 h-4"
+              style={{ filter: 'brightness(0) invert(1)' }}
+            />
           </div>
 
-          {/* Right: Actions */}
-          <div className="flex items-center gap-1 shrink-0">
-            {/* Gallery Button */}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-10 w-10 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-900"
-              onClick={() => {
-                sessionStorage.setItem('app-navigation', 'true');
-                navigate('/outputs');
-              }}
-              title={t('common.gallery')}
-            >
-              <Image className="w-5 h-5 text-slate-600 dark:text-slate-400" />
-            </Button>
-          </div>
+          {/* Breadcrumbs */}
+          <nav className="flex items-center gap-1 min-w-0 overflow-x-auto scrollbar-hide whitespace-nowrap text-[13.5px] font-semibold">
+            {breadcrumbs.map((item, index) => (
+              <React.Fragment key={item.id || 'root'}>
+                {index > 0 && <ChevronRight className="w-3.5 h-3.5 text-[#4a5261] shrink-0" strokeWidth={2} />}
+                <button
+                  onClick={() => setCurrentFolderId(item.id)}
+                  className={`transition-colors ${index === breadcrumbs.length - 1
+                    ? 'text-[#e9ebef]'
+                    : 'text-[#71798a] hover:text-[#c8ccd4]'
+                    }`}
+                >
+                  {item.name}
+                </button>
+              </React.Fragment>
+            ))}
+          </nav>
+
+          {/* Server chip */}
+          {serverHost && (
+            <span className="shrink-0 font-mono text-[11px] text-[#565d6b] px-1.5 py-[3px] border border-white/10 rounded-[5px] max-w-[164px] truncate">
+              {serverHost}
+            </span>
+          )}
+
+          <div className="flex-1" />
+
+          {/* Gallery */}
+          <button
+            onClick={() => {
+              sessionStorage.setItem('app-navigation', 'true');
+              navigate('/outputs');
+            }}
+            className="shrink-0 p-1.5 text-[#8a919e] hover:text-[#c8ccd4] transition-colors"
+            aria-label={t('common.gallery')}
+          >
+            <Image className="w-[18px] h-[18px]" strokeWidth={1.7} />
+          </button>
         </div>
       </header>
 
-      {/* Sub Header (Search) */}
-      <div className="flex-none bg-white dark:bg-slate-950 border-b border-slate-200/60 dark:border-slate-800/60 z-30">
-        <div className="max-w-[1600px] mx-auto px-4 py-2">
-          {/* Search */}
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-            <Input
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder={t('workflow.searchPlaceholder')}
-              className="w-full pl-10 h-10 bg-slate-100/50 dark:bg-slate-900/50 border-transparent focus:bg-white dark:focus:bg-slate-950 focus:border-blue-500/50 transition-all duration-200 rounded-xl text-sm"
-            />
-            {searchQuery && (
-              <button
-                onClick={() => setSearchQuery('')}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-              >
-                <X className="w-4 h-4" />
+      {/* Search + New workflow */}
+      <div className="flex-none z-30 border-b border-white/[0.08] px-4 py-2.5 flex gap-2">
+        <div
+          className="flex-1 min-w-0 relative flex items-center h-9 pl-3 pr-2 rounded-[9px] border border-white/[0.08] focus-within:border-[#3069f0]/50 transition-colors"
+          style={{ background: 'rgba(255,255,255,0.045)' }}
+        >
+          <Search className="w-3.5 h-3.5 text-[#71798a] shrink-0" strokeWidth={1.8} />
+          <Input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={t('workflow.searchPlaceholder')}
+            className="flex-1 h-9 min-w-0 border-none bg-transparent dark:bg-transparent shadow-none focus-visible:ring-0 px-2 text-[12.5px] text-[#e9ebef] placeholder:text-[#71798a]"
+          />
+          {searchQuery ? (
+            <button onClick={() => setSearchQuery('')} className="shrink-0 text-[#565d6b] hover:text-[#9aa3b2]">
+              <X className="w-3.5 h-3.5" />
+            </button>
+          ) : (
+            <span className="shrink-0 font-mono text-[10px] text-[#565d6b] border border-white/10 rounded-[4px] px-1.5 py-0.5">
+              {workflows.length}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={() => setIsUploadModalOpen(true)}
+          className="shrink-0 h-9 px-3.5 flex items-center gap-1.5 rounded-[9px] bg-[#3069f0] hover:bg-[#3f78f5] text-white text-[12.5px] font-semibold transition-colors"
+        >
+          <Plus className="w-[13px] h-[13px]" strokeWidth={2.4} />
+          {t('workflow.uploadButton')}
+        </button>
+      </div>
+
+      {/* Folders */}
+      <div className="flex-none z-30 px-4 pt-3 pb-2">
+        <div className="flex items-center gap-2 mb-2.5">
+          <span className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] shrink-0 uppercase">{t('folder.title')}</span>
+          <div className="flex-1 h-px bg-white/[0.06]" />
+        </div>
+
+        <div className="flex gap-[7px] overflow-x-auto scrollbar-hide">
+          {/* Parent */}
+          {currentFolderId && !selectionMode && (
+            <button
+              onClick={() => setCurrentFolderId(folderStructure.folders[currentFolderId]?.parentId ?? null)}
+              className="h-10 shrink-0 flex items-center gap-[9px] px-3 rounded-[9px] border border-white/[0.08] hover:border-white/[0.16] transition-colors"
+              style={{ background: 'rgba(255,255,255,0.035)' }}
+            >
+              <CornerLeftUp className="w-[15px] h-[15px] text-[#71798a]" strokeWidth={1.8} />
+              <span className="text-[12.5px] font-medium text-[#9aa3b2] whitespace-nowrap">{t('folder.backToParent')}</span>
+            </button>
+          )}
+
+          {/* Inline create */}
+          {isCreatingFolder && (
+            <div
+              className="h-10 shrink-0 flex items-center gap-2 px-3 rounded-[9px] border border-[#3069f0]/60"
+              style={{ background: 'rgba(48,105,240,0.08)' }}
+            >
+              <FolderIcon className="w-[15px] h-[15px] text-[#5b8af5] shrink-0" strokeWidth={1.8} />
+              <Input
+                value={newFolderName}
+                onChange={(e) => setNewFolderName(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleCreateFolder()}
+                onBlur={() => {
+                  if (!newFolderName.trim()) {
+                    setIsCreatingFolder(false);
+                    setNewFolderName('');
+                  }
+                }}
+                placeholder={t('folder.namePlaceholder')}
+                className="h-8 w-28 min-w-0 border-none bg-transparent dark:bg-transparent shadow-none focus-visible:ring-0 px-0 text-[12.5px] text-[#e9ebef]"
+                autoFocus
+              />
+              <button onClick={handleCreateFolder} className="shrink-0 text-[#5b8af5]">
+                <Check className="w-4 h-4" strokeWidth={2.2} />
               </button>
-            )}
-          </div>
+            </div>
+          )}
+
+          {/* Folder tiles */}
+          {filteredContents.folders.map((folder) => (
+            <div key={folder.id} className="shrink-0">
+              <FolderGridItem
+                folder={folder}
+                onClick={() => handleFolderClick(folder.id)}
+                onLongPress={() => {
+                  setDetailFolder(folder);
+                  setIsFolderDetailModalOpen(true);
+                }}
+                workflowCount={folder.workflows.length + folder.children.length}
+                isSelected={selectedIds.has(folder.id)}
+                selectionMode={selectionMode}
+              />
+            </div>
+          ))}
+
+          {/* Add folder (dashed) */}
+          {!isCreatingFolder && !selectionMode && (
+            <button
+              onClick={() => setIsCreatingFolder(true)}
+              className="h-10 w-10 shrink-0 flex items-center justify-center rounded-[9px] border border-dashed border-white/[0.13] hover:border-white/25 text-[#565d6b] hover:text-[#9aa3b2] transition-colors"
+              aria-label={t('folder.newFolder')}
+            >
+              <Plus className="w-[14px] h-[14px]" strokeWidth={1.8} />
+            </button>
+          )}
+
+          {/* Empty */}
+          {filteredContents.folders.length === 0 && !isCreatingFolder && !currentFolderId && (
+            <span className="self-center font-mono text-[10px] text-[#4a5261] px-1 whitespace-nowrap">EMPTY</span>
+          )}
         </div>
       </div>
 
-      {/* Action Toolbar (create / select / sort) */}
-      <div className="flex-none bg-white dark:bg-slate-950 border-b border-slate-200/60 dark:border-slate-800/60 z-30">
-        <div className="max-w-[1600px] mx-auto px-4 py-2 flex items-center flex-wrap gap-2">
-          {/* New Workflow */}
-          <Button
-            onClick={() => setIsUploadModalOpen(true)}
-            className="h-9 gap-2 rounded-xl text-sm bg-blue-600 hover:bg-blue-700 text-white border-none shadow-sm"
-          >
-            <Plus className="w-4 h-4" />
-            {t('workflow.uploadButton')}
-          </Button>
-          {/* New Folder */}
-          <Button
-            onClick={() => setIsCreatingFolder(true)}
-            variant="outline"
-            className="h-9 gap-2 rounded-xl text-sm border-slate-200 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900"
-          >
-            <FolderPlus className="w-4 h-4" />
-            {t('folder.newFolder')}
-          </Button>
-          {/* Select / multi-select mode */}
-          <Button
+      {/* Workflows label (fixed header) */}
+      <div className="flex-none z-30 px-4 pt-1.5 pb-2.5">
+        <div className="max-w-[1600px] mx-auto flex items-center gap-2.5">
+          <span className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] shrink-0 whitespace-nowrap">
+            {t('workflow.listTitle').toUpperCase()} · {filteredContents.workflows.length}
+          </span>
+          <div className="flex-1 h-px bg-white/[0.06]" />
+          {/* Select */}
+          <button
             onClick={() => (selectionMode ? exitSelection() : enterSelection())}
-            variant="outline"
-            className={`h-9 gap-2 rounded-xl text-sm ${selectionMode
-              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 border-transparent'
-              : 'border-slate-200 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900'
+            className={`shrink-0 flex items-center gap-1 text-[11px] font-medium transition-colors ${selectionMode ? 'text-[#5b8af5]' : 'text-[#8a919e] hover:text-[#c8ccd4]'
               }`}
           >
-            {selectionMode ? <X className="w-4 h-4" /> : <ArrowRightLeft className="w-4 h-4" />}
+            {selectionMode ? <X className="w-3 h-3" strokeWidth={2.2} /> : <ArrowRightLeft className="w-3 h-3" strokeWidth={2} />}
             {selectionMode ? t('workflow.cancelSelection') : t('workflow.selectItems')}
-          </Button>
-
-          {/* Sort (pinned right on wider screens) */}
-          <Button
-            variant="ghost"
+          </button>
+          {/* Sort */}
+          <button
             onClick={() => {
               const nextSort: SortOrder = selectedSortOrder === 'date-desc' ? 'name-asc' : 'date-desc';
               setSortOrder(nextSort);
             }}
-            className="h-9 px-3 gap-2 rounded-xl text-sm text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 shrink-0 sm:ml-auto"
-            title={t('workflow.sorting.title', 'Sort')}
+            className="shrink-0 flex items-center gap-1 text-[11px] font-medium text-[#8a919e] hover:text-[#c8ccd4] transition-colors"
           >
-            <ArrowUpDown className="w-4 h-4" />
+            <ArrowUpDown className="w-3 h-3" strokeWidth={2} />
             {selectedSortOrder.includes('date') ? t('workflow.sorting.newest') : t('workflow.sorting.name')}
-          </Button>
+          </button>
         </div>
       </div>
 
-      {/* Fixed Folder Section */}
-      <div className="flex-none bg-slate-50/50 dark:bg-slate-950/50 border-b border-slate-200/60 dark:border-slate-800/60 z-30">
-        <div className="max-w-[1600px] mx-auto px-4 py-3">
-          {/* Folder Section Header */}
-          <div className="flex items-center mb-4">
-            <h2 className="text-lg font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
-              <FolderIcon className="w-6 h-6" />
-              {t('folder.title')}
-            </h2>
-          </div>
-
-          {/* Folders List */}
-          <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
-            {/* Parent Folder */}
-            {currentFolderId && !selectionMode && (
-              <div className="min-w-[160px] shrink-0">
-                <ParentFolderGridItem
-                  onClick={() => {
-                    const parentId = folderStructure.folders[currentFolderId]?.parentId ?? null;
-                    setCurrentFolderId(parentId);
-                  }}
-                  isTarget={false}
-                  isMoveMode={false}
-                />
-              </div>
-            )}
-
-            {/* New Folder Input */}
-            {isCreatingFolder && (
-              <div className="min-w-[160px] h-[72px] flex items-center gap-2 bg-white dark:bg-slate-900 rounded-xl border border-blue-500 shadow-lg px-3">
-                <Input
-                  value={newFolderName}
-                  onChange={(e) => setNewFolderName(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleCreateFolder()}
-                  onBlur={() => {
-                    if (!newFolderName.trim()) {
-                      setIsCreatingFolder(false);
-                      setNewFolderName('');
-                    }
-                  }}
-                  placeholder={t('folder.namePlaceholder')}
-                  className="h-10 text-base border-none shadow-none focus-visible:ring-0 px-0 min-w-0"
-                  autoFocus
-                />
-                <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={handleCreateFolder}>
-                  <Plus className="w-5 h-5 text-blue-500" />
-                </Button>
-              </div>
-            )}
-
-            {/* Folder Items */}
-            {filteredContents.folders.length === 0 && !isCreatingFolder && !currentFolderId && (
-              <div className="text-sm text-slate-400 italic py-3 px-2">{t('folder.noFolders')}</div>
-            )}
-
-            {filteredContents.folders.map((folder) => (
-              <div key={folder.id} className="min-w-[160px]">
-                <FolderGridItem
-                  folder={folder}
-                  onClick={() => handleFolderClick(folder.id)}
-                  onLongPress={() => {
-                    setDetailFolder(folder);
-                    setIsFolderDetailModalOpen(true);
-                  }}
-                  workflowCount={folder.workflows.length + folder.children.length}
-                  isSelected={selectedIds.has(folder.id)}
-                  selectionMode={selectionMode}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content - Scrollable Workflow List */}
-      <main className="flex-1 overflow-y-auto w-full bg-slate-50 dark:bg-slate-950">
-        <div className="max-w-[1600px] mx-auto px-4 py-6 space-y-6">
+      {/* Main scroll (workflow grid only) */}
+      <main className="flex-1 overflow-y-auto w-full" style={{ background: '#0b0c0f' }}>
+        <div className="max-w-[1600px] mx-auto px-4">
           {error && (
-            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4 text-red-600 dark:text-red-400 text-sm">
+            <div className="mb-3 rounded-[10px] border border-[#f25555]/30 bg-[#f25555]/10 px-3 py-2.5 text-[#f87c7c] text-[12px]">
               {error}
             </div>
           )}
 
-          {/* Workflows Header */}
-          <div className="flex items-center">
-            <h2 className="text-lg font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
-              <FileText className="w-6 h-6" />
-              {t('workflow.listTitle')} ({filteredContents.workflows.length})
-            </h2>
-          </div>
-
-          {/* Workflow Grid */}
+          {/* Workflow grid */}
           {filteredContents.workflows.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-20 text-center">
-              <div className="w-16 h-16 bg-slate-100 dark:bg-slate-900 rounded-full flex items-center justify-center mb-4">
-                <FileText className="w-8 h-8 text-slate-400" />
-              </div>
-              <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100">{t('workflow.noWorkflows')}</h3>
-              <p className="text-slate-500 dark:text-slate-400 mt-1 max-w-sm">
-                {t('workflow.noWorkflowsSub')}
-              </p>
-              <Button onClick={() => setIsUploadModalOpen(true)} variant="outline" className="mt-6">
+            <div className="flex flex-col items-center justify-center py-24 text-center">
+              <FileText className="w-9 h-9 text-white/[0.12] mb-3" strokeWidth={1.4} />
+              <h3 className="text-[14px] font-semibold text-[#c8ccd4]">{t('workflow.noWorkflows')}</h3>
+              <p className="text-[12px] text-[#66758a] mt-1 max-w-xs">{t('workflow.noWorkflowsSub')}</p>
+              <button
+                onClick={() => setIsUploadModalOpen(true)}
+                className="mt-5 h-9 px-4 flex items-center gap-1.5 rounded-[9px] bg-[#3069f0] hover:bg-[#3f78f5] text-white text-[12.5px] font-semibold transition-colors"
+              >
+                <Plus className="w-[13px] h-[13px]" strokeWidth={2.4} />
                 {t('workflow.uploadButton')}
-              </Button>
+              </button>
             </div>
           ) : (
-            <div className={`grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-6 ${selectionMode ? 'pb-32' : 'pb-20'}`}>
+            <div className={`grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 ${selectionMode ? 'pb-32' : 'pb-20'}`}>
               {filteredContents.workflows.map((workflow) => (
                 <WorkflowGridItem
                   key={workflow.id}
@@ -684,41 +679,41 @@ const WorkflowList: React.FC = () => {
         </div>
       </main>
 
-      {/* Selection action bar */}
+      {/* Selection action bar (floating) */}
       <AnimatePresence>
         {selectionMode && (
           <motion.div
-            initial={{ y: 90, opacity: 0 }}
+            initial={{ y: 80, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
-            exit={{ y: 90, opacity: 0 }}
+            exit={{ y: 80, opacity: 0 }}
             transition={{ duration: 0.2, ease: 'easeOut' }}
-            className="fixed bottom-0 inset-x-0 z-40 border-t border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-900/90 backdrop-blur-xl"
+            className="fixed inset-x-0 z-40 flex justify-center px-4"
+            style={{ bottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
           >
             <div
-              className="max-w-[1600px] mx-auto px-4 py-3 flex items-center gap-2"
-              style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+              className="flex items-center gap-2 p-1.5 rounded-[14px] border border-white/[0.09]"
+              style={{ background: 'rgba(15,17,22,0.9)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)', boxShadow: '0 12px 32px rgba(0,0,0,0.45)' }}
             >
-              <span className="text-sm font-medium text-slate-700 dark:text-slate-300 shrink-0">
+              <span className="pl-2 pr-1 font-mono text-[11px] text-[#8a919e] whitespace-nowrap">
                 {t('workflow.selectedCount', { count: selectedIds.size })}
               </span>
-              <div className="flex-1" />
-              <Button
+              <span className="w-px h-5 bg-white/[0.08]" />
+              <button
                 onClick={openMoveForSelection}
                 disabled={selectedIds.size === 0}
-                className="h-10 gap-2 rounded-xl bg-blue-600 hover:bg-blue-700 text-white border-none disabled:opacity-40"
+                className="h-9 px-3.5 flex items-center gap-1.5 rounded-[10px] bg-[#3069f0] hover:bg-[#3f78f5] text-white text-[12px] font-semibold disabled:opacity-40 transition-colors"
               >
-                <FolderInput className="w-4 h-4" />
+                <FolderInput className="w-3.5 h-3.5" strokeWidth={1.9} />
                 {t('workflow.move')}
-              </Button>
-              <Button
+              </button>
+              <button
                 onClick={() => setShowBulkDeleteConfirm(true)}
                 disabled={selectedIds.size === 0}
-                variant="outline"
-                className="h-10 gap-2 rounded-xl border-red-300 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-40"
+                className="h-9 px-3.5 flex items-center gap-1.5 rounded-[10px] border border-[#f25555]/30 bg-[#f25555]/[0.12] text-[#f87c7c] text-[12px] font-semibold disabled:opacity-40 transition-colors"
               >
-                <Trash2 className="w-4 h-4" />
+                <Trash2 className="w-3.5 h-3.5" strokeWidth={1.9} />
                 {t('common.delete')}
-              </Button>
+              </button>
             </div>
           </motion.div>
         )}

--- a/src/components/workflow/WorkflowList.tsx
+++ b/src/components/workflow/WorkflowList.tsx
@@ -863,31 +863,31 @@ const WorkflowList: React.FC = () => {
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: 20 }}
               transition={{ duration: 0.2, ease: 'easeOut' }}
-              className="w-full max-w-sm bg-white dark:bg-slate-900 rounded-3xl shadow-2xl border border-slate-200 dark:border-slate-700 p-6 space-y-6"
+              className="w-full max-w-[300px] bg-[#101217] rounded-xl shadow-2xl border border-white/10 p-4 space-y-4"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="flex flex-col items-center text-center space-y-3">
-                <div className="w-14 h-14 rounded-full bg-red-500/10 flex items-center justify-center">
-                  <AlertTriangle className="w-7 h-7 text-red-600 dark:text-red-400" />
+              <div className="flex flex-col items-center text-center gap-2.5">
+                <div className="w-9 h-9 rounded-[10px] border flex items-center justify-center" style={{ background: 'rgba(242,85,85,0.1)', borderColor: 'rgba(242,85,85,0.3)' }}>
+                  <AlertTriangle className="w-4 h-4 text-[#f25555]" strokeWidth={1.8} />
                 </div>
-                <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">
+                <h3 className="text-[14px] font-bold text-[#e9ebef] leading-tight">
                   {t('workflow.deleteSelectedConfirm')}
                 </h3>
-                <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
+                <p className="text-[11.5px] text-[#8a919e] leading-relaxed">
                   {t('workflow.deleteSelectedMessage')}
                 </p>
               </div>
-              <div className="flex gap-3">
+              <div className="flex gap-2">
                 <Button
                   onClick={() => setShowBulkDeleteConfirm(false)}
                   variant="outline"
-                  className="flex-1 h-12 rounded-xl border-slate-200 dark:border-slate-700"
+                  className="flex-1 h-9 rounded-[10px] text-[12px] bg-white/[0.05] border-white/[0.08] text-[#c8ccd4] hover:bg-white/[0.07]"
                 >
                   {t('common.cancel')}
                 </Button>
                 <Button
                   onClick={handleBulkDelete}
-                  className="flex-1 h-12 rounded-xl bg-red-600 hover:bg-red-700 text-white border-none"
+                  className="flex-1 h-9 rounded-[10px] text-[12px] font-semibold bg-[#f25555] hover:bg-[#f36d6d] text-white border-none"
                 >
                   {t('common.delete')}
                 </Button>

--- a/src/components/workflow/WorkflowSnapshots.tsx
+++ b/src/components/workflow/WorkflowSnapshots.tsx
@@ -316,55 +316,40 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
           onClick={(e) => e.stopPropagation()}
         >
           <div
-            style={{ backgroundColor: '#374151' }}
-            className="relative w-full h-full rounded-[40px] shadow-2xl ring-1 ring-slate-100/10 overflow-hidden flex flex-col text-white"
+            style={{ backgroundColor: '#101217' }}
+            className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
             {/* Sticky Header */}
-            <div className="absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] pt-2 pb-[13px] pl-4 pr-[44px] bg-black/50 backdrop-blur-xl border-white/10">
-              <div className="absolute right-4 top-1/2 -translate-y-1/2 flex-shrink-0 scale-75">
+            <div className="absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b h-11 pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]">
+              <div className="absolute right-3 top-1/2 -translate-y-1/2 flex-shrink-0">
                 <button
                   onClick={onClose}
-                  className="p-2 rounded-full bg-black/20 text-white hover:bg-black/40 transition-all pointer-events-auto"
+                  className="p-1.5 rounded-lg bg-white/[0.06] text-[#9aa3b2] hover:text-white hover:bg-white/[0.1] transition-all pointer-events-auto"
                 >
-                  <X className="w-5 h-5" />
+                  <X className="w-4 h-4" />
                 </button>
               </div>
 
-              <div className="flex flex-col justify-center flex-1 min-w-0 pointer-events-none">
-                <div className="flex items-center space-x-2 mb-1 scale-90 origin-left">
-                  <Badge variant="secondary" className="text-[10px] font-mono px-2 py-0.5 rounded-full bg-black/20 text-white/80 border-transparent">
-                    HISTORY
-                  </Badge>
-                  <span className="text-[10px] font-bold uppercase tracking-widest text-white/60">
-                    {t('workflow.snapshot.title')}
-                  </span>
-                </div>
-                <div className="flex items-center min-w-0 h-[13px]">
-                  <h2
-                    style={{
-                      fontSize: baseTitleSize,
-                      lineHeight: '1',
-                      transform: `scale(${0.8125 / 1.875})`,
-                      transformOrigin: 'left center',
-                    }}
-                    className="font-extrabold tracking-tight leading-tight text-white/95 transition-transform duration-300 will-change-transform truncate pr-4"
-                  >
-                    {t('workflow.snapshot.title')}
-                  </h2>
-                </div>
+              <div className="flex items-center gap-2 flex-1 min-w-0 pointer-events-none">
+                <h2 className="text-[14px] font-bold text-[#e9ebef] truncate">
+                  {t('workflow.snapshot.title')}
+                </h2>
+                <span className="font-mono text-[9px] font-semibold text-[#565d6b] tracking-[0.12em] px-1.5 py-0.5 rounded-md bg-black/20 shrink-0">
+                  HISTORY
+                </span>
               </div>
             </div>
 
             {/* Persistent Controls Bar */}
-            <div className="absolute left-0 w-full z-20 px-4 sm:px-8 top-[68px]">
-              <div className="flex items-center gap-2 bg-[#374151]/90 backdrop-blur-xl p-2 rounded-2xl border border-white/10 shadow-2xl">
+            <div className="absolute left-0 w-full z-20 px-3 sm:px-6 top-[52px]">
+              <div className="flex items-center gap-2 bg-[#101217]/90 backdrop-blur-xl p-1.5 rounded-[10px] border border-white/[0.08] shadow-xl">
                 <div className="relative flex-1 min-w-0">
                   <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
                   <Input
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     placeholder={t('workflow.searchPlaceholder')}
-                    className="w-full bg-black/40 border-white/10 text-xs text-white/90 placeholder:text-white/20 h-10 pl-9 pr-8 rounded-xl focus-visible:ring-1 focus-visible:ring-white/20 focus-visible:border-white/20 transition-all duration-300 border shadow-inner"
+                    className="w-full bg-white/[0.045] border-white/[0.08] text-[#e9ebef] placeholder:text-[#565d6b] h-8 pl-8 pr-8 rounded-lg text-[12px] focus-visible:ring-0 focus-visible:border-[#3069f0]/50 transition-all duration-300 border"
                   />
                   {searchQuery && (
                     <button
@@ -380,27 +365,27 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
 
             {/* Content Area */}
             <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
-              <div className="h-[140px] relative pointer-events-none" />
+              <div className="h-[108px] relative pointer-events-none" />
 
               <div className="px-6 pb-8 sm:px-8">
                 {/* HEAD Section */}
                 {!searchQuery && (
                   <div className="mb-8">
                     <div className="flex items-center gap-2 mb-3 p-1">
-                      <Clock className="w-4 h-4 text-blue-400" />
-                      <span className="text-[10px] font-bold uppercase tracking-widest text-blue-400/80">
+                      <Clock className="w-4 h-4 text-[#5b8af5]" />
+                      <span className="text-[10px] font-bold uppercase tracking-widest text-[#5b8af5]/80">
                         {t('workflow.snapshot.live')}
                       </span>
                     </div>
-                    <div className="relative rounded-3xl bg-blue-500/5 border border-blue-500/20 p-5 flex items-center justify-between group/live">
-                      <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-transparent opacity-0 group-hover/live:opacity-100 transition-opacity rounded-3xl" />
+                    <div className="relative rounded-[10px] bg-[#3069f0]/[0.06] border border-[#3069f0]/25 p-3 flex items-center justify-between group/live">
+                      <div className="absolute inset-0 bg-gradient-to-r from-[#3069f0]/10 to-transparent opacity-0 group-hover/live:opacity-100 transition-opacity rounded-[10px]" />
                       <div className="flex items-center space-x-4 min-w-0 relative z-10 flex-1">
-                        <div className="w-10 h-10 rounded-2xl bg-blue-500/20 flex items-center justify-center border border-blue-500/30 flex-shrink-0">
-                          <History className="w-5 h-5 text-blue-400" />
+                        <div className="w-8 h-8 rounded-lg bg-[#3069f0]/[0.15] flex items-center justify-center border border-[#3069f0]/30 flex-shrink-0">
+                          <History className="w-5 h-5 text-[#5b8af5]" />
                         </div>
                         <div className="flex flex-col min-w-0 flex-1">
-                          <span className="font-bold text-white/95 text-sm tracking-tight">{t('workflow.snapshot.currentState')}</span>
-                          <span className="text-[10px] font-medium text-blue-400/60 uppercase tracking-wider tabular-nums">{currentTime} • {t('workflow.snapshot.uncapturedChanges')}</span>
+                          <span className="font-bold text-white/95 text-[12px] tracking-tight">{t('workflow.snapshot.currentState')}</span>
+                          <span className="text-[10px] font-medium text-[#5b8af5]/60 uppercase tracking-wider tabular-nums">{currentTime} • {t('workflow.snapshot.uncapturedChanges')}</span>
                         </div>
                       </div>
 
@@ -409,12 +394,12 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                           onClick={() => setIsSaveModalOpen(true)}
                           disabled={!currentWorkflowId || isSaving}
                           variant="ghost"
-                          className="h-9 px-4 bg-blue-600/20 hover:bg-blue-600 text-blue-300 hover:text-white border border-blue-500/20 rounded-xl transition-all shadow-lg shadow-blue-600/10 active:scale-95 flex items-center gap-2"
+                          className="h-9 px-4 bg-blue-600/20 hover:bg-blue-600 text-[#7ba3f5] hover:text-white border border-blue-500/20 rounded-xl transition-all shadow-lg shadow-blue-600/10 active:scale-95 flex items-center gap-2"
                         >
                           <Camera className="w-4 h-4" />
                           <span className="hidden sm:inline-block font-bold text-[10px] uppercase tracking-wider">{t('workflow.snapshot.saveButton')}</span>
                         </Button>
-                        <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30 font-bold px-3 py-1 rounded-full text-[10px] animate-pulse">
+                        <Badge className="bg-blue-500/20 text-[#7ba3f5] border-blue-500/30 font-bold px-3 py-1 rounded-full text-[10px] animate-pulse">
                           HEAD
                         </Badge>
                       </div>
@@ -426,13 +411,13 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                   <div className="flex flex-col items-center justify-center py-20 space-y-4">
                     <div className="relative">
                       <Loader2 className="h-10 w-10 animate-spin text-white/20" />
-                      <Sparkles className="absolute -top-1 -right-1 h-4 w-4 text-blue-400/50 animate-pulse" />
+                      <Sparkles className="absolute -top-1 -right-1 h-4 w-4 text-[#5b8af5]/50 animate-pulse" />
                     </div>
                   </div>
                 ) : filteredSnapshots.length === 0 ? (
-                  <div className="text-center py-12 rounded-[32px] bg-black/20 border border-dashed border-white/10">
+                  <div className="text-center py-10 rounded-xl bg-black/20 border border-dashed border-white/10">
                     <History className="h-10 w-10 text-white/10 mx-auto mb-3" />
-                    <p className="text-white/40 text-sm font-medium">{t('workflow.snapshot.noSnapshots')}</p>
+                    <p className="text-white/40 text-[12px] font-medium">{t('workflow.snapshot.noSnapshots')}</p>
                   </div>
                 ) : (
                   <div className="space-y-6">
@@ -445,19 +430,19 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                       </div>
                     </div>
 
-                    <div className="grid grid-cols-1 gap-3">
+                    <div className="grid grid-cols-1 gap-2">
                       {filteredSnapshots.map((snapshot) => (
                         <div
                           key={snapshot.filename}
-                          className="group relative rounded-3xl bg-black/10 border border-white/5 hover:bg-black/20 hover:border-white/10 transition-all flex flex-col md:flex-row md:items-center p-4 overflow-hidden gap-4"
+                          className="group relative rounded-[10px] bg-white/[0.03] border border-white/[0.07] hover:bg-white/[0.05] hover:border-white/[0.12] transition-all flex flex-col md:flex-row md:items-center p-2 overflow-hidden gap-2"
                         >
-                          <div className="flex items-center space-x-4 min-w-0 flex-1">
-                            <div className="w-10 h-10 rounded-2xl bg-white/5 flex items-center justify-center border border-white/5 group-hover:bg-white/10 group-hover:border-white/10 transition-all flex-shrink-0">
-                              <FileText className="w-5 h-5 text-white/40 group-hover:text-white/60" />
+                          <div className="flex items-center space-x-2.5 min-w-0 flex-1">
+                            <div className="w-7 h-7 rounded-md bg-white/[0.05] flex items-center justify-center border border-white/[0.06] group-hover:bg-white/[0.08] transition-all flex-shrink-0">
+                              <FileText className="w-3.5 h-3.5 text-white/40 group-hover:text-white/60" />
                             </div>
                             <div className="flex flex-col min-w-0">
-                              <span className="font-bold text-white/90 truncate text-sm tracking-tight mb-1">{snapshot.title}</span>
-                              <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium text-white/20 uppercase tracking-wider">
+                              <span className="font-semibold text-[#e9ebef] truncate text-[11.5px] tracking-tight mb-0.5">{snapshot.title}</span>
+                              <div className="flex flex-wrap items-center gap-1.5 font-mono text-[9px] text-[#565d6b] uppercase tracking-[0.08em]">
                                 <span className="whitespace-nowrap">{formatDate(snapshot.createdAt)}</span>
                                 <span className="hidden sm:inline">•</span>
                                 <span className="whitespace-nowrap">{formatFileSize(snapshot.fileSize)}</span>
@@ -468,24 +453,24 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                           <div className="flex items-center justify-end gap-1.5 pt-2 border-t border-white/5 md:pt-0 md:border-t-0 md:ml-4">
                             <button
                               onClick={() => showRenameModal(snapshot)}
-                              className="p-2.5 rounded-xl bg-white/5 text-white/40 hover:bg-white/10 hover:text-white transition-all border border-white/5 flex-shrink-0"
+                              className="p-1.5 rounded-lg bg-white/[0.05] text-white/40 hover:bg-white/10 hover:text-white transition-all border border-white/[0.06] flex-shrink-0"
                               title={t('workflow.snapshot.rename')}
                             >
-                              <Edit3 className="w-4 h-4" />
+                              <Edit3 className="w-3.5 h-3.5" />
                             </button>
                             <button
                               onClick={() => { setSnapshotToDelete(snapshot); setDeleteConfirmOpen(true); }}
-                              className="p-2.5 rounded-xl bg-white/5 text-red-400/40 hover:bg-red-500/20 hover:text-red-400 transition-all border border-white/5 flex-shrink-0"
+                              className="p-1.5 rounded-lg bg-white/[0.05] text-[#f87c7c]/50 hover:bg-[#f25555]/[0.15] hover:text-[#f87c7c] transition-all border border-white/[0.06] flex-shrink-0"
                               title={t('common.delete')}
                             >
-                              <Trash2 className="w-4 h-4" />
+                              <Trash2 className="w-3.5 h-3.5" />
                             </button>
                             <button
                               onClick={() => showLoadWarning(snapshot)}
-                              className="p-2.5 rounded-xl bg-blue-600/20 text-blue-400 hover:bg-blue-600 hover:text-white transition-all border border-blue-500/20 active:scale-95 h-11 px-4 flex items-center gap-2 flex-shrink-0"
+                              className="rounded-lg bg-[#3069f0]/[0.15] text-[#5b8af5] hover:bg-[#3069f0] hover:text-white transition-all border border-[#3069f0]/25 active:scale-95 h-8 px-3 flex items-center gap-1.5 flex-shrink-0"
                             >
-                              <Upload className="w-4 h-4" />
-                              <span className="font-bold text-[10px] uppercase tracking-widest">{t('workflow.snapshot.load')}</span>
+                              <Upload className="w-3.5 h-3.5" />
+                              <span className="font-mono font-semibold text-[9px] uppercase tracking-[0.1em]">{t('workflow.snapshot.load')}</span>
                             </button>
                           </div>
                         </div>
@@ -522,14 +507,14 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                 initial={{ opacity: 0, scale: 0.9, y: 20 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.9, y: 20 }}
-                className="relative w-full max-w-sm bg-[#1F2937] rounded-[32px] border border-white/10 shadow-2xl p-8 space-y-6"
+                className="relative w-full max-w-sm bg-[#101217] rounded-xl border border-white/10 shadow-2xl p-5 space-y-4"
                 onClick={e => e.stopPropagation()}
               >
                 <div className="flex items-center gap-3">
-                  <div className="w-12 h-12 rounded-2xl bg-blue-500/20 flex items-center justify-center border border-blue-500/30">
-                    <Save className="w-6 h-6 text-blue-400" />
+                  <div className="w-9 h-9 rounded-[10px] bg-[#3069f0]/[0.15] flex items-center justify-center border border-[#3069f0]/30">
+                    <Save className="w-6 h-6 text-[#5b8af5]" />
                   </div>
-                  <h3 className="text-lg font-bold text-white">{t('workflow.snapshot.saveTitle')}</h3>
+                  <h3 className="text-[14px] font-bold text-[#e9ebef]">{t('workflow.snapshot.saveTitle')}</h3>
                 </div>
                 <div className="space-y-4">
                   <p className="text-xs text-white/50 leading-relaxed">{t('workflow.snapshot.saveDesc')}</p>
@@ -537,15 +522,15 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                     value={saveTitle}
                     onChange={(e) => setSaveTitle(e.target.value)}
                     placeholder={t('workflow.snapshot.savePlaceholder')}
-                    className="bg-black/40 border-white/10 text-white rounded-2xl h-12 px-5"
+                    className="bg-white/[0.045] border-white/[0.08] text-[#e9ebef] rounded-[10px] h-10 px-3.5 text-[12.5px]"
                     autoFocus
                   />
                 </div>
                 <div className="flex gap-2">
-                  <Button variant="ghost" className="flex-1 h-12 rounded-2xl text-white/40 hover:bg-white/5" onClick={() => setIsSaveModalOpen(false)}>
+                  <Button variant="ghost" className="flex-1 h-9 rounded-[10px] text-[12px] text-[#8a919e] hover:bg-white/[0.05]" onClick={() => setIsSaveModalOpen(false)}>
                     {t('common.cancel')}
                   </Button>
-                  <Button className="flex-1 h-12 rounded-2xl bg-blue-600 hover:bg-blue-500 text-white font-bold" onClick={handleSaveSnapshot} disabled={isSaving || !saveTitle.trim()}>
+                  <Button className="flex-1 h-9 rounded-[10px] text-[12px] bg-[#3069f0] hover:bg-[#3f78f5] text-white font-semibold" onClick={handleSaveSnapshot} disabled={isSaving || !saveTitle.trim()}>
                     {isSaving ? <Loader2 className="w-4 h-4 animate-spin" /> : t('common.save')}
                   </Button>
                 </div>
@@ -558,28 +543,28 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                 initial={{ opacity: 0, scale: 0.9, y: 20 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.9, y: 20 }}
-                className="relative w-full max-w-sm bg-[#1F2937] rounded-[32px] border border-white/10 shadow-2xl p-8 space-y-6"
+                className="relative w-full max-w-sm bg-[#101217] rounded-xl border border-white/10 shadow-2xl p-5 space-y-4"
                 onClick={e => e.stopPropagation()}
               >
                 <div className="flex items-center gap-3">
-                  <div className="w-12 h-12 rounded-2xl bg-blue-500/20 flex items-center justify-center border border-blue-500/30">
-                    <Edit3 className="w-6 h-6 text-blue-400" />
+                  <div className="w-9 h-9 rounded-[10px] bg-[#3069f0]/[0.15] flex items-center justify-center border border-[#3069f0]/30">
+                    <Edit3 className="w-6 h-6 text-[#5b8af5]" />
                   </div>
-                  <h3 className="text-lg font-bold text-white">{t('workflow.snapshot.renameTitle')}</h3>
+                  <h3 className="text-[14px] font-bold text-[#e9ebef]">{t('workflow.snapshot.renameTitle')}</h3>
                 </div>
                 <div className="space-y-4">
                   <Input
                     value={renameTitle}
                     onChange={(e) => setRenameTitle(e.target.value)}
-                    className="bg-black/40 border-white/10 text-white rounded-2xl h-12 px-5"
+                    className="bg-white/[0.045] border-white/[0.08] text-[#e9ebef] rounded-[10px] h-10 px-3.5 text-[12.5px]"
                     autoFocus
                   />
                 </div>
                 <div className="flex gap-2">
-                  <Button variant="ghost" className="flex-1 h-12 rounded-2xl text-white/40 hover:bg-white/5" onClick={() => setRenameModalOpen(false)}>
+                  <Button variant="ghost" className="flex-1 h-9 rounded-[10px] text-[12px] text-[#8a919e] hover:bg-white/[0.05]" onClick={() => setRenameModalOpen(false)}>
                     {t('common.cancel')}
                   </Button>
-                  <Button className="flex-1 h-12 rounded-2xl bg-blue-600 hover:bg-blue-500 text-white font-bold" onClick={handleRenameSnapshot} disabled={isRenaming || !renameTitle.trim()}>
+                  <Button className="flex-1 h-9 rounded-[10px] text-[12px] bg-[#3069f0] hover:bg-[#3f78f5] text-white font-semibold" onClick={handleRenameSnapshot} disabled={isRenaming || !renameTitle.trim()}>
                     {isRenaming ? <Loader2 className="w-4 h-4 animate-spin" /> : t('common.save')}
                   </Button>
                 </div>
@@ -592,30 +577,30 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                 initial={{ opacity: 0, scale: 0.9, y: 20 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.9, y: 20 }}
-                className="relative w-full max-w-sm bg-[#1F2937] rounded-[32px] border border-white/10 shadow-2xl p-8 space-y-6"
+                className="relative w-full max-w-sm bg-[#101217] rounded-xl border border-white/10 shadow-2xl p-5 space-y-4"
                 onClick={e => e.stopPropagation()}
               >
                 <div className="flex items-center gap-3">
                   <div className="w-12 h-12 rounded-2xl bg-amber-500/20 flex items-center justify-center border border-amber-500/30">
                     <AlertTriangle className="w-6 h-6 text-amber-400" />
                   </div>
-                  <h3 className="text-lg font-bold text-white">{t('workflow.snapshot.loadWarningTitle')}</h3>
+                  <h3 className="text-[14px] font-bold text-[#e9ebef]">{t('workflow.snapshot.loadWarningTitle')}</h3>
                 </div>
                 <div className="space-y-4">
                   <p className="text-xs text-white/50 leading-relaxed font-medium">{t('workflow.snapshot.loadWarningDesc')}</p>
                   <div className="bg-black/20 p-4 rounded-2xl border border-white/5">
                     <p className="text-[10px] text-white/30 uppercase tracking-widest mb-1">{t('workflow.snapshot.loadingLabel', { title: '' })}</p>
-                    <p className="text-sm font-bold text-white/90">{snapshotToLoad?.title}</p>
+                    <p className="text-[12px] font-bold text-white/90">{snapshotToLoad?.title}</p>
                   </div>
                   <div className="bg-red-500/10 p-4 rounded-2xl border border-red-500/20">
                     <p className="text-xs font-bold text-red-400">{t('workflow.snapshot.loadWarningCritical')}</p>
                   </div>
                 </div>
                 <div className="flex gap-2">
-                  <Button variant="ghost" className="flex-1 h-12 rounded-2xl text-white/40 hover:bg-white/5" onClick={() => setLoadWarningOpen(false)}>
+                  <Button variant="ghost" className="flex-1 h-9 rounded-[10px] text-[12px] text-[#8a919e] hover:bg-white/[0.05]" onClick={() => setLoadWarningOpen(false)}>
                     {t('common.cancel')}
                   </Button>
-                  <Button className="flex-1 h-12 rounded-2xl bg-blue-600 hover:bg-blue-500 text-white font-bold" onClick={handleLoadSnapshot}>
+                  <Button className="flex-1 h-9 rounded-[10px] text-[12px] bg-[#3069f0] hover:bg-[#3f78f5] text-white font-semibold" onClick={handleLoadSnapshot}>
                     {t('workflow.snapshot.loadAnyway')}
                   </Button>
                 </div>
@@ -628,21 +613,21 @@ export const WorkflowSnapshots: React.FC<WorkflowSnapshotsProps> = ({
                 initial={{ opacity: 0, scale: 0.9, y: 20 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.9, y: 20 }}
-                className="relative w-full max-w-sm bg-[#1F2937] rounded-[32px] border border-white/10 shadow-2xl p-8 space-y-6"
+                className="relative w-full max-w-sm bg-[#101217] rounded-xl border border-white/10 shadow-2xl p-5 space-y-4"
                 onClick={e => e.stopPropagation()}
               >
                 <div className="flex items-center gap-3">
                   <div className="w-12 h-12 rounded-2xl bg-red-500/20 flex items-center justify-center border border-red-500/30">
                     <Trash2 className="w-6 h-6 text-red-400" />
                   </div>
-                  <h3 className="text-lg font-bold text-white">{t('workflow.snapshot.deleteTitle')}</h3>
+                  <h3 className="text-[14px] font-bold text-[#e9ebef]">{t('workflow.snapshot.deleteTitle')}</h3>
                 </div>
                 <div className="space-y-2">
                   <p className="text-xs text-white/50 leading-relaxed">{t('workflow.snapshot.deleteDesc')}</p>
                   <p className="font-bold text-white/90 text-sm">{snapshotToDelete?.title}</p>
                 </div>
                 <div className="flex gap-2">
-                  <Button variant="ghost" className="flex-1 h-12 rounded-2xl text-white/40 hover:bg-white/5" onClick={() => setDeleteConfirmOpen(false)}>
+                  <Button variant="ghost" className="flex-1 h-9 rounded-[10px] text-[12px] text-[#8a919e] hover:bg-white/[0.05]" onClick={() => setDeleteConfirmOpen(false)}>
                     {t('common.cancel')}
                   </Button>
                   <Button className="flex-1 h-12 rounded-2xl bg-red-600 hover:bg-red-500 text-white font-bold" onClick={handleDeleteSnapshot} disabled={isDeleting}>

--- a/src/components/workflow/WorkflowUpload.tsx
+++ b/src/components/workflow/WorkflowUpload.tsx
@@ -225,10 +225,7 @@ const WorkflowUpload: React.FC = () => {
       }}
     >
       {/* Main Background with Dark Theme */}
-      <div className="absolute inset-0 bg-[#374151]" />
-
-      {/* Glassmorphism Background Overlay */}
-      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+      <div className="absolute inset-0 bg-[#0b0c0f]" />
 
       {/* Main Scrollable Content Area */}
       <div
@@ -242,7 +239,7 @@ const WorkflowUpload: React.FC = () => {
         }}
       >
         {/* Header */}
-        <header className="sticky top-0 z-50 pwa-header bg-[#1e293b] border-b border-white/10 shadow-xl relative overflow-hidden">
+        <header className="sticky top-0 z-50 pwa-header bg-[#0b0c0f]/95 backdrop-blur-xl border-b border-white/[0.08] relative overflow-hidden">
           <div className="relative z-10 p-4">
             <div className="flex items-center space-x-3">
               <Button
@@ -252,16 +249,16 @@ const WorkflowUpload: React.FC = () => {
                 }}
                 variant="ghost"
                 size="sm"
-                className="bg-white/10 backdrop-blur-sm border border-white/10 shadow-lg hover:bg-white/20 transition-all duration-300 h-9 w-9 p-0 flex-shrink-0 rounded-lg text-white"
+                className="bg-white/[0.045] border border-white/[0.08] hover:bg-white/[0.08] transition-all h-9 w-9 p-0 flex-shrink-0 rounded-[10px] text-[#c8ccd4]"
                 style={{ touchAction: 'manipulation' }}
               >
                 <ArrowLeft className="w-4 h-4" />
               </Button>
               <div>
-                <h1 className="text-lg font-bold text-white/95 leading-none">
+                <h1 className="text-[15px] font-bold text-[#e9ebef] leading-none">
                   {t('workflow.upload.title')}
                 </h1>
-                <p className="text-[11px] text-white/40 mt-1">
+                <p className="font-mono text-[9px] font-medium text-[#565d6b] tracking-[0.12em] uppercase mt-1">
                   {t('workflow.upload.subtitle')}
                 </p>
               </div>
@@ -270,21 +267,21 @@ const WorkflowUpload: React.FC = () => {
         </header>
 
         {/* Content */}
-        <div className="container mx-auto px-6 py-8 max-w-4xl">
+        <div className="container mx-auto px-4 py-5 max-w-4xl">
 
           {/* Server Requirements Check */}
           {(isCheckingExtension || !isConnected || !hasExtension) && (
-            <Card className="mb-6 border border-white/5 bg-black/20 backdrop-blur-sm shadow-xl">
+            <Card className="mb-3 border border-white/[0.08] bg-white/[0.025] shadow-none">
               <CardHeader>
                 <CardTitle className="text-white/90 flex items-center gap-2">
-                  <Server className="h-5 w-5 text-blue-400" />
+                  <Server className="h-4 w-4 text-[#5b8af5]" />
                   {t('common.serverRequirements')}
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-2.5">
                 {isCheckingExtension ? (
                   <div className="flex items-center space-x-3">
-                    <Loader2 className="h-4 w-4 animate-spin text-blue-400" />
+                    <Loader2 className="h-4 w-4 animate-spin text-[#5b8af5]" />
                     <span className="text-white/70">
                       {t('common.checkingServer')}
                     </span>
@@ -296,12 +293,12 @@ const WorkflowUpload: React.FC = () => {
                       <span className="text-white/70 font-medium">{t('common.serverConnection')}</span>
                       <div className="flex items-center gap-2">
                         {isConnected ? (
-                          <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                          <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                             <CheckCircle className="h-3 w-3 mr-1" />
                             {t('common.connected')}
                           </Badge>
                         ) : (
-                          <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                          <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                             <AlertCircle className="h-3 w-3 mr-1" />
                             {t('common.notConnected')}
                           </Badge>
@@ -314,12 +311,12 @@ const WorkflowUpload: React.FC = () => {
                       <span className="text-white/70 font-medium">{t('common.extension')}</span>
                       <div className="flex items-center gap-2">
                         {hasExtension ? (
-                          <Badge className="bg-green-500/10 text-green-400 border-green-500/20">
+                          <Badge className="bg-[#34c77b]/10 text-[#4ade80] border-[#34c77b]/20">
                             <CheckCircle className="h-3 w-3 mr-1" />
                             {t('common.available')}
                           </Badge>
                         ) : (
-                          <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
+                          <Badge variant="destructive" className="bg-[#f25555]/20 text-[#f87c7c] border-[#f25555]/30">
                             <AlertCircle className="h-3 w-3 mr-1" />
                             {t('common.notFound')}
                           </Badge>
@@ -331,25 +328,25 @@ const WorkflowUpload: React.FC = () => {
                     {(!isConnected || !hasExtension) && (
                       <div className="space-y-2">
                         {!serverUrl && (
-                          <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-                            <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-                            <span className="text-red-400 text-sm">
+                          <div className="p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+                            <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+                            <span className="text-[#f87c7c] text-[12px]">
                               {t('workflow.import.noServerUrl')}
                             </span>
                           </div>
                         )}
                         {!isConnected && serverUrl && (
-                          <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-                            <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-                            <span className="text-red-400 text-sm">
+                          <div className="p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+                            <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+                            <span className="text-[#f87c7c] text-[12px]">
                               {t('workflow.import.notConnected')}
                             </span>
                           </div>
                         )}
                         {isConnected && !hasExtension && (
-                          <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-                            <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-                            <span className="text-red-400 text-sm">
+                          <div className="p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+                            <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+                            <span className="text-[#f87c7c] text-[12px]">
                               {t('workflow.import.extensionNotFound')}
                             </span>
                           </div>
@@ -397,9 +394,9 @@ const WorkflowUpload: React.FC = () => {
 
           {/* Error Display */}
           {error && (
-            <div className="mb-6 p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-2">
-              <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
-              <span className="text-red-400 text-sm">
+            <div className="mb-3 p-3 bg-[#f25555]/10 border border-[#f25555]/20 rounded-lg flex items-start gap-2">
+              <AlertCircle className="h-4 w-4 text-[#f87c7c] flex-shrink-0 mt-0.5" />
+              <span className="text-[#f87c7c] text-[12px]">
                 {error}
               </span>
             </div>
@@ -409,7 +406,7 @@ const WorkflowUpload: React.FC = () => {
           {isLoading && (
             <div className="flex items-center justify-center min-h-[200px]">
               <div className="text-center">
-                <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-indigo-400" />
+                <Loader2 className="h-10 w-12 animate-spin mx-auto mb-4 text-[#5b8af5]" />
                 <p className="text-white/70">{t('workflow.upload.loadingLocal')}</p>
               </div>
             </div>
@@ -417,9 +414,9 @@ const WorkflowUpload: React.FC = () => {
 
           {/* Local Workflows List */}
           {!isLoading && (
-            <div className="space-y-4">
+            <div className="space-y-2.5">
               {/* Search Bar and Count */}
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-white/40" />
                   <input
@@ -427,7 +424,7 @@ const WorkflowUpload: React.FC = () => {
                     placeholder={t('common.searchWorkflows')}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="w-full pl-9 pr-9 py-2 bg-black/20 border border-white/10 rounded-xl text-white/90 placeholder:text-white/20 focus:outline-none focus:ring-1 focus:ring-white/20 transition-all text-sm h-10"
+                    className="w-full pl-9 pr-9 bg-white/[0.045] border border-white/[0.08] rounded-[10px] text-[#e9ebef] placeholder:text-[#71798a] focus:outline-none focus:border-[#3069f0]/50 transition-all text-[12.5px] h-[42px]"
                   />
                   {searchQuery && (
                     <button
@@ -438,10 +435,11 @@ const WorkflowUpload: React.FC = () => {
                     </button>
                   )}
                 </div>
-                <div className="flex items-center justify-between px-1">
-                  <h2 className="text-sm font-medium text-white/70">
+                <div className="flex items-center gap-2 px-0.5">
+                  <h2 className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] uppercase whitespace-nowrap">
                     {searchQuery ? t('workflow.upload.foundCount', { count: filteredWorkflows.length }) : t('workflow.upload.localWorkflows', { count: localWorkflows.length })}
                   </h2>
+                  <div className="flex-1 h-px bg-white/[0.06]" />
                   <Button
                     variant="ghost"
                     size="sm"
@@ -459,60 +457,52 @@ const WorkflowUpload: React.FC = () => {
               {filteredWorkflows.length === 0 ? (
                 <Card className="bg-black/20 border-white/5">
                   <CardContent className="py-12 text-center">
-                    <Upload className="h-12 w-12 mx-auto mb-4 text-white/20" />
+                    <Upload className="h-10 w-12 mx-auto mb-4 text-white/20" />
                     <p className="text-white/60">
                       {searchQuery ? t('workflow.upload.noResultsQuery') : t('workflow.upload.noWorkflowsAvailable')}
                     </p>
-                    <p className="text-white/30 text-sm mt-2">
+                    <p className="text-white/30 text-[12px] mt-2">
                       {searchQuery ? t('workflow.upload.tryDifferent') : t('workflow.upload.createFirst')}
                     </p>
                   </CardContent>
                 </Card>
               ) : (
-                <div className="grid gap-2">
+                <div className="grid grid-cols-[minmax(0,1fr)] gap-2">
                   {filteredWorkflows.map((workflow, index) => (
                     <div
                       key={workflow.id}
-                      className="transition-all duration-300 ease-in-out"
+                      className="min-w-0 transition-all duration-300 ease-in-out"
                     >
-                      <Card className={`border border-white/5 bg-black/20 backdrop-blur-sm hover:bg-white/5 transition-all group ${isUploading === workflow.id ? 'opacity-70 pointer-events-none' : ''
+                      <Card className={`border border-white/5 bg-white/[0.025] hover:bg-white/5 transition-all group ${isUploading === workflow.id ? 'opacity-70 pointer-events-none' : ''
                         }`}>
-                        <CardContent className="p-3">
+                        <CardContent className="px-3 py-3">
                           <div className="flex gap-3 items-center w-full">
                             <div className="flex-1 min-w-0">
-                              <h3 className="font-medium text-white/95 mb-1 break-all text-sm leading-tight">
+                              <h3 className="text-[13px] font-semibold text-[#e9ebef] leading-[1.35] line-clamp-1 break-all">
                                 {workflow.name || t('workflow.newWorkflowName')}
                               </h3>
-                              <div className="flex flex-wrap items-center gap-1.5 text-xs text-white/40 font-mono">
-                                <Badge variant="outline" className="bg-white/5 border-white/5 text-white/40 text-[10px] h-4 px-1.5 min-h-[16px] flex items-center">
-                                  {formatFileSize(workflow.workflow_json)}
-                                </Badge>
-                                <span className="truncate text-[10px]">
-                                  {formatDate(workflow.modifiedAt || new Date())}
-                                </span>
-                                <span className="text-blue-400 bg-blue-500/10 px-1.5 py-0.5 rounded ml-1 text-[10px] h-4 flex items-center">
-                                  {(workflow.workflow_json && typeof workflow.workflow_json === 'object' && 'nodes' in workflow.workflow_json && Array.isArray(workflow.workflow_json.nodes) ? workflow.workflow_json.nodes.length : 0)} NODES
-                                </span>
+                              <div className="flex items-center gap-1.5 mt-1 font-mono text-[10px] text-[#565d6b] whitespace-nowrap">
+                                <span>{formatDate(workflow.modifiedAt || new Date())}</span>
+                                <span className="text-[#31363f]">·</span>
+                                <span>{formatFileSize(workflow.workflow_json)}</span>
+                                <span className="text-[#31363f]">·</span>
+                                <span className="text-[#5b8af5]">{(workflow.workflow_json && typeof workflow.workflow_json === 'object' && 'nodes' in workflow.workflow_json && Array.isArray(workflow.workflow_json.nodes) ? workflow.workflow_json.nodes.length : 0)}N</span>
                               </div>
                             </div>
 
-                            <Button
+                            <button
                               onClick={() => uploadWorkflow(workflow)}
                               disabled={isUploading === workflow.id || !isConnected || !hasExtension}
-                              size="sm"
-                              className="bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 text-white disabled:opacity-70 whitespace-nowrap flex-shrink-0 touch-manipulation min-h-[32px] h-8 px-3 rounded-lg shadow-lg hover:shadow-indigo-500/20 transition-all"
-                              style={{ touchAction: 'manipulation' }}
+                              className="h-8 px-[13px] flex items-center gap-1.5 rounded-lg border text-[11.5px] font-semibold whitespace-nowrap flex-shrink-0 transition-colors disabled:opacity-60"
+                              style={{ background: 'rgba(61,123,253,0.12)', borderColor: 'rgba(61,123,253,0.3)', color: '#7ba3f5', touchAction: 'manipulation' }}
                             >
                               {isUploading === workflow.id ? (
-                                <>
-                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                </>
+                                <Loader2 className="h-3 w-3 animate-spin" />
                               ) : (
-                                <>
-                                  <Upload className="h-4 w-4" />
-                                </>
+                                <Upload className="h-3 w-3" strokeWidth={1.9} />
                               )}
-                            </Button>
+                              {t('menu.upload')}
+                            </button>
                           </div>
                         </CardContent>
                       </Card>
@@ -528,17 +518,17 @@ const WorkflowUpload: React.FC = () => {
       {/* Override Confirmation Dialog */}
       {overrideDialog.isOpen && (
         <div className="fixed inset-0 pwa-modal z-[65] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-          <div className="relative max-w-md w-full bg-white/20 dark:bg-slate-800/20 backdrop-blur-xl rounded-3xl shadow-2xl border border-white/20 dark:border-slate-600/20 flex flex-col overflow-hidden">
+          <div className="relative max-w-[320px] w-full bg-[#101217] rounded-xl shadow-2xl border border-white/10 flex flex-col overflow-hidden">
             {/* Gradient Overlay for Enhanced Glass Effect */}
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-slate-900/10 pointer-events-none" />
+            <div className="absolute inset-0 bg-transparent pointer-events-none" />
 
             {/* Dialog Header */}
-            <div className="relative flex items-center justify-between p-4 border-b border-white/10 dark:border-slate-600/10 flex-shrink-0">
+            <div className="relative flex items-center justify-between p-4 border-b border-white/10 dark:border-white/[0.1]/10 flex-shrink-0">
               <div className="flex items-center space-x-2">
                 <div className="w-6 h-6 bg-yellow-500/20 backdrop-blur-sm rounded-full flex items-center justify-center border border-yellow-400/30">
                   <AlertCircle className="w-4 h-4 text-yellow-300" />
                 </div>
-                <h3 className="text-lg font-semibold text-white">
+                <h3 className="text-[14px] font-semibold text-white">
                   {t('workflow.upload.existsTitle')}
                 </h3>
               </div>
@@ -549,13 +539,13 @@ const WorkflowUpload: React.FC = () => {
               <p className="text-white/90 mb-4">
                 {t('workflow.upload.existsDesc', { name: overrideDialog.filename })}
               </p>
-              <p className="text-white/70 text-sm mb-4">
+              <p className="text-white/70 text-[12px] mb-4">
                 {t('workflow.upload.existsPrompt')}
               </p>
             </div>
 
             {/* Dialog Footer */}
-            <div className="relative flex justify-end gap-2 p-4 border-t border-white/10 dark:border-slate-600/10 flex-shrink-0">
+            <div className="relative flex justify-end gap-2 p-4 border-t border-white/10 dark:border-white/[0.1]/10 flex-shrink-0">
               <Button
                 onClick={handleOverrideCancel}
                 variant="outline"
@@ -565,7 +555,7 @@ const WorkflowUpload: React.FC = () => {
               </Button>
               <Button
                 onClick={handleOverrideConfirm}
-                className="bg-red-600 hover:bg-red-700 text-white shadow-sm hover:shadow-md transition-all duration-300"
+                className="bg-[#f25555] hover:bg-[#f36d6d] text-white shadow-sm hover:shadow-md transition-all duration-300"
               >
                 {t('workflow.upload.overwrite')}
               </Button>

--- a/src/components/workflow/WorkflowUploadModal.tsx
+++ b/src/components/workflow/WorkflowUploadModal.tsx
@@ -91,47 +91,47 @@ const WorkflowUploadModal: React.FC<WorkflowUploadModalProps> = ({
                         initial={{ opacity: 0, scale: 0.95, y: 20 }}
                         animate={{ opacity: 1, scale: 1, y: 0 }}
                         exit={{ opacity: 0, scale: 0.95, y: 20 }}
-                        className="relative w-full max-w-lg bg-white dark:bg-slate-900 rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-800 overflow-hidden"
+                        className="relative w-full max-w-sm bg-[#101217] rounded-xl shadow-2xl border border-white/10 overflow-hidden"
                         onClick={(e) => e.stopPropagation()}
                     >
                         {/* Header */}
-                        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100 dark:border-slate-800">
-                            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                        <div className="flex items-center justify-between h-11 px-4 border-b border-white/[0.08]">
+                            <h2 className="text-[14px] font-bold text-[#e9ebef]">
                                 {t('workflow.uploadModal.title')}
                             </h2>
                             <button
                                 onClick={onClose}
                                 disabled={isLoading}
-                                className="p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-full transition-colors disabled:opacity-50"
+                                className="p-1.5 bg-white/[0.06] hover:bg-white/[0.1] rounded-lg border border-white/[0.08] transition-colors disabled:opacity-50"
                             >
-                                <X className="w-5 h-5 text-slate-500" />
+                                <X className="w-4 h-4 text-[#9aa3b2]" />
                             </button>
                         </div>
 
                         {/* Content */}
-                        <div className="p-6">
+                        <div className="p-4">
                             <div
-                                className={`relative w-full aspect-[4/3] rounded-xl border-2 border-dashed transition-all duration-200 flex flex-col items-center justify-center gap-4 ${isDragging
-                                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
-                                    : 'border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 bg-slate-50/50 dark:bg-slate-900/50'
+                                className={`relative w-full aspect-[16/9] rounded-[10px] border border-dashed transition-all duration-200 flex flex-col items-center justify-center gap-2.5 ${isDragging
+                                    ? 'border-[#3069f0]/60 bg-[#3069f0]/[0.08]'
+                                    : 'border-white/[0.13] hover:border-white/25 bg-white/[0.02]'
                                     }`}
                                 onDragOver={handleDragOver}
                                 onDragLeave={handleDragLeave}
                                 onDrop={handleDrop}
                             >
-                                <div className="p-4 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
+                                <div className="w-9 h-9 rounded-[10px] border border-[#3069f0]/30 flex items-center justify-center text-[#5b8af5]" style={{ background: 'rgba(48,105,240,0.1)' }}>
                                     {isLoading ? (
-                                        <Loader2 className="w-8 h-8 animate-spin" />
+                                        <Loader2 className="w-4 h-4 animate-spin" />
                                     ) : (
-                                        <Upload className="w-8 h-8" />
+                                        <Upload className="w-4 h-4" strokeWidth={1.8} />
                                     )}
                                 </div>
 
                                 <div className="text-center space-y-1">
-                                    <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                                    <p className="text-[12px] font-semibold text-[#e9ebef]">
                                         {isLoading ? t('common.processing') : t('workflow.uploadModal.dragDrop')}
                                     </p>
-                                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                                    <p className="font-mono text-[9.5px] text-[#565d6b] uppercase tracking-[0.08em]">
                                         {t('workflow.uploadModal.supportedExt')}
                                     </p>
                                 </div>
@@ -149,20 +149,20 @@ const WorkflowUploadModal: React.FC<WorkflowUploadModalProps> = ({
                                     onClick={() => fileInputRef.current?.click()}
                                     disabled={isLoading}
                                     variant="outline"
-                                    className="mt-2"
+                                    className="mt-1 h-8 px-3 rounded-lg text-[11.5px] bg-white/[0.05] border-white/[0.08] text-[#c8ccd4] hover:bg-white/[0.08]"
                                 >
                                     {t('common.selectFile')}
                                 </Button>
                             </div>
 
                             {/* Info Alert */}
-                            <div className="mt-6 p-4 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 flex gap-3">
-                                <AlertCircle className="w-5 h-5 text-slate-400 flex-shrink-0" />
+                            <div className="mt-3 p-2.5 rounded-[10px] bg-white/[0.03] border border-white/[0.07] flex gap-2">
+                                <AlertCircle className="w-3.5 h-3.5 text-[#565d6b] flex-shrink-0 mt-0.5" strokeWidth={1.8} />
                                 <div className="space-y-1">
-                                    <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                                    <p className="text-[11.5px] font-semibold text-[#c8ccd4]">
                                         {t('workflow.uploadModal.formatsTitle')}
                                     </p>
-                                    <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+                                    <p className="text-[10.5px] text-[#66758a] leading-relaxed">
                                         {t('workflow.uploadModal.formatsDesc')}
                                     </p>
                                 </div>
@@ -170,13 +170,13 @@ const WorkflowUploadModal: React.FC<WorkflowUploadModalProps> = ({
                         </div>
 
                         {/* Create New Option */}
-                        <div className="px-6 pb-6">
+                        <div className="px-4 pb-4">
                             <div className="relative">
                                 <div className="absolute inset-0 flex items-center">
-                                    <span className="w-full border-t border-slate-200 dark:border-slate-800" />
+                                    <span className="w-full border-t border-white/[0.07]" />
                                 </div>
-                                <div className="relative flex justify-center text-xs uppercase">
-                                    <span className="bg-white dark:bg-slate-900 px-2 text-slate-500 dark:text-slate-400">
+                                <div className="relative flex justify-center">
+                                    <span className="bg-[#101217] px-2 font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[#565d6b]">
                                         {t('common.or')}
                                     </span>
                                 </div>
@@ -189,7 +189,7 @@ const WorkflowUploadModal: React.FC<WorkflowUploadModalProps> = ({
                                 }}
                                 disabled={isLoading}
                                 variant="outline"
-                                className="w-full mt-4 h-12 border-dashed border-2 hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 dark:hover:border-blue-500/50 transition-all"
+                                className="w-full mt-3 h-9 rounded-[10px] text-[12px] border-dashed border border-white/[0.13] text-[#8a919e] bg-transparent hover:border-[#3069f0]/50 hover:text-[#5b8af5] hover:bg-transparent transition-all"
                             >
                                 <Plus className="w-4 h-4 mr-2" />
                                 {t('workflow.uploadModal.createNew')}

--- a/src/config/canvasConfig.ts
+++ b/src/config/canvasConfig.ts
@@ -35,8 +35,8 @@ export const DEFAULT_CANVAS_CONFIG: CanvasConfig = {
   // Layout (increased padding)
   padding: 20,
   
-  // Colors - Dark mode only
-  backgroundColor: '#0f172a',
+  // Colors - Dark mode only (design-system page background)
+  backgroundColor: '#0b0c0f',
   defaultNodeColor: '#374151', // Dark gray for nodes without specific colors
   linkColor: '#64748b',
   textColor: '#f1f5f9',

--- a/src/config/canvasConfig.ts
+++ b/src/config/canvasConfig.ts
@@ -37,10 +37,10 @@ export const DEFAULT_CANVAS_CONFIG: CanvasConfig = {
   
   // Colors - Dark mode only (design-system page background)
   backgroundColor: '#0b0c0f',
-  defaultNodeColor: '#374151', // Dark gray for nodes without specific colors
-  linkColor: '#64748b',
+  defaultNodeColor: '#1c212c', // Elevated node surface (design system, lifted for canvas contrast)
+  linkColor: '#566070',
   textColor: '#f1f5f9',
-  selectedNodeColor: '#6366f1',
+  selectedNodeColor: '#3069f0',
   
   // Group colors
   groupColor: '#1e293b',

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -276,7 +276,7 @@ export const useCanvasRenderer = ({
     const draw = () => {
       // Clear canvas - use darker background color in repositioning mode
       const backgroundColor = repositionMode?.isActive
-        ? '#1e293b' // Darker slate background for repositioning mode
+        ? '#14171e' // Elevated surface tone for repositioning mode
         : config.backgroundColor;
 
       ctx.fillStyle = backgroundColor;

--- a/src/index.css
+++ b/src/index.css
@@ -85,39 +85,40 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-/* Dark theme variables */
+/* Dark theme variables — "tool aesthetic" design system (dark only) */
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.16 0.006 260);        /* #0b0c0f page bg */
+  --foreground: oklch(0.925 0.006 255);       /* #e9ebef body/title */
+  --card: oklch(0.19 0.008 258);              /* #101217 opaque card */
+  --card-foreground: oklch(0.925 0.006 255);
+  --popover: oklch(0.205 0.008 258);          /* #14171e elevated surface */
+  --popover-foreground: oklch(0.925 0.006 255);
+  --primary: oklch(0.55 0.19 262);            /* #3069f0 blue accent */
+  --primary-foreground: oklch(0.99 0 0);      /* white on blue */
+  --primary-hover: oklch(0.6 0.17 262);       /* #5b8af5 */
+  --secondary: oklch(0.235 0.006 260);        /* subtle raised */
+  --secondary-foreground: oklch(0.86 0.01 255);
+  --muted: oklch(0.235 0.006 260);
+  --muted-foreground: oklch(0.62 0.015 255);  /* #8a919e */
+  --accent: oklch(0.25 0.006 260);            /* hover */
+  --accent-foreground: oklch(0.925 0.006 255);
+  --destructive: oklch(0.62 0.19 25);         /* #f25555 */
+  --border: oklch(1 0 0 / 8%);                /* hairline */
+  --input: oklch(1 0 0 / 10%);
+  --ring: oklch(0.55 0.19 262 / 55%);         /* blue focus */
+  --chart-1: oklch(0.55 0.19 262);
+  --chart-2: oklch(0.7 0.13 165);
+  --chart-3: oklch(0.75 0.15 75);
+  --chart-4: oklch(0.62 0.2 305);
+  --chart-5: oklch(0.62 0.19 25);
+  --sidebar: oklch(0.19 0.008 258);
+  --sidebar-foreground: oklch(0.925 0.006 255);
+  --sidebar-primary: oklch(0.55 0.19 262);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.25 0.006 260);
+  --sidebar-accent-foreground: oklch(0.925 0.006 255);
+  --sidebar-border: oklch(1 0 0 / 8%);
+  --sidebar-ring: oklch(0.55 0.19 262 / 55%);
 }
 
 /* Tailwind base styles */
@@ -129,6 +130,7 @@
   html,
   body {
     @apply bg-background text-foreground;
+    font-family: 'Pretendard Variable', Pretendard, -apple-system, system-ui, sans-serif;
     height: 100%;
     width: 100%;
     overflow: hidden;
@@ -210,6 +212,15 @@ canvas {
 }
 
 
+
+/* Hide scrollbars on horizontal scroll rows (breadcrumbs, folder strip, etc.) */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
 
 /* Mask Gradients for Breadcrumbs */
 .mask-gradient-right {

--- a/src/locale/en/common.json
+++ b/src/locale/en/common.json
@@ -230,7 +230,8 @@
             "existsTitle": "Workflow Already Exists",
             "existsDesc": "A workflow named {{name}} already exists in your local collection.",
             "existsPrompt": "Do you want to import anyway and create a renamed copy?",
-            "importAnyway": "Import Anyway"
+            "importAnyway": "Import Anyway",
+            "importButton": "Import"
         },
         "snapshot": {
             "title": "Workflow Snapshots",

--- a/src/locale/ja/common.json
+++ b/src/locale/ja/common.json
@@ -228,7 +228,8 @@
             "existsTitle": "ワークフローは既に存在します",
             "existsDesc": "{{name}} という名前のワークフローは既にローカルコレクションに存在します。",
             "existsPrompt": "名前を変更して複製を作成し、インポートしますか？",
-            "importAnyway": "とにかくインポート"
+            "importAnyway": "とにかくインポート",
+            "importButton": "インポート"
         },
         "snapshot": {
             "title": "ワークフロースナップショット",

--- a/src/locale/ko/common.json
+++ b/src/locale/ko/common.json
@@ -230,7 +230,8 @@
             "existsTitle": "워크플로우가 이미 존재함",
             "existsDesc": "{{name}}라는 워크플로우가 이미 로컬 컬렉션에 존재합니다.",
             "existsPrompt": "그래도 가져와서 이름을 변경하여 사본을 만드시겠습니까?",
-            "importAnyway": "그래도 가져오기"
+            "importAnyway": "그래도 가져오기",
+            "importButton": "가져오기"
         },
         "snapshot": {
             "title": "워크플로우 스냅샷",

--- a/src/locale/zh/common.json
+++ b/src/locale/zh/common.json
@@ -229,7 +229,8 @@
             "existsTitle": "工作流已存在",
             "existsDesc": "名为 {{name}} 的工作流已存在于您的本地集合中。",
             "existsPrompt": "是否仍要导入并创建重命名的副本？",
-            "importAnyway": "仍要导入"
+            "importAnyway": "仍要导入",
+            "importButton": "导入"
         },
         "snapshot": {
             "title": "工作流快照",

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -656,18 +656,18 @@ function drawVirtualNodeBracket(
 
   // Set stroke style based on state
   if (isError) {
-    ctx.strokeStyle = '#ef4444';
+    ctx.strokeStyle = '#f25555';
     ctx.lineWidth = 4;
   } else if (isExecuting) {
-    ctx.strokeStyle = '#10b981';
+    ctx.strokeStyle = '#34c77b';
     ctx.lineWidth = 4;
     // Add glow for executing state
-    ctx.shadowColor = '#10b981';
+    ctx.shadowColor = '#34c77b';
     ctx.shadowBlur = 10;
   } else if (isSelected) {
-    ctx.strokeStyle = '#3b82f6';
+    ctx.strokeStyle = '#5b8af5';
     ctx.lineWidth = 4;
-    ctx.shadowColor = '#3b82f6';
+    ctx.shadowColor = '#5b8af5';
     ctx.shadowBlur = 8;
   } else {
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
@@ -946,34 +946,34 @@ export function renderNodes(
 
     // Inactive nodes get special colors
     if (isMuted) {
-      backgroundColor = '#3b82f6'; // Blue color for muted nodes
+      backgroundColor = '#3069f0'; // Blue color for muted nodes
     } else if (isBypassed) {
-      backgroundColor = '#9333ea'; // Purple color for bypassed nodes
+      backgroundColor = '#8b7ae8'; // Violet for bypassed nodes
     } else if (isExecuting) {
       // Executing nodes get green background color
-      backgroundColor = '#10b981'; // Green background for executing nodes
+      backgroundColor = '#34c77b'; // Green background for executing nodes
     } else {
       if (node.bgcolor) {
         backgroundColor = node.bgcolor;
       } else {
-        backgroundColor = '#374151';
+        backgroundColor = '#1c212c';
       }
 
       // Simple state modifications without complex color enhancement
       if (isSelected) {
         backgroundColor = config.selectedNodeColor;
       } else if (isConnectionSourceSelected) {
-        backgroundColor = '#1e40af'; // Blue background for selected source node
+        backgroundColor = '#2a56c2'; // Blue background for selected source node
       } else if (isConnectionTargetSelected) {
-        backgroundColor = '#dc2626'; // Red background for selected target node
+        backgroundColor = '#c74848'; // Red background for selected target node
       } else if (isConnectionCompatible) {
-        backgroundColor = '#22c55e'; // Light green for compatible target nodes
+        backgroundColor = '#2ea56a'; // Light green for compatible target nodes
       } else if (isCollapsed) {
         backgroundColor = darkenColor(backgroundColor, 0.15); // Simple darkening for collapsed
       }
     }
 
-    const cornerRadius = 4;
+    const cornerRadius = 8;
     const isVirtualNode = node.type === 'GraphInput' || node.type === 'GraphOutput';
 
     // Calculate scaling and font sizes early for all nodes
@@ -1028,7 +1028,7 @@ export function renderNodes(
 
         // Create horizontal gradient for progress
         const gradient = ctx.createLinearGradient(bounds.x, bounds.y, bounds.x + bounds.width, bounds.y);
-        const baseGreen = '#10b981';    // Base green for executing nodes
+        const baseGreen = '#34c77b';    // Base green for executing nodes
         const lighterGreen = darkenColor(baseGreen, -0.3); // Lighter version of same color (negative = brighter)
 
         // Add gradient stops based on progress
@@ -1078,7 +1078,7 @@ export function renderNodes(
         ctx.beginPath();
         ctx.moveTo(bounds.x, bounds.y + titleHeight);
         ctx.lineTo(bounds.x + bounds.width, bounds.y + titleHeight);
-        ctx.strokeStyle = 'rgba(0, 0, 0, 0.2)';
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
         ctx.lineWidth = 1;
         ctx.stroke();
       }
@@ -1086,7 +1086,7 @@ export function renderNodes(
 
     // Always draw subtle white outline for all nodes (Skip for virtual nodes as they have their own bracket line)
     if (!isVirtualNode) {
-      ctx.strokeStyle = 'rgba(255, 255, 255, 0.2)'; // 20% opacity white
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.09)'; // hairline outline
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.roundRect(bounds.x, bounds.y, bounds.width, bounds.height, cornerRadius);
@@ -1099,25 +1099,25 @@ export function renderNodes(
         let lineWidth = 2;
 
         if (isMissingNodeType) {
-          strokeColor = '#dc2626'; // Red border for missing node types
+          strokeColor = '#f25555'; // Red border for missing node types
           lineWidth = 3;
         } else if (isError) {
-          strokeColor = '#ef4444'; // Simple red for errors
+          strokeColor = '#f25555'; // Simple red for errors
           lineWidth = 2;
         } else if (hasModifications) {
-          strokeColor = '#10b981'; // Simple green for nodes with temporary changes
+          strokeColor = '#34c77b'; // Simple green for nodes with temporary changes
           lineWidth = 6;
         } else if (isRepositionSelected) {
-          strokeColor = '#3b82f6'; // Blue for repositioning selection
+          strokeColor = '#5b8af5'; // Blue for repositioning selection
           lineWidth = 3;
         } else if (isConnectionSourceSelected) {
-          strokeColor = '#3b82f6'; // Bright blue border for source node
+          strokeColor = '#5b8af5'; // Bright blue border for source node
           lineWidth = 4;
         } else if (isConnectionTargetSelected) {
-          strokeColor = '#ef4444'; // Bright red border for target node
+          strokeColor = '#f25555'; // Bright red border for target node
           lineWidth = 4;
         } else if (isConnectionCompatible) {
-          strokeColor = '#16a34a'; // Green border for compatible nodes
+          strokeColor = '#34c77b'; // Green border for compatible nodes
           lineWidth = 3;
         }
 

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -1836,15 +1836,15 @@ export function drawGridPattern(
   canvasHeight: number,
   viewport: ViewportTransform
 ): void {
-  const gridSize = 20; // Base grid size in pixels
-  const dotSize = 1.5; // Size of grid dots
+  const gridSize = 22; // Base grid size in pixels (design-spec dot grid)
+  const dotSize = 1; // Size of grid dots
 
   // Calculate grid offset based on viewport position
   const offsetX = viewport.x % (gridSize * viewport.scale);
   const offsetY = viewport.y % (gridSize * viewport.scale);
 
   // Grid color (subtle dots)
-  ctx.fillStyle = 'rgba(100, 116, 139, 0.3)'; // Slightly visible dots
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.06)'; // Hairline white dots
 
   // Draw grid dots
   const scaledGridSize = gridSize * viewport.scale;


### PR DESCRIPTION
Applies the confirmed **"tool aesthetic"** design system (from the Claude Design project) across the app — dark-only, hairline borders, squared radii, monospace meta labels, a single blue accent (`#3069f0`). Visual/organization only; no behavior changes.

## Foundation
- `.dark` tokens replaced (bg `#0b0c0f`, card `#101217`, hairline `white/8%`, primary `#3069f0`, destructive `#f25555`, blue focus ring). Pretendard Variable body font, `scrollbar-hide` utility. Base `Card`/`Progress` components restyled so every screen using them inherits the language.
- Mobile canvas repainted to the palette (node surface `#1c212c`, radius 8, hairline outlines, blue/green/violet states) with **geometry and LOD untouched**; background + white hairline dot grid to match.

## Screens
- **Home (1d):** 52px tool header (app tile + mono server chip), search + New Workflow row, mono `FOLDERS`/`WORKFLOWS · N` labels with hairline rules, compact folder tiles + dashed add tile, thumbnail cards with mono `date · Nnodes` meta, floating glass selection bar, fixed section header with only the grid scrolling.
- **Gallery (4a/4b):** 36px glass tiles, 19px title + mono sublabel, INPUT/OUTPUT/TEMP glass segment control, square selection checks with blue wash, floating move/delete bar.
- **Editor chrome (3a/3c):** 56px glass header with mono `graph view · N` sublabel and **green save tile**, thin blue progress bar with mono status line, glass right rail (30px buttons, blue active tint, 7px alert dots), execute action bar.

## Editor children (unified scale + tokens)
- Rail child panels (settings dropdown, node search, console, history — queue rows compressed to ~4 visible).
- Node/group detail modals, Fast Group Moder, trigger words, JSON/Object Info viewer, snapshots, missing-node/model modals, node-add, file preview, and the widget value editor + widget subtree.
- Confirm dialogs (`SimpleConfirmDialog`, bulk-delete, per-item delete) unified compact.
- Reposition + connection bars as single-row floating glass bars (translucent connection slot rings so colored nodes show through); circular long-press menu scaled to 75%; canvas mode toggles as glass segments.
- Workflow + official-canvas loading/error screens restyled.

## Side menu + sub-pages
- Chains and node patches moved into a collapsible **OLD** section above Language.
- Server settings/reboot, workflow import/upload, model download/browser, video downloader, data backup, app-update pages moved onto the dark palette: page backgrounds corrected from grey `#374151` → `#0b0c0f`, gradients removed, mono field labels, tinted action buttons.

## Fixes
- Upload/import list rows no longer overflow horizontally (grid track `minmax(0,1fr)` + `min-w-0`).
- `workflow.import.importButton` label added (en/ko/ja/zh).

## Notes / follow-ups
- Design **language** (surface/scale/color) is applied app-wide, but a few side-menu sub-pages still keep their old **structure** (sticky header + `Card` wrapper) rather than the mockups' single-scroll layout — page-by-page structural rebuilds are deferred.
- Pretendard is loaded via CDN (falls back to system-ui); bundling is a possible follow-up.
- `tsc --noEmit` clean. Verified on device for home, editor chrome, and the main modals; not every sub-page was walked through in-browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 앱 전반의 다크 테마, 색상 팔레트, 폰트와 간격이 새 디자인으로 통일되었습니다.
  * 캔버스, 노드, 연결 메뉴와 각종 패널·모달이 더욱 컴팩트하고 일관된 형태로 개선되었습니다.
  * 미디어 미리보기, 파일 갤러리, 모델·워크플로 화면의 카드와 버튼 디자인이 обнов되었습니다.
* **사용성 개선**
  * 로딩 표시와 실행 진행 상태가 간결한 오버레이 및 진행 바 형태로 변경되었습니다.
  * 검색 결과와 폴더·파일 선택 화면의 정보 표시가 정돈되었습니다.
* **번역**
  * 워크플로 가져오기 버튼 문구가 지원 언어에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->