### PR TITLE
Improve mobile delete button affordance

### DIFF
--- a/src/components/controls/widgets/StringWidget.tsx
+++ b/src/components/controls/widgets/StringWidget.tsx
@@ -661,11 +661,11 @@ export const StringWidget: React.FC<StringWidgetProps> = ({
             type="button"
             onClick={handleDeleteSource}
             disabled={isTranslating}
-            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[#66758a] hover:bg-white/[0.05] hover:text-[#e16f7a] disabled:opacity-50"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[#e16f7a] hover:bg-[#e16f7a]/[0.1] hover:text-[#f28a94] active:bg-[#e16f7a]/[0.16] disabled:cursor-not-allowed disabled:bg-transparent disabled:text-[#66758a] disabled:opacity-60"
             title={t('translationWidget.deleteSource')}
             aria-label={t('translationWidget.deleteSource')}
           >
-            <Trash2 className="h-3 w-3" />
+            <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
       )}


### PR DESCRIPTION
## What changed

- Show the saved-source delete icon in red whenever it is active.
- Keep the disabled translation state gray.
- Increase the button from 24×24px to 28×28px and the icon from 12px to 14px.
- Add active-state feedback that works on touch devices without relying on hover.

## Why

The previous control used a muted gray default color and only turned red on hover. Mobile users do not receive persistent hover feedback, so the active delete action looked disabled and its touch target felt too small.

## Validation

- `npx tsc -b`
- `npx eslint src/components/controls/widgets/StringWidget.tsx`
- `npm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 번역 소스 삭제 버튼의 크기와 삭제 아이콘을 확대했습니다.
  * 기본, 호버, 활성화, 비활성화 상태별 색상과 배경 스타일을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->