### PR TITLE
fix(official-canvas): DPR-safe fit-view on load + Official β label

### DIFF
--- a/comfy-mobile-ui-api-extension/fe/mobileBridge.js
+++ b/comfy-mobile-ui-api-extension/fe/mobileBridge.js
@@ -301,12 +301,64 @@ async function applySetting({ id, value }) {
   }
 }
 
-function fitView() {
-  try {
+// Fit all nodes into view. We do the math ourselves instead of the official
+// "Canvas.FitView" command: in this iframe embed that command double-applies
+// devicePixelRatio, so on a DPR-3 phone it zooms out ~3x (nodes tiny, pushed
+// to a corner). Working in CSS pixels against ds.scale/offset is DPR-safe —
+// the canvas transform is ctx.scale(dpr) · ds.scale · (p + ds.offset), so the
+// dpr factor cancels out of both the scale and the centering below.
+function fitViewOnce() {
+  const canvas = app.canvas;
+  const graph = app.graph;
+  const el = canvas?.canvas;
+  const nodes = graph?._nodes;
+  if (!canvas?.ds || !el || !nodes || !nodes.length) {
+    // Fallback for unexpected shapes (empty graph, missing ds, ...).
     app.extensionManager?.command?.execute?.("Canvas.FitView");
-  } catch (e) {
-    console.warn("[MobileBridge] fit view failed", e);
+    return;
   }
+
+  const TITLE = (window.LiteGraph && window.LiteGraph.NODE_TITLE_HEIGHT) || 30;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const n of nodes) {
+    if (!n.pos || !n.size) continue;
+    const w = n.flags?.collapsed ? (n._collapsed_width || 80) : n.size[0];
+    const h = n.flags?.collapsed ? 0 : n.size[1];
+    const x = n.pos[0];
+    const y = n.pos[1] - TITLE;
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x + w > maxX) maxX = x + w;
+    if (y + TITLE + h > maxY) maxY = y + TITLE + h;
+  }
+  if (!isFinite(minX)) {
+    app.extensionManager?.command?.execute?.("Canvas.FitView");
+    return;
+  }
+
+  const bw = Math.max(1, maxX - minX);
+  const bh = Math.max(1, maxY - minY);
+  const vw = el.clientWidth || el.width || 1;
+  const vh = el.clientHeight || el.height || 1;
+  const margin = 0.88; // breathing room around the graph
+  let scale = Math.min(vw / bw, vh / bh) * margin;
+  scale = Math.max(0.1, Math.min(scale, 1.4)); // don't over-zoom tiny graphs
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+
+  canvas.ds.scale = scale;
+  canvas.ds.offset = [vw / (2 * scale) - cx, vh / (2 * scale) - cy];
+  canvas.setDirty?.(true, true);
+}
+
+function fitView() {
+  const doFit = () => {
+    try { fitViewOnce(); } catch (e) { console.warn("[MobileBridge] fit view failed", e); }
+  };
+  // The canvas keeps resizing for a few frames after the embed becomes visible,
+  // so run once now and once after it settles.
+  requestAnimationFrame(doFit);
+  setTimeout(doFit, 250);
 }
 
 // Hide the desktop chrome so only the litegraph canvas remains visible.

--- a/src/components/canvas-v2/CanvasHost.tsx
+++ b/src/components/canvas-v2/CanvasHost.tsx
@@ -78,6 +78,11 @@ export const CanvasHost: React.FC<CanvasHostProps> = ({
     if (loadedKeyRef.current === workflowKey) return;
     loadedKeyRef.current = workflowKey;
     clientRef.current?.loadWorkflow(workflowJson);
+    // The bridge already fits after loadGraphData, but the iframe canvas may
+    // not have its final dimensions yet on first show. Re-fit once the layout
+    // has settled so the workflow always lands centered.
+    const fitTimer = setTimeout(() => clientRef.current?.fitView(), 350);
+    return () => clearTimeout(fitTimer);
   }, [isReady, workflowJson, workflowKey]);
 
   return (

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -3638,7 +3638,7 @@ const WorkflowEditor: React.FC = () => {
           )}
           title="Switch to the official canvas (beta)"
         >
-          Official β
+          Official <span className="normal-case">β</span>
         </button>
       </div>
 


### PR DESCRIPTION
Fixes the official (β) canvas so a workflow lands correctly framed on load, plus a small label fix.

## Fit view on load

The bridge already fits after loading a workflow, but in the iframe embed the official `Canvas.FitView` command **double-applies devicePixelRatio** — on a DPR-3 phone the whole graph zoomed out ~3× (nodes tiny, shoved into a corner) instead of filling the viewport.

- `mobileBridge.js` now does the fit itself: compute the node bounding box and set `ds.scale` / `ds.offset` directly in **CSS pixels**. The canvas transform is `ctx.scale(dpr) · ds.scale · (p + offset)`, so the `dpr` factor cancels out of both the scale and the centering → correct framing on any DPR. Falls back to `Canvas.FitView` for empty/unexpected graphs.
- `CanvasHost` explicitly re-fits ~350ms after `loadWorkflow`, so the graph still centers when the iframe canvas is mid-resize on first show.

(An earlier attempt forced `app.canvas.resize()` before fitting — that corrupted the canvas backing store, so it's gone; the fix needs no forced resize.)

## Label

- Wrap the `β` in **Official β** in `normal-case` so the toggle's `uppercase` style stops rendering it as a Latin **B**.

## Notes
- `mobileBridge.js` is a served web-extension file — it takes effect on an official-canvas iframe reload (toggle Mobile ↔ Official β or refresh); no server restart needed.
- Confirmed on device: the graph now loads centered at a readable scale, and the label reads `OFFICIAL β`.
