### PR TITLE
Fix save button state races

### DIFF
--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -178,6 +178,8 @@ const WorkflowEditor: React.FC = () => {
   const [isExecuting, setIsExecuting] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [saveSucceeded, setSaveSucceeded] = useState(false);
+  const saveInFlightRef = useRef(false);
+  const saveSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isJsonViewerOpen, setIsJsonViewerOpen] = useState<boolean>(false);
   const [jsonViewerData, setJsonViewerData] = useState<{ title: string; data: any } | null>(null);
   const [isExtractConfirmOpen, setIsExtractConfirmOpen] = useState(false);
@@ -196,6 +198,31 @@ const WorkflowEditor: React.FC = () => {
   const [queueRefreshTrigger, setQueueRefreshTrigger] = useState<number>(0);
   const [uploadState, setUploadState] = useState<any>({ isUploading: false });
   const [renderTrigger, setRenderTrigger] = useState(0); // State to force re-renders
+
+  const clearSaveSuccessFeedback = useCallback(() => {
+    if (saveSuccessTimerRef.current) {
+      clearTimeout(saveSuccessTimerRef.current);
+      saveSuccessTimerRef.current = null;
+    }
+    setSaveSucceeded(false);
+  }, []);
+
+  const showSaveSuccessFeedback = useCallback(() => {
+    if (saveSuccessTimerRef.current) {
+      clearTimeout(saveSuccessTimerRef.current);
+    }
+    setSaveSucceeded(true);
+    saveSuccessTimerRef.current = setTimeout(() => {
+      saveSuccessTimerRef.current = null;
+      setSaveSucceeded(false);
+    }, 1000);
+  }, []);
+
+  useEffect(() => () => {
+    if (saveSuccessTimerRef.current) {
+      clearTimeout(saveSuccessTimerRef.current);
+    }
+  }, []);
 
   // Force re-render utility (moved up for hoisting)
   const forceRender = useCallback(() => {
@@ -677,15 +704,18 @@ const WorkflowEditor: React.FC = () => {
   const officialCanvasEnabled = useCanvasV2Store((s) => s.officialCanvasEnabled);
   const setOfficialCanvasEnabled = useCanvasV2Store((s) => s.setOfficialCanvasEnabled);
   const [canvasDirty, setCanvasDirty] = useState(false);
+  const canvasRevisionRef = useRef(0);
   // In-flight official-canvas save. Mode switching reloads from storage, so
   // a toggle right after tapping Save must wait for this write to commit —
   // otherwise it rebuilds the legacy graph from the PREVIOUS json and the
   // node hints keep showing stale values until the next full reload.
   const pendingCanvasSaveRef = useRef<Promise<void> | null>(null);
   const handleBridgeGraphMutated = useCallback(() => {
+    canvasRevisionRef.current += 1;
     setCanvasDirty(true);
   }, []);
   useEffect(() => {
+    canvasRevisionRef.current = 0;
     setCanvasDirty(false);
   }, [id]);
   // Official node renderer (Nodes 2.0 vs Classic). Reported by the bridge on
@@ -1385,9 +1415,17 @@ const WorkflowEditor: React.FC = () => {
     // A history preview is intentionally read-only with respect to the
     // current workflow until the user explicitly applies it.
     if (historyWorkflowSession?.mode === 'preview') return;
+    // React state alone cannot prevent two buttons from entering this handler
+    // before the disabled state is rendered. Guard the async operation
+    // synchronously as well.
+    if (saveInFlightRef.current) return;
 
+    saveInFlightRef.current = true;
+    clearSaveSuccessFeedback();
     setIsSaving(true);
-    setSaveSucceeded(false);
+    const savedModifiedValues = new Map<number, NodeWidgetModifications>(
+      Array.from(widgetEditor.modifiedWidgetValues, ([nodeId, values]) => [nodeId, { ...values }])
+    );
 
     try {
       // Canvas v2: the official graph is the source of truth — serializing it
@@ -1395,6 +1433,7 @@ const WorkflowEditor: React.FC = () => {
       // and widget/mode edits were already mirrored into it.
       const v2Bridge = getActiveCanvasBridge();
       if (officialCanvasEnabled && v2Bridge?.isReady) {
+        const savedCanvasRevision = canvasRevisionRef.current;
         const saveTask = (async () => {
           const officialJson = (await v2Bridge.getWorkflow()) as IComfyJson;
           // Persist only — the legacy view rebuilds from storage on mode
@@ -1421,13 +1460,15 @@ const WorkflowEditor: React.FC = () => {
         } finally {
           if (pendingCanvasSaveRef.current === saveTask) pendingCanvasSaveRef.current = null;
         }
-        widgetEditor.clearModifications();
-        setCanvasDirty(false);
+        widgetEditor.clearSavedModifications(savedModifiedValues);
+        // A bridge mutation after this save started belongs to the next save.
+        // Do not erase that dirty signal when the older write completes.
+        if (canvasRevisionRef.current === savedCanvasRevision) {
+          setCanvasDirty(false);
+        }
         setHistoryWorkflowSession(null);
         setHistoryWorkflowDirty(false);
-        setIsSaving(false);
-        setSaveSucceeded(true);
-        setTimeout(() => setSaveSucceeded(false), 1500);
+        showSaveSuccessFeedback();
         return;
       }
 
@@ -1444,7 +1485,7 @@ const WorkflowEditor: React.FC = () => {
       // The changes made to the subgraph object will be reflected in the root graph 
       // because subgraphs are referenced within the root graph structure
       const currentGraph = comfyGraphRef.current;
-      const modifiedValues = widgetEditor.modifiedWidgetValues;
+      const modifiedValues = savedModifiedValues;
 
       // createModifiedGraph returns a copy, so we need to apply changes directly to the original Graph
       if (modifiedValues.size > 0 && currentGraph) {
@@ -1540,7 +1581,6 @@ const WorkflowEditor: React.FC = () => {
         await updateWorkflow(updatedWorkflow);
       } catch (error) {
         console.error('Failed to save workflow:', error);
-        setIsSaving(false);
         return;
       }
 
@@ -1548,7 +1588,7 @@ const WorkflowEditor: React.FC = () => {
       setWorkflow(updatedWorkflow);
 
       // Clear modifications
-      widgetEditor.clearModifications();
+      widgetEditor.clearSavedModifications(savedModifiedValues);
       setHistoryWorkflowSession(null);
       setHistoryWorkflowDirty(false);
 
@@ -1561,19 +1601,15 @@ const WorkflowEditor: React.FC = () => {
       }
 
       // Success animation
-      setIsSaving(false);
-      setSaveSucceeded(true);
-
-      // Reset success state after animation completes
-      setTimeout(() => {
-        setSaveSucceeded(false);
-      }, 1500); // Reset 0.5s after WorkflowHeader hides the checkmark
+      showSaveSuccessFeedback();
 
     } catch (error) {
       console.error('Failed to save workflow:', error);
+    } finally {
+      saveInFlightRef.current = false;
       setIsSaving(false);
     }
-  }, [workflow, widgetEditor, objectInfo, syncWorkflow, officialCanvasEnabled, historyWorkflowSession]);
+  }, [workflow, widgetEditor, objectInfo, syncWorkflow, officialCanvasEnabled, historyWorkflowSession, clearSaveSuccessFeedback, showSaveSuccessFeedback]);
 
   // Canvas v2: data-driven mode switch. The persisted workflow JSON is the
   // only boundary between the two canvases — no state carries over. Unsaved
@@ -3637,6 +3673,10 @@ const WorkflowEditor: React.FC = () => {
   }
 
   // Main render
+  const hasUnsavedWorkflowChanges = historyWorkflowDirty
+    || widgetEditor.hasModifications()
+    || (officialCanvasEnabled && canvasDirty);
+
   return (
     <div className="pwa-container relative w-full">
       {/* Header */}
@@ -3645,7 +3685,7 @@ const WorkflowEditor: React.FC = () => {
         selectedNode={selectedNode}
         hasUnsavedChanges={historyWorkflowSession?.mode === 'preview'
           ? false
-          : historyWorkflowDirty || (officialCanvasEnabled ? canvasDirty : widgetEditor.hasModifications())}
+          : hasUnsavedWorkflowChanges}
         isSaving={isSaving}
         saveSucceeded={saveSucceeded}
         sessionStack={sessionStack}
@@ -4038,7 +4078,7 @@ const WorkflowEditor: React.FC = () => {
       {/* Workflow Save Button - Floating separately */}
       {!isLatentPreviewFullscreen && historyWorkflowSession?.mode !== 'preview' && (
         <WorkflowSaveButton
-          hasUnsavedChanges={historyWorkflowDirty || (officialCanvasEnabled ? canvasDirty : widgetEditor.hasModifications())}
+          hasUnsavedChanges={hasUnsavedWorkflowChanges}
           isSaving={isSaving}
           saveSucceeded={saveSucceeded}
           onSaveChanges={handleSaveChanges}

--- a/src/components/workflow/WorkflowHeader.tsx
+++ b/src/components/workflow/WorkflowHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowLeft, Loader2, ChevronRight, Home, Network } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -101,7 +101,6 @@ export const WorkflowHeader: React.FC<WorkflowHeaderProps> = ({
   onNavigateBreadcrumb,
 }) => {
   const { t } = useTranslation();
-  const [showCheckmark, setShowCheckmark] = useState(false);
   const breadcrumbRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll breadcrumbs to the right when session stack changes
@@ -112,16 +111,7 @@ export const WorkflowHeader: React.FC<WorkflowHeaderProps> = ({
     }
   }, [sessionStack]);
 
-  // Handle save success animation
-  useEffect(() => {
-    if (saveSucceeded) {
-      setShowCheckmark(true);
-      const timer = setTimeout(() => {
-        setShowCheckmark(false);
-      }, 1000); // Show checkmark for 1 second before fade out
-      return () => clearTimeout(timer);
-    }
-  }, [saveSucceeded]);
+  const showSaveSuccess = saveSucceeded && !hasUnsavedChanges;
 
   return (
     <header className="absolute top-0 left-0 right-0 z-10 pwa-header">
@@ -183,7 +173,7 @@ export const WorkflowHeader: React.FC<WorkflowHeaderProps> = ({
           {/* Save Button Slot - Reserved space to prevent breadcrumb invasion */}
           <div className="w-9 h-9 flex items-center justify-end flex-shrink-0">
             <AnimatePresence>
-              {(hasUnsavedChanges || showCheckmark) && (
+              {(hasUnsavedChanges || isSaving || showSaveSuccess) && (
                 <motion.div
                   initial={{ opacity: 0, x: 20, scale: 0.8 }}
                   animate={{ opacity: 1, x: 0, scale: 1 }}
@@ -192,19 +182,19 @@ export const WorkflowHeader: React.FC<WorkflowHeaderProps> = ({
                 >
                   <button
                     onClick={onSaveChanges}
-                    disabled={isSaving || showCheckmark}
-                    className={`w-9 h-9 flex items-center justify-center rounded-[10px] text-white transition-all ${showCheckmark
+                    disabled={isSaving || showSaveSuccess}
+                    className={`w-9 h-9 flex items-center justify-center rounded-[10px] text-white transition-all ${showSaveSuccess
                       ? 'bg-[#34c77b]'
                       : isSaving
                         ? 'bg-[#34c77b]/60 cursor-not-allowed'
                         : 'bg-[#34c77b] hover:bg-[#3fd08a]'
                       }`}
-                    style={showCheckmark ? undefined : { boxShadow: '0 2px 10px rgba(52,199,123,0.35)' }}
-                    title={showCheckmark ? t('common.saved') : isSaving ? t('common.saving') : t('workflow.saveChanges')}
+                    style={showSaveSuccess ? undefined : { boxShadow: '0 2px 10px rgba(52,199,123,0.35)' }}
+                    title={showSaveSuccess ? t('common.saved') : isSaving ? t('common.saving') : t('workflow.saveChanges')}
                   >
                     <SaveToCheckIcon
                       isSaving={isSaving}
-                      isSuccess={showCheckmark}
+                      isSuccess={showSaveSuccess}
                       size={16}
                     />
                   </button>

--- a/src/components/workflow/WorkflowSaveButton.tsx
+++ b/src/components/workflow/WorkflowSaveButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -87,20 +87,8 @@ export const WorkflowSaveButton: React.FC<WorkflowSaveButtonProps> = ({
     onSaveChanges
 }) => {
     const { t } = useTranslation();
-    const [showCheckmark, setShowCheckmark] = useState(false);
-
-    // Handle save success animation
-    useEffect(() => {
-        if (saveSucceeded) {
-            setShowCheckmark(true);
-            const timer = setTimeout(() => {
-                setShowCheckmark(false);
-            }, 1000); // Show checkmark for 1 second before fade out
-            return () => clearTimeout(timer);
-        }
-    }, [saveSucceeded]);
-
-    const isVisible = hasUnsavedChanges || isSaving || showCheckmark;
+    const showSaveSuccess = saveSucceeded && !hasUnsavedChanges;
+    const isVisible = hasUnsavedChanges || isSaving || showSaveSuccess;
 
     return (
         <div className="fixed right-6 bottom-34 z-40 pointer-events-none flex flex-col items-center">
@@ -116,19 +104,19 @@ export const WorkflowSaveButton: React.FC<WorkflowSaveButtonProps> = ({
                         <div className="bg-slate-600/40 backdrop-blur-3xl rounded-full shadow-[0_20px_50px_rgba(0,0,0,0.3)] border border-white/30 p-1.5">
                             <Button
                                 onClick={onSaveChanges}
-                                disabled={isSaving || showCheckmark}
+                                disabled={isSaving || showSaveSuccess}
                                 size="icon"
-                                className={`text-white border border-white/20 backdrop-blur-md shadow-lg transition-all duration-300 h-11 w-11 p-0 rounded-full ${showCheckmark
+                                className={`text-white border border-white/20 backdrop-blur-md shadow-lg transition-all duration-300 h-11 w-11 p-0 rounded-full ${showSaveSuccess
                                     ? 'bg-emerald-500/80'
                                     : isSaving
                                         ? 'bg-gray-500/80 cursor-not-allowed'
                                         : 'bg-green-500/80 hover:bg-green-600/90 hover:shadow-xl'
                                     }`}
-                                title={showCheckmark ? t('common.saved') : isSaving ? t('common.saving') : t('workflow.saveChanges')}
+                                title={showSaveSuccess ? t('common.saved') : isSaving ? t('common.saving') : t('workflow.saveChanges')}
                             >
                                 <SaveToCheckIcon
                                     isSaving={isSaving}
-                                    isSuccess={showCheckmark}
+                                    isSuccess={showSaveSuccess}
                                     size={20}
                                 />
                             </Button>

--- a/src/hooks/useWidgetValueEditor.ts
+++ b/src/hooks/useWidgetValueEditor.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { graphChangeLogger } from '@/utils/GraphChangeLogger';
 import { getActiveCanvasBridge } from '@/services/bridge/CanvasBridgeClient';
 import type { NodeWidgetModifications } from '@/shared/types/widgets/widgetModifications';
+import { retainUnsavedWidgetModifications } from '@/shared/utils/widgetModifications';
 
 // Canvas v2: mirror widget edits into the official graph inside the iframe.
 // No-op when the official canvas is not mounted (bridge is null).
@@ -250,6 +251,14 @@ export const useWidgetValueEditor = (options?: UseWidgetValueEditorOptions) => {
 
   };
 
+  // Clear only the values that were part of a completed save. Values edited
+  // while the storage write was in flight must stay dirty for the next save.
+  const clearSavedModifications = (savedValues: Map<number, NodeWidgetModifications>) => {
+    setModifiedWidgetValues(currentValues => (
+      retainUnsavedWidgetModifications(currentValues, savedValues)
+    ));
+  };
+
   // Directly set a modified widget value without going through edit mode
   const setModifiedWidgetValue = (nodeId: number, paramName: string, value: any) => {
     setModifiedWidgetValues(prev => {
@@ -308,6 +317,7 @@ export const useWidgetValueEditor = (options?: UseWidgetValueEditorOptions) => {
     // setNodeMode,
     // setNodeModeBatch,
     clearModifications,
+    clearSavedModifications,
     setModifiedWidgetValue,
     hasModifications,
 

--- a/src/shared/utils/widgetModifications.ts
+++ b/src/shared/utils/widgetModifications.ts
@@ -1,0 +1,29 @@
+import type { NodeWidgetModifications } from '@/shared/types/widgets/widgetModifications';
+
+export const retainUnsavedWidgetModifications = (
+  currentValues: Map<number, NodeWidgetModifications>,
+  savedValues: Map<number, NodeWidgetModifications>,
+): Map<number, NodeWidgetModifications> => {
+  const remainingValues = new Map<number, NodeWidgetModifications>();
+
+  currentValues.forEach((nodeValues, nodeId) => {
+    const savedNodeValues = savedValues.get(nodeId);
+    const remainingNodeValues: NodeWidgetModifications = {};
+
+    Object.entries(nodeValues).forEach(([paramName, currentValue]) => {
+      const wasSaved = savedNodeValues
+        && Object.prototype.hasOwnProperty.call(savedNodeValues, paramName)
+        && Object.is(savedNodeValues[paramName], currentValue);
+
+      if (!wasSaved) {
+        remainingNodeValues[paramName] = currentValue;
+      }
+    });
+
+    if (Object.keys(remainingNodeValues).length > 0) {
+      remainingValues.set(nodeId, remainingNodeValues);
+    }
+  });
+
+  return remainingValues;
+};

--- a/tests/integration/saveStateTest.ts
+++ b/tests/integration/saveStateTest.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env npx tsx
+
+import assert from 'node:assert/strict';
+import { retainUnsavedWidgetModifications } from '../../src/shared/utils/widgetModifications';
+
+const savedValues = new Map([
+  [1, { prompt: 'first prompt', seed: 1 }],
+  [2, { strength: 0.5 }],
+]);
+
+const currentValues = new Map([
+  [1, { prompt: 'edited during save', seed: 1, steps: 20 }],
+  [2, { strength: 0.5 }],
+  [3, { filename: 'new-output' }],
+]);
+
+assert.deepEqual(
+  retainUnsavedWidgetModifications(currentValues, savedValues),
+  new Map([
+    [1, { prompt: 'edited during save', steps: 20 }],
+    [3, { filename: 'new-output' }],
+  ]),
+  'only values changed or added while saving should remain dirty',
+);
+
+assert.deepEqual(
+  retainUnsavedWidgetModifications(savedValues, savedValues),
+  new Map(),
+  'a completed save with no concurrent edits should clear all dirty values',
+);
+
+console.log('Save state tests passed');


### PR DESCRIPTION
## Summary

- centralize save-success feedback so the header and floating save buttons share one timer
- guard the async save path against near-simultaneous clicks from the two save controls
- preserve widget and official-canvas changes made while an earlier save is still in flight
- immediately expose the save action again when unsaved changes remain after a completed write
- add a regression test for retaining concurrent widget edits

## Root cause

The editor exposed the same save handler through two buttons, but relied only on React's rendered `isSaving` state to disable them. Each button also owned a separate success-animation timer while the editor owned another reset timer. A stale reset from an earlier save could cancel the next button timer without clearing its local checkmark state, leaving the control permanently visible and disabled.

The save completion path also cleared every dirty value unconditionally, including edits made after the storage write began.

## Impact

Rapid save interactions no longer start overlapping writes or strand either save button in its success state. Changes made during a save remain dirty and can be saved immediately afterward instead of being incorrectly cleared.

## Validation

- `npx tsc --noEmit`
- `npx tsx --tsconfig tsconfig.app.json tests/integration/saveStateTest.ts`
- targeted ESLint checks for the new save-state utility, regression test, and floating save button
- `npm run build`
- `git diff --check`