### PR TITLE
polish(canvas): brighter canvas background + detail modals matched to node colors

### DIFF
--- a/src/components/canvas/GroupInspector.tsx
+++ b/src/components/canvas/GroupInspector.tsx
@@ -8,6 +8,7 @@ import { NodeMode } from '@/shared/types/app/base';
 import { Eye, EyeOff, Play, Square, Trash2, X, MousePointer2, VolumeX, Shuffle } from 'lucide-react';
 import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
 import { SimpleConfirmDialog } from '@/components/ui/SimpleConfirmDialog';
+import { darkenColor } from '@/shared/utils/rendering/CanvasRendererService';
 
 interface GroupInspectorProps {
   selectedNode: any;
@@ -204,15 +205,16 @@ export const GroupInspector: React.FC<GroupInspectorProps> = ({
 
           {/* Main Card */}
           <div
-            style={{ backgroundColor: '#101217' }}
+            style={{ backgroundColor: '#1c212c' }}
             className="relative w-full h-full rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col text-white"
           >
-            {/* Dynamic Sticky Header */}
+            {/* Dynamic Sticky Header - solid fill matching the canvas node title bar */}
             <div
-              className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] transition-all duration-300 ease-in-out
+              style={{ backgroundColor: darkenColor('#1c212c', 0.25) }}
+              className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b border-white/[0.06] min-h-[32px] transition-all duration-300 ease-in-out
                 ${isHeaderCompact
-                  ? 'pt-1.5 pb-[11px] pl-4 pr-[40px] bg-[#0f1116]/90 backdrop-blur-xl border-white/[0.08]'
-                  : 'pt-4 pb-3.5 pl-4 pr-12 border-transparent bg-black/20 backdrop-blur-0'
+                  ? 'pt-1.5 pb-[11px] pl-4 pr-[40px]'
+                  : 'pt-4 pb-3.5 pl-4 pr-12'
                 }`}
             >
               {/* Floating Close Button */}

--- a/src/components/canvas/NodeDetailModal.tsx
+++ b/src/components/canvas/NodeDetailModal.tsx
@@ -12,6 +12,7 @@ import {
 import { INodeWithMetadata, IProcessedParameter } from '@/shared/types/comfy/IComfyObjectInfo';
 import { ComfyGraphNode } from '@/core/domain/ComfyGraphNode';
 import { GroupInspector } from '@/components/canvas/GroupInspector';
+import { darkenColor } from '@/shared/utils/rendering/CanvasRendererService';
 import { globalWebSocketService } from '@/infrastructure/websocket/GlobalWebSocketService';
 
 import { toast } from 'sonner';
@@ -169,9 +170,13 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
     const isBypassed = currentMode === 4;
     const isAlways = currentMode === 0;
 
-    const baseColor = (selectedNode.bgcolor || selectedNode.color || (selectedNode.properties?.['Node Color'])) || '#14171e';
+    const baseColor = (selectedNode.bgcolor || selectedNode.color || (selectedNode.properties?.['Node Color'])) || '#1c212c';
     const effectiveBgColor = isMuted ? '#3b82f6' : (isBypassed ? '#9333ea' : baseColor);
     const effectiveOpacity = (isMuted || isBypassed) ? 0.5 : 1;
+    // Match the canvas node title bar exactly: a hue-preserving 25% darken of the
+    // body color (canvas draws the title as body*0.75), instead of a black/20
+    // overlay (body*0.8) which reads as a different, muddier tone than the node.
+    const headerColor = darkenColor(effectiveBgColor, 0.25);
 
     const NODE_COLORS = [
         { name: 'Brown', key: 'circularMenu.colors.brown', value: '#593930' },
@@ -991,7 +996,7 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                                                         onNodeColorChange?.(nodeId, c.value);
                                                         setShowColorPicker(false);
                                                     }}
-                                                    style={{ backgroundColor: c.value || '#14171e' }}
+                                                    style={{ backgroundColor: c.value || '#1c212c' }}
                                                     className="w-8 h-8 rounded-[7px] border border-white/20 shadow-sm active:scale-90 transition-transform flex-shrink-0"
                                                     title={t(c.key)}
                                                 />
@@ -1011,12 +1016,13 @@ export const NodeDetailModal: React.FC<NodeDetailModalProps> = ({
                         }}
                         className={`relative w-full h-full bg-[#101217] rounded-xl shadow-2xl ring-1 ring-white/10 overflow-hidden flex flex-col ${hasCustomColor ? 'text-white' : ''}`}
                     >
-                        {/* Dynamic Sticky Header - Overlay Architecture */}
+                        {/* Dynamic Sticky Header - solid fill matching the canvas node title bar */}
                         <div
-                            className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b min-h-[32px] transition-all duration-300 ease-in-out
+                            style={{ backgroundColor: headerColor }}
+                            className={`absolute top-0 left-0 w-full z-30 flex items-center justify-between border-b border-white/[0.06] min-h-[32px] transition-all duration-300 ease-in-out
                                 ${isHeaderCompact
-                                    ? `pt-1.5 pb-[11px] pl-4 pr-[40px] backdrop-blur-xl border-white/[0.08] ${hasCustomColor ? 'bg-black/30' : 'bg-[#0f1116]/90'}`
-                                    : `pt-4 pb-3.5 pl-4 pr-12 border-transparent ${hasCustomColor ? 'bg-black/20' : 'bg-transparent'} backdrop-blur-0`
+                                    ? 'pt-1.5 pb-[11px] pl-4 pr-[40px]'
+                                    : 'pt-4 pb-3.5 pl-4 pr-12'
                                 }`}
                         >
                             {/* Minimalist Floating Close Button */}

--- a/src/config/canvasConfig.ts
+++ b/src/config/canvasConfig.ts
@@ -36,7 +36,7 @@ export const DEFAULT_CANVAS_CONFIG: CanvasConfig = {
   padding: 20,
   
   // Colors - Dark mode only (design-system page background)
-  backgroundColor: '#0b0c0f',
+  backgroundColor: '#111419', // canvas fill (lifted from #0b0c0f for visibility)
   defaultNodeColor: '#1c212c', // Elevated node surface (design system, lifted for canvas contrast)
   linkColor: '#566070',
   textColor: '#f1f5f9',

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -276,7 +276,7 @@ export const useCanvasRenderer = ({
     const draw = () => {
       // Clear canvas - use darker background color in repositioning mode
       const backgroundColor = repositionMode?.isActive
-        ? '#14171e' // Elevated surface tone for repositioning mode
+        ? '#1a1f28' // Elevated surface tone for repositioning mode
         : config.backgroundColor;
 
       ctx.fillStyle = backgroundColor;

--- a/src/shared/utils/rendering/CanvasRendererService.ts
+++ b/src/shared/utils/rendering/CanvasRendererService.ts
@@ -956,7 +956,7 @@ export function renderNodes(
       if (node.bgcolor) {
         backgroundColor = node.bgcolor;
       } else {
-        backgroundColor = '#1c212c';
+        backgroundColor = config.defaultNodeColor;
       }
 
       // Simple state modifications without complex color enhancement
@@ -1844,7 +1844,7 @@ export function drawGridPattern(
   const offsetY = viewport.y % (gridSize * viewport.scale);
 
   // Grid color (subtle dots)
-  ctx.fillStyle = 'rgba(255, 255, 255, 0.06)'; // Hairline white dots
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.075)'; // Hairline white dots
 
   // Draw grid dots
   const scaledGridSize = gridSize * viewport.scale;


### PR DESCRIPTION
## What
Fine-tunes canvas readability without changing node tones, and makes the node/group detail modals share the exact same colors as the canvas node.

## Changes
- **Canvas background only** lifted for visibility: `#0b0c0f → #111419`, plus slightly brighter grid dots (`0.06 → 0.075`) and repositioning-mode fill (`#14171e → #1a1f28`).
- **Canvas nodes unchanged** — body stays the original `#1c212c`, title stays `body × 0.75` (`#151921`).
- **Renderer single source of truth** — colorless-node fallback now reads `config.defaultNodeColor` instead of a hardcoded literal.
- **Detail modals matched to the node** — `NodeDetailModal` and `GroupInspector` now paint body = node body color and header = `darkenColor(body, 0.25)`, the same hue-preserving darken the canvas uses for the title bar. This replaces the previous `bg-black/20` header overlay (which computed `body × 0.8` and read as a muddier, mismatched tone).

## Result (measured)
Canvas node and both detail modals now collapse to two matched values:

| | Body | Header/Title |
|---|---|---|
| Canvas node | `#1c212c` | `#151921` |
| Node modal | `#1c212c` | `#151921` |
| Group modal | `#1c212c` | `#151921` |

Verified by sampling canvas pixels (`getImageData`) and reading modal computed styles in-browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 다크 모드 캔버스의 기본 배경색과 노드 배경색을 조정했습니다.
  * 캔버스 그리드 점의 가시성을 높였습니다.
  * 그룹 및 노드 상세 모달의 헤더가 더 일관된 단색 배경으로 표시됩니다.
  * 모달의 컴팩트 상태에 맞춰 헤더 여백과 레이아웃이 개선되었습니다.
  * 노드 색상을 지정하지 않은 경우에도 기본 색상이 일관되게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->