### PR TITLE
Preserve and restore string widget translation sources

### DIFF
--- a/src/components/controls/widgets/StringWidget.tsx
+++ b/src/components/controls/widgets/StringWidget.tsx
@@ -4,15 +4,22 @@
  * Handles STRING type parameters with multi-line text input control
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
-import { ChevronDown, ClipboardPaste, Copy, Download, HardDrive, KeyRound, Languages, Loader2, X } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ChevronDown, ClipboardPaste, Copy, Download, HardDrive, KeyRound, Languages, Loader2, RotateCcw, Trash2, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { getAllApiKeys } from '@/infrastructure/storage/ApiKeyStorageService';
+import {
+  createTranslationDraftId,
+  deleteTranslationDraft,
+  getTranslationDraft,
+  saveTranslationDraft,
+  type TranslationDraft
+} from '@/infrastructure/storage/TranslationDraftStorageService';
 import {
   getLocalTranslationStatus,
   installLocalTranslationPairs,
@@ -42,6 +49,8 @@ const TARGET_LANGUAGES: TranslationTargetLanguage[] = [
   'EN', 'ZH-HANS', 'KO', 'JA', 'DE', 'FR', 'ES', 'IT', 'PT', 'RU'
 ];
 
+type DraftMode = 'source' | 'translated' | null;
+
 export const StringWidget: React.FC<StringWidgetProps> = ({
   param,
   editingValue,
@@ -51,18 +60,65 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const serverUrl = useConnectionStore((state) => state.url);
   const [showTranslationPanel, setShowTranslationPanel] = useState(false);
   const [isTranslating, setIsTranslating] = useState(false);
   const [isInstallingLocalPacks, setIsInstallingLocalPacks] = useState(false);
   const [localStatus, setLocalStatus] = useState<LocalTranslationStatus | null>(null);
   const [pendingRequiredPairs, setPendingRequiredPairs] = useState<string[]>([]);
+  const [translationDraft, setTranslationDraft] = useState<TranslationDraft | null>(null);
+  const [draftMode, setDraftMode] = useState<DraftMode>(null);
+  const [isDraftLoading, setIsDraftLoading] = useState(true);
   const [translationPreferences, setTranslationPreferences] = useState<TranslationPreferences>(loadTranslationPreferences);
   const [availableProviders, setAvailableProviders] = useState<Record<TranslationProvider, boolean>>({
     groq: false,
     deepl: false,
     argos: false
   });
+  const editingValueRef = useRef(editingValue);
+  const storageScope = location.pathname || 'unknown-workflow';
+  const translationDraftId = useMemo(
+    () => node ? createTranslationDraftId(storageScope, node.id, param.name) : null,
+    [node, param.name, storageScope]
+  );
+
+  useEffect(() => {
+    editingValueRef.current = editingValue;
+  }, [editingValue]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setTranslationDraft(null);
+    setDraftMode(null);
+
+    if (!translationDraftId) {
+      setIsDraftLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setIsDraftLoading(true);
+    getTranslationDraft(translationDraftId).then((draft) => {
+      if (cancelled) return;
+      setTranslationDraft(draft);
+      const currentValue = String(editingValueRef.current ?? '');
+      if (draft && currentValue === draft.sourceText) {
+        setDraftMode('source');
+      } else if (draft && currentValue === draft.translatedText) {
+        setDraftMode('translated');
+      }
+    }).catch((error) => {
+      console.error('Failed to load translation source draft:', error);
+    }).finally(() => {
+      if (!cancelled) setIsDraftLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [translationDraftId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -169,9 +225,16 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
     }
   };
 
-  const handleValueChange = (newValue: string) => {
+  const applyValueChange = (newValue: string) => {
     onValueChange(newValue);
     executeWidgetCallback(newValue);
+  };
+
+  const handleValueChange = (newValue: string) => {
+    if (draftMode === 'translated' && newValue !== translationDraft?.translatedText) {
+      setDraftMode(null);
+    }
+    applyValueChange(newValue);
   };
 
   const handleCopy = async () => {
@@ -192,21 +255,63 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
   };
 
   const handleTranslate = async () => {
-    const sourceText = String(editingValue || '');
+    const sourceText = draftMode === 'translated' && translationDraft
+      ? translationDraft.sourceText
+      : String(editingValue || '');
     if (!sourceText.trim()) {
       toast.error(t('translationWidget.messages.emptyText'));
       return;
     }
 
+    if (!translationDraftId || !node) {
+      toast.error(t('translationWidget.messages.sourceSaveFailed'));
+      return;
+    }
+
     setIsTranslating(true);
+    const sourceDraft: TranslationDraft = {
+      id: translationDraftId,
+      scope: storageScope,
+      nodeId: node.id,
+      widgetName: param.name,
+      sourceText,
+      translatedText: translationDraft?.translatedText || '',
+      sourceLanguage: translationPreferences.sourceLanguage,
+      targetLanguage: translationPreferences.targetLanguage,
+      provider: translationPreferences.provider,
+      updatedAt: new Date().toISOString()
+    };
+
+    try {
+      await saveTranslationDraft(sourceDraft);
+      setTranslationDraft(sourceDraft);
+    } catch (error) {
+      console.error('Failed to preserve translation source text:', error);
+      toast.error(t('translationWidget.messages.sourceSaveFailed'));
+      setIsTranslating(false);
+      return;
+    }
+
     try {
       const result = await translateText({
         text: sourceText,
         serverUrl,
         ...translationPreferences
       });
-      handleValueChange(result.text);
-      toast.success(t('translationWidget.messages.complete'));
+
+      const completedDraft: TranslationDraft = {
+        ...sourceDraft,
+        translatedText: result.text,
+        updatedAt: new Date().toISOString()
+      };
+      try {
+        await saveTranslationDraft(completedDraft);
+      } catch (error) {
+        console.error('Failed to save the latest translated value:', error);
+      }
+      setTranslationDraft(completedDraft);
+      setDraftMode('translated');
+      applyValueChange(result.text);
       setShowTranslationPanel(false);
     } catch (error) {
       if (error instanceof TranslationServiceError && error.code === 'missing-key') {
@@ -235,6 +340,32 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
       }
     } finally {
       setIsTranslating(false);
+    }
+  };
+
+  const handleRestoreSource = () => {
+    if (!translationDraft) return;
+    setDraftMode('source');
+    applyValueChange(translationDraft.sourceText);
+  };
+
+  const handleShowTranslation = () => {
+    if (!translationDraft?.translatedText) return;
+    setDraftMode('translated');
+    applyValueChange(translationDraft.translatedText);
+  };
+
+  const handleDeleteSource = async () => {
+    if (!translationDraftId || !window.confirm(t('translationWidget.confirmDeleteSource'))) return;
+
+    try {
+      await deleteTranslationDraft(translationDraftId);
+      setTranslationDraft(null);
+      setDraftMode(null);
+      toast.success(t('translationWidget.messages.sourceDeleted'));
+    } catch (error) {
+      console.error('Failed to delete translation source text:', error);
+      toast.error(t('translationWidget.messages.sourceDeleteFailed'));
     }
   };
 
@@ -287,6 +418,14 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
   const engineInstallState = localStatus?.engine_install?.state || 'idle';
   const isInstallingLocalEngine = engineInstallState === 'running';
   const localEngineNeedsRestart = engineInstallState === 'restart_required';
+  const translateActionLabel = draftMode === 'translated'
+    ? t('translationWidget.retranslateSource')
+    : t('translationWidget.translate');
+  const draftStatusLabel = draftMode === 'source'
+    ? t('translationWidget.sourceEditing')
+    : draftMode === 'translated'
+      ? t('translationWidget.translationShown')
+      : t('translationWidget.sourceAvailable');
 
   return (
     <div className="space-y-3">
@@ -301,9 +440,9 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
               variant="outline"
               size="sm"
               onClick={handleTranslate}
-              disabled={isTranslating}
+              disabled={isTranslating || isDraftLoading}
               className="h-8 rounded-r-none border-r-0 border-white/[0.1] px-2 text-xs hover:bg-[#3069f0]/10 hover:text-[#7ba3f5]"
-              title={t('translationWidget.translate')}
+              title={translateActionLabel}
             >
               {isTranslating ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Languages className="mr-1 h-3.5 w-3.5" />}
               <span>{providerName} · {targetShortName}</span>
@@ -481,20 +620,61 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
               type="button"
               size="sm"
               onClick={handleTranslate}
-              disabled={isTranslating || isInstallingLocalPacks || isInstallingLocalEngine || !selectedProviderAvailable || (translationPreferences.provider === 'argos' && missingLocalPairs.length > 0)}
+              disabled={isTranslating || isDraftLoading || isInstallingLocalPacks || isInstallingLocalEngine || !selectedProviderAvailable || (translationPreferences.provider === 'argos' && missingLocalPairs.length > 0)}
               className="h-8 shrink-0 rounded-lg bg-[#3069f0] px-3 text-[11.5px] text-white hover:bg-[#3f78f5] disabled:opacity-45"
             >
               {isTranslating ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Languages className="mr-1.5 h-3.5 w-3.5" />}
-              {isTranslating ? t('translationWidget.translating') : t('translationWidget.translate')}
+              {isTranslating ? t('translationWidget.translating') : translateActionLabel}
             </Button>
           </div>
+        </div>
+      )}
+
+      {!isDraftLoading && translationDraft && (
+        <div className="flex items-center gap-2 rounded-lg border border-[#3069f0]/20 bg-[#3069f0]/[0.07] px-2.5 py-2">
+          <HardDrive className="h-3.5 w-3.5 shrink-0 text-[#7ba3f5]" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-[10.5px] font-medium text-[#a8c1fa]">{draftStatusLabel}</p>
+            <p className="truncate text-[9.5px] text-[#66758a]">{t('translationWidget.localOnlyHint')}</p>
+          </div>
+          {draftMode === 'source' && translationDraft.translatedText ? (
+            <button
+              type="button"
+              onClick={handleShowTranslation}
+              disabled={isTranslating}
+              className="shrink-0 text-[10.5px] font-medium text-[#7ba3f5] hover:text-[#a8c1fa] disabled:opacity-50"
+            >
+              {t('translationWidget.showTranslation')}
+            </button>
+          ) : draftMode !== 'source' ? (
+            <button
+              type="button"
+              onClick={handleRestoreSource}
+              disabled={isTranslating}
+              className="flex shrink-0 items-center gap-1 text-[10.5px] font-medium text-[#7ba3f5] hover:text-[#a8c1fa] disabled:opacity-50"
+            >
+              <RotateCcw className="h-3 w-3" />
+              {t('translationWidget.restoreSource')}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={handleDeleteSource}
+            disabled={isTranslating}
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[#66758a] hover:bg-white/[0.05] hover:text-[#e16f7a] disabled:opacity-50"
+            title={t('translationWidget.deleteSource')}
+            aria-label={t('translationWidget.deleteSource')}
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
         </div>
       )}
 
       <Textarea
         value={String(editingValue)}
         onChange={(event) => handleValueChange(event.target.value)}
-        className="text-[14px] resize-y"
+        disabled={isTranslating}
+        className="text-[14px] resize-y disabled:cursor-wait disabled:opacity-70"
         rows={6}
         placeholder={t('node.enterText')}
       />

--- a/src/components/etc/BrowserDataBackup.tsx
+++ b/src/components/etc/BrowserDataBackup.tsx
@@ -24,6 +24,11 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import {
+  getAllTranslationDrafts,
+  replaceTranslationDrafts,
+  type TranslationDraft
+} from '@/infrastructure/storage/TranslationDraftStorageService';
 
 interface BackupInfo {
   hasBackup: boolean;
@@ -124,6 +129,7 @@ export const BrowserDataBackup: React.FC = () => {
       indexedDB: {
         apiKeys?: any[];
         workflows?: any[];
+        translationDrafts?: TranslationDraft[];
       };
     } = {
       localStorage: {},
@@ -210,6 +216,13 @@ export const BrowserDataBackup: React.FC = () => {
       });
     } catch (error) {
       console.error('Error collecting IndexedDB data:', error);
+    }
+
+    try {
+      data.indexedDB.translationDrafts = await getAllTranslationDrafts();
+      console.log(`Collected ${data.indexedDB.translationDrafts.length} translation source drafts`);
+    } catch (error) {
+      console.error('Error collecting translation source drafts:', error);
     }
 
     return data;
@@ -314,6 +327,9 @@ export const BrowserDataBackup: React.FC = () => {
         // Restore IndexedDB
         if (backupData.indexedDB) {
           await restoreIndexedDBData(backupData.indexedDB);
+          if (Array.isArray(backupData.indexedDB.translationDrafts)) {
+            await replaceTranslationDrafts(backupData.indexedDB.translationDrafts);
+          }
         }
 
         toast.success(t('backup.toast.restoreSuccess'));
@@ -729,6 +745,14 @@ export const BrowserDataBackup: React.FC = () => {
                   <div className="flex items-start">
                     <span className="text-[#5b8af5] mr-2 mt-0.5">•</span>
                     <span>{t('backup.info.storage')}</span>
+                  </div>
+                  <Badge variant="secondary" className="bg-white/[0.08] font-mono text-[9px] py-0 h-4 opacity-60">CORE</Badge>
+                </li>
+
+                <li className="flex items-center justify-between">
+                  <div className="flex items-start">
+                    <span className="text-[#5b8af5] mr-2 mt-0.5">•</span>
+                    <span>{t('backup.info.translationDrafts')}</span>
                   </div>
                   <Badge variant="secondary" className="bg-white/[0.08] font-mono text-[9px] py-0 h-4 opacity-60">CORE</Badge>
                 </li>

--- a/src/infrastructure/storage/TranslationDraftStorageService.ts
+++ b/src/infrastructure/storage/TranslationDraftStorageService.ts
@@ -1,0 +1,122 @@
+/**
+ * Device-local source text storage for translated STRING widgets.
+ *
+ * Translation drafts intentionally live outside workflow JSON so exported
+ * workflows continue to contain only the value that ComfyUI will execute.
+ */
+
+const DB_NAME = 'ComfyMobileUITranslationDrafts';
+const DB_VERSION = 1;
+const STORE_NAME = 'translationDrafts';
+
+export interface TranslationDraft {
+  id: string;
+  scope: string;
+  nodeId: number;
+  widgetName: string;
+  sourceText: string;
+  translatedText: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  provider: string;
+  updatedAt: string;
+}
+
+let databasePromise: Promise<IDBDatabase> | null = null;
+
+const openDatabase = (): Promise<IDBDatabase> => {
+  if (databasePromise) return databasePromise;
+
+  databasePromise = new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB is not available.'));
+      return;
+    }
+
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => {
+      databasePromise = null;
+      reject(request.error || new Error('Failed to open translation draft storage.'));
+    };
+
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        const store = database.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('scope', 'scope', { unique: false });
+        store.createIndex('updatedAt', 'updatedAt', { unique: false });
+      }
+    };
+
+    request.onsuccess = () => {
+      const database = request.result;
+      database.onversionchange = () => {
+        database.close();
+        databasePromise = null;
+      };
+      resolve(database);
+    };
+  });
+
+  return databasePromise;
+};
+
+const runRequest = async <T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> => {
+  const database = await openDatabase();
+
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, mode);
+    const request = operation(transaction.objectStore(STORE_NAME));
+    let result!: T;
+
+    request.onsuccess = () => {
+      result = request.result;
+    };
+    request.onerror = () => reject(request.error || new Error('Translation draft request failed.'));
+    transaction.oncomplete = () => resolve(result);
+    transaction.onabort = () => reject(transaction.error || new Error('Translation draft transaction was aborted.'));
+  });
+};
+
+export const createTranslationDraftId = (
+  scope: string,
+  nodeId: number,
+  widgetName: string
+): string => JSON.stringify([scope, nodeId, widgetName]);
+
+export const getTranslationDraft = async (id: string): Promise<TranslationDraft | null> => {
+  const draft = await runRequest<TranslationDraft | undefined>('readonly', (store) => store.get(id));
+  return draft || null;
+};
+
+export const saveTranslationDraft = async (draft: TranslationDraft): Promise<void> => {
+  await runRequest<IDBValidKey>('readwrite', (store) => store.put(draft));
+};
+
+export const deleteTranslationDraft = async (id: string): Promise<void> => {
+  await runRequest<undefined>('readwrite', (store) => store.delete(id));
+};
+
+export const getAllTranslationDrafts = async (): Promise<TranslationDraft[]> => {
+  return runRequest<TranslationDraft[]>('readonly', (store) => store.getAll());
+};
+
+export const replaceTranslationDrafts = async (drafts: TranslationDraft[]): Promise<void> => {
+  const database = await openDatabase();
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+
+    store.clear();
+    drafts.forEach((draft) => store.put(draft));
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error || new Error('Failed to restore translation drafts.'));
+    transaction.onabort = () => reject(transaction.error || new Error('Translation draft restore was aborted.'));
+  });
+};

--- a/src/locale/en/common.json
+++ b/src/locale/en/common.json
@@ -1213,6 +1213,15 @@
         "installingLanguagePack": "Installing language packs...",
         "translate": "Translate",
         "translating": "Translating...",
+        "retranslateSource": "Retranslate source",
+        "restoreSource": "Restore source",
+        "showTranslation": "Show translation",
+        "deleteSource": "Delete saved source",
+        "confirmDeleteSource": "Delete the source text saved on this device? This cannot be undone.",
+        "sourceEditing": "Editing source text",
+        "translationShown": "Showing translated text",
+        "sourceAvailable": "Saved source text available",
+        "localOnlyHint": "Saved only on this device",
         "languages": {
             "auto": "Detect automatically",
             "EN": "English",
@@ -1240,6 +1249,9 @@
             "languagePackInstalled": "Local language packs installed",
             "languagePackInstallFailed": "Failed to install local language packs",
             "complete": "Translation complete",
+            "sourceDeleted": "Saved source text deleted",
+            "sourceDeleteFailed": "Failed to delete the saved source text",
+            "sourceSaveFailed": "The source text could not be saved on this device, so translation was stopped",
             "failed": "Translation failed. Check the API key and server connection"
         }
     },
@@ -1462,6 +1474,7 @@
             "folders": "Workflow folder structure (localStorage: comfy-workflow-folders)",
             "apiKeys": "API keys (IndexedDB: apiKeys)",
             "storage": "Workflow detailed data (IndexedDB: workflows)",
+            "translationDrafts": "Translation source drafts (IndexedDB: translationDrafts)",
             "settings": "User interface & language preferences",
             "note": "Note: Only one backup file is maintained. New backups overwrite the existing one."
         },

--- a/src/locale/ja/common.json
+++ b/src/locale/ja/common.json
@@ -1209,6 +1209,15 @@
         "installingLanguagePack": "言語パックをインストール中...",
         "translate": "翻訳",
         "translating": "翻訳中...",
+        "retranslateSource": "原文を再翻訳",
+        "restoreSource": "原文を復元",
+        "showTranslation": "翻訳文を表示",
+        "deleteSource": "保存した原文を削除",
+        "confirmDeleteSource": "このデバイスに保存された原文を削除しますか？この操作は元に戻せません。",
+        "sourceEditing": "原文を編集中",
+        "translationShown": "翻訳文を表示中",
+        "sourceAvailable": "保存された原文があります",
+        "localOnlyHint": "このデバイスにのみ保存",
         "languages": {
             "auto": "自動検出",
             "EN": "英語",
@@ -1236,6 +1245,9 @@
             "languagePackInstalled": "ローカル言語パックのインストールが完了しました",
             "languagePackInstallFailed": "ローカル言語パックのインストールに失敗しました",
             "complete": "翻訳が完了しました",
+            "sourceDeleted": "保存された原文を削除しました",
+            "sourceDeleteFailed": "保存された原文を削除できませんでした",
+            "sourceSaveFailed": "このデバイスに原文を保存できなかったため、翻訳を中止しました",
             "failed": "翻訳に失敗しました。APIキーとサーバー接続を確認してください"
         }
     },
@@ -1458,6 +1470,7 @@
             "folders": "ワークフローフォルダ構造 (localStorage: comfy-workflow-folders)",
             "apiKeys": "APIキー情報 (IndexedDB: apiKeys)",
             "storage": "ワークフロー詳細データ (IndexedDB: workflows)",
+            "translationDrafts": "翻訳用の原文下書き (IndexedDB: translationDrafts)",
             "settings": "ユーザーインターフェースと言語設定",
             "note": "注意：1つのバックアップファイルのみが保持されます。新しいバックアップは既存のものを上書きします。"
         },

--- a/src/locale/ko/common.json
+++ b/src/locale/ko/common.json
@@ -1213,6 +1213,15 @@
         "installingLanguagePack": "언어팩 설치 중...",
         "translate": "번역",
         "translating": "번역 중...",
+        "retranslateSource": "원문 다시 번역",
+        "restoreSource": "원문 복구",
+        "showTranslation": "번역본 보기",
+        "deleteSource": "저장된 원문 삭제",
+        "confirmDeleteSource": "이 기기에 저장된 원문을 삭제할까요? 삭제한 원문은 복구할 수 없습니다.",
+        "sourceEditing": "원문 편집 중",
+        "translationShown": "번역본 표시 중",
+        "sourceAvailable": "저장된 원문 있음",
+        "localOnlyHint": "이 기기에만 저장됨",
         "languages": {
             "auto": "자동 감지",
             "EN": "영어",
@@ -1240,6 +1249,9 @@
             "languagePackInstalled": "로컬 언어팩 설치가 완료되었습니다",
             "languagePackInstallFailed": "로컬 언어팩 설치에 실패했습니다",
             "complete": "번역이 완료되었습니다",
+            "sourceDeleted": "저장된 원문을 삭제했습니다",
+            "sourceDeleteFailed": "저장된 원문을 삭제하지 못했습니다",
+            "sourceSaveFailed": "이 기기에 원문을 저장하지 못해 번역을 중단했습니다",
             "failed": "번역에 실패했습니다. API 키와 서버 연결을 확인해주세요"
         }
     },
@@ -1462,6 +1474,7 @@
             "folders": "워크플로우 폴더 구조 (localStorage: comfy-workflow-folders)",
             "apiKeys": "API 키 정보 (IndexedDB: apiKeys)",
             "storage": "워크플로우 상세 데이터 (IndexedDB: workflows)",
+            "translationDrafts": "번역 원문 초안 (IndexedDB: translationDrafts)",
             "settings": "사용자 인터페이스 및 언어 설정",
             "note": "참고: 하나의 백업 파일만 유지되며, 새 백업은 기존 백업을 덮어씁니다."
         },

--- a/src/locale/zh/common.json
+++ b/src/locale/zh/common.json
@@ -1210,6 +1210,15 @@
         "installingLanguagePack": "正在安装语言包...",
         "translate": "翻译",
         "translating": "翻译中...",
+        "retranslateSource": "重新翻译原文",
+        "restoreSource": "恢复原文",
+        "showTranslation": "显示译文",
+        "deleteSource": "删除已保存的原文",
+        "confirmDeleteSource": "要删除保存在此设备上的原文吗？此操作无法撤销。",
+        "sourceEditing": "正在编辑原文",
+        "translationShown": "正在显示译文",
+        "sourceAvailable": "已保存原文",
+        "localOnlyHint": "仅保存在此设备上",
         "languages": {
             "auto": "自动检测",
             "EN": "英语",
@@ -1237,6 +1246,9 @@
             "languagePackInstalled": "本地语言包安装完成",
             "languagePackInstallFailed": "本地语言包安装失败",
             "complete": "翻译完成",
+            "sourceDeleted": "已删除本地保存的原文",
+            "sourceDeleteFailed": "无法删除本地保存的原文",
+            "sourceSaveFailed": "无法在此设备上保存原文，因此已停止翻译",
             "failed": "翻译失败，请检查 API 密钥和服务器连接"
         }
     },
@@ -1459,6 +1471,7 @@
             "folders": "工作流文件夹结构 (localStorage: comfy-workflow-folders)",
             "apiKeys": "API 密钥信息 (IndexedDB: apiKeys)",
             "storage": "工作流详细数据 (IndexedDB: workflows)",
+            "translationDrafts": "翻译原文草稿 (IndexedDB: translationDrafts)",
             "settings": "用户界面和语言设置",
             "note": "注意：仅保留一个备份文件。新备份将覆盖现有备份。"
         },


### PR DESCRIPTION
## What changed

- Preserve the pre-translation STRING widget value in a device-local IndexedDB store keyed by workflow route, node, and widget.
- Add reversible source/translation states so users can restore and edit the original prompt, return to the last translation, retranslate from the saved source, or delete the saved source.
- Stop translation before replacing the widget value if the source cannot be preserved.
- Include translation source drafts in the existing browser backup and restore flow. Older backups without the new field remain compatible and do not erase current drafts.
- Add all new UI copy to the English, Korean, Japanese, and Simplified Chinese locale files.
- Keep restore and successful translation transitions quiet; error and destructive-action feedback remains.

## Why

Translation currently replaces the STRING widget value directly. After submitting a translated prompt, users have no reliable way to return to and revise the original-language prompt without translating it back, which can lose meaning over repeated cycles.

The saved source is intentionally kept outside workflow JSON so workflow serialization and exported workflow files remain unchanged.

## User impact

Users can repeatedly:

1. write an original prompt,
2. translate and submit it,
3. restore the original prompt,
4. revise it,
5. translate and submit again.

The locally saved source also follows the app's browser-data backup and restore workflow.

## Validation

- `npx tsc -b`
- `npx eslint src/components/controls/widgets/StringWidget.tsx src/infrastructure/storage/TranslationDraftStorageService.ts`
- Parsed all four locale JSON files and verified the new keys
- `git diff --check`
- Confirmed the Vite development server responds with HTTP 200 on port 5173
- Confirmed the nine lint findings in `BrowserDataBackup.tsx` are pre-existing by running ESLint against the file from `HEAD`
- A production build completed once; later local reruns reached 2,451 transformed modules before the Windows Node process exited with native status `0xC0000409` without a TypeScript or bundle diagnostic
