### PR TITLE
List ComfyUI workflows inside subfolders

### DIFF
--- a/comfy-mobile-ui-api-extension/api.py
+++ b/comfy-mobile-ui-api-extension/api.py
@@ -101,7 +101,7 @@ def setup_routes():
                 
                 # Workflow routes
                 app.router.add_get('/comfymobile/api/workflows/list', list_workflows)
-                app.router.add_get('/comfymobile/api/workflows/content/{filename}', get_workflow_content)
+                app.router.add_get('/comfymobile/api/workflows/content/{filename:.*}', get_workflow_content)
                 app.router.add_post('/comfymobile/api/workflows/save', save_workflow)
                 app.router.add_post('/comfymobile/api/workflows/upload', upload_workflow)
                 
@@ -229,7 +229,7 @@ def setup_routes():
             
             # Basic workflow routes for compatibility
             routes.get('/comfymobile/api/workflows/list')(list_workflows)
-            routes.get('/comfymobile/api/workflows/content/{filename}')(get_workflow_content)
+            routes.get('/comfymobile/api/workflows/content/{filename:.*}')(get_workflow_content)
             routes.post('/comfymobile/api/workflows/save')(save_workflow)
             routes.post('/comfymobile/api/workflows/upload')(upload_workflow)
             

--- a/comfy-mobile-ui-api-extension/handlers/workflow_handler.py
+++ b/comfy-mobile-ui-api-extension/handlers/workflow_handler.py
@@ -67,9 +67,7 @@ async def list_workflows(request):
         
         if os.path.exists(workflows_dir):
             # Users organise large collections into subfolders, so walk the
-            # tree. Symlinked directories are not followed (os.walk default),
-            # which keeps the listing consistent with what
-            # resolve_workflow_path is willing to read back.
+            # tree. Symlinked directories are not followed (os.walk default).
             for current_dir, dir_names, file_names in os.walk(workflows_dir):
                 # Skip dot-directories such as .git or editor state.
                 dir_names[:] = [d for d in dir_names if not d.startswith('.')]
@@ -79,8 +77,17 @@ async def list_workflows(request):
                         continue
 
                     file_path = os.path.join(current_dir, file)
-                    file_info = get_file_info(file_path)
                     relative_path = to_relative_workflow_path(file_path)
+
+                    # os.walk declines to follow symlinked *directories*, but a
+                    # symlinked file still shows up here and os.stat would report
+                    # its target's size and mtime. Filtering through the same
+                    # resolver the content endpoint uses keeps the two in step,
+                    # so nothing is listed that would then fail to open.
+                    if resolve_workflow_path(relative_path) is None:
+                        continue
+
+                    file_info = get_file_info(file_path)
 
                     workflows.append({
                         # Identifier for the content endpoint: path relative to

--- a/comfy-mobile-ui-api-extension/handlers/workflow_handler.py
+++ b/comfy-mobile-ui-api-extension/handlers/workflow_handler.py
@@ -16,6 +16,49 @@ def ensure_workflows_directory() -> str:
     os.makedirs(workflows_dir, exist_ok=True)
     return workflows_dir
 
+def resolve_workflow_path(relative_path: str) -> Optional[str]:
+    """
+    Resolve a client-supplied workflow path against the workflows directory.
+
+    Workflows may live in subfolders, so a plain "reject anything containing a
+    separator" check is no longer possible. Instead the joined path is fully
+    resolved - following symlinks - and required to stay inside the workflows
+    directory. Returns None when the path escapes, is absolute, or is empty.
+    """
+    if not relative_path:
+        return None
+
+    # Clients send POSIX separators; accept backslashes too so Windows-authored
+    # paths do not silently resolve to a single oddly named file.
+    candidate = relative_path.replace(os.sep, '/').replace('\\', '/').strip('/')
+    if not candidate:
+        return None
+
+    if os.path.isabs(candidate) or os.path.splitdrive(candidate)[0]:
+        return None
+
+    workflows_dir = get_workflows_directory()
+    root = os.path.realpath(workflows_dir)
+    target = os.path.realpath(os.path.join(root, *candidate.split('/')))
+
+    # commonpath raises when the two live on different drives, which is itself
+    # an escape.
+    try:
+        if os.path.commonpath([root, target]) != root:
+            return None
+    except ValueError:
+        return None
+
+    if target == root:
+        return None
+
+    return target
+
+def to_relative_workflow_path(absolute_path: str) -> str:
+    """Path relative to the workflows directory, with POSIX separators."""
+    root = os.path.realpath(get_workflows_directory())
+    return os.path.relpath(absolute_path, root).replace(os.sep, '/')
+
 async def list_workflows(request):
     """List all workflow files in user/default/workflows directory"""
     try:
@@ -23,13 +66,29 @@ async def list_workflows(request):
         workflows = []
         
         if os.path.exists(workflows_dir):
-            for file in os.listdir(workflows_dir):
-                if file.endswith('.json'):
-                    file_path = os.path.join(workflows_dir, file)
+            # Users organise large collections into subfolders, so walk the
+            # tree. Symlinked directories are not followed (os.walk default),
+            # which keeps the listing consistent with what
+            # resolve_workflow_path is willing to read back.
+            for current_dir, dir_names, file_names in os.walk(workflows_dir):
+                # Skip dot-directories such as .git or editor state.
+                dir_names[:] = [d for d in dir_names if not d.startswith('.')]
+
+                for file in file_names:
+                    if not file.endswith('.json'):
+                        continue
+
+                    file_path = os.path.join(current_dir, file)
                     file_info = get_file_info(file_path)
-                    
+                    relative_path = to_relative_workflow_path(file_path)
+
                     workflows.append({
-                        "filename": file,
+                        # Identifier for the content endpoint: path relative to
+                        # the workflows root, POSIX separators.
+                        "filename": relative_path,
+                        # Split out so clients can group without re-parsing.
+                        "name": file,
+                        "folder": os.path.dirname(relative_path),
                         "size": file_info["size"],
                         "modified": file_info["modified"],
                         "modified_iso": file_info["modified_iso"]
@@ -145,21 +204,20 @@ async def get_workflow_content(request):
     try:
         filename = request.match_info['filename']
         
-        # Security: ensure filename doesn't contain path traversal
-        if '..' in filename or '/' in filename or '\\' in filename:
+        # Ensure .json extension
+        if not filename.endswith('.json'):
+            filename += '.json'
+        
+        # Workflows may live in subfolders, so containment is verified by
+        # resolving the path rather than by rejecting separators outright.
+        workflow_path = resolve_workflow_path(filename)
+        if workflow_path is None:
             return web.json_response({
                 "status": "error",
                 "message": "Invalid filename"
             }, status=400)
         
-        # Ensure .json extension
-        if not filename.endswith('.json'):
-            filename += '.json'
-            
-        workflows_dir = get_workflows_directory()
-        workflow_path = os.path.join(workflows_dir, filename)
-        
-        if not os.path.exists(workflow_path):
+        if not os.path.isfile(workflow_path):
             return web.json_response({
                 "status": "error",
                 "message": f"Workflow file '{filename}' not found"

--- a/comfy-mobile-ui-api-extension/tests/test_workflow_paths.py
+++ b/comfy-mobile-ui-api-extension/tests/test_workflow_paths.py
@@ -1,0 +1,150 @@
+"""
+Path containment tests for workflow subfolder support.
+
+Allowing subfolders meant replacing a blanket "reject any separator" check with
+resolution-based containment, so these cover what that rule used to cover for
+free: traversal, absolute paths, and symlinks pointing outside the root.
+
+Run with:  python tests/test_workflow_paths.py
+"""
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import types
+
+# The handler imports folder_paths from ComfyUI, which is not available when
+# running the tests standalone. A stub is enough: only base_path is used.
+_TEMP_ROOT = tempfile.mkdtemp(prefix="comfymobile-workflow-tests-")
+sys.modules.setdefault("folder_paths", types.SimpleNamespace(base_path=_TEMP_ROOT))
+
+_EXT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_workflow_handler():
+    """
+    Import the handler without importing the extension package.
+
+    The directory name contains dashes so it is not importable directly, and
+    the real __init__ boots the launcher. Synthesising the package hierarchy
+    lets the handler's `from ..utils.file_utils import ...` resolve normally.
+    """
+    for name, path in (
+        ("_cmui", _EXT_DIR),
+        ("_cmui.handlers", os.path.join(_EXT_DIR, "handlers")),
+        ("_cmui.utils", os.path.join(_EXT_DIR, "utils")),
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = [path]
+        sys.modules[name] = package
+
+    spec = importlib.util.spec_from_file_location(
+        "_cmui.handlers.workflow_handler",
+        os.path.join(_EXT_DIR, "handlers", "workflow_handler.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_handler = _load_workflow_handler()
+get_workflows_directory = _handler.get_workflows_directory
+resolve_workflow_path = _handler.resolve_workflow_path
+to_relative_workflow_path = _handler.to_relative_workflow_path
+
+FAILURES = []
+
+
+def check(condition, label):
+    if condition:
+        print("  ok   %s" % label)
+    else:
+        print("  FAIL %s" % label)
+        FAILURES.append(label)
+
+
+def main():
+    workflows_dir = get_workflows_directory()
+    nested_dir = os.path.join(workflows_dir, "portraits", "sdxl")
+    os.makedirs(nested_dir, exist_ok=True)
+
+    root_file = os.path.join(workflows_dir, "root.json")
+    nested_file = os.path.join(nested_dir, "hires.json")
+    for path in (root_file, nested_file):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("{}")
+
+    outside_dir = os.path.join(_TEMP_ROOT, "outside")
+    os.makedirs(outside_dir, exist_ok=True)
+    secret = os.path.join(outside_dir, "secret.json")
+    with open(secret, "w", encoding="utf-8") as f:
+        f.write("{}")
+
+    print("accepted paths:")
+    check(resolve_workflow_path("root.json") == os.path.realpath(root_file),
+          "root file")
+    check(resolve_workflow_path("portraits/sdxl/hires.json") == os.path.realpath(nested_file),
+          "nested file")
+    check(resolve_workflow_path("/portraits/sdxl/hires.json") == os.path.realpath(nested_file),
+          "leading slash is tolerated, not treated as absolute")
+    check(resolve_workflow_path("portraits\\sdxl\\hires.json") == os.path.realpath(nested_file),
+          "backslash separators")
+    check(resolve_workflow_path("portraits/../root.json") == os.path.realpath(root_file),
+          "traversal that stays inside is fine")
+
+    print("rejected paths:")
+    check(resolve_workflow_path("../outside/secret.json") is None, "parent traversal")
+    check(resolve_workflow_path("portraits/../../outside/secret.json") is None,
+          "traversal through a real subfolder")
+    check(resolve_workflow_path(os.path.join(outside_dir, "secret.json")) is None,
+          "absolute path")
+
+    # "....//" defeats sanitisers that strip "../" textually. Resolution instead
+    # treats "...." as an ordinary (nonexistent) folder name, so the result must
+    # stay under the root rather than reach the file outside it.
+    mangled = resolve_workflow_path("....//outside/secret.json")
+    root = os.path.realpath(get_workflows_directory())
+    check(mangled is None or mangled.startswith(root + os.sep),
+          "mangled traversal stays inside the root")
+    check(mangled != os.path.realpath(secret), "mangled traversal misses the outside file")
+    check(resolve_workflow_path("") is None, "empty")
+    check(resolve_workflow_path("/") is None, "root itself")
+    check(resolve_workflow_path(".") is None, "dot resolves to the root")
+
+    # A symlinked file inside the root that points outside must not be readable,
+    # matching os.walk's refusal to follow symlinked directories when listing.
+    link = os.path.join(workflows_dir, "linked.json")
+    symlinks_supported = True
+    try:
+        os.symlink(secret, link)
+    except (OSError, NotImplementedError, AttributeError):
+        symlinks_supported = False
+
+    if symlinks_supported:
+        check(resolve_workflow_path("linked.json") is None,
+              "symlink escaping the root")
+    else:
+        print("  skip symlink escape (not permitted on this platform)")
+
+    print("relative path mapping:")
+    check(to_relative_workflow_path(nested_file) == "portraits/sdxl/hires.json",
+          "nested file maps to POSIX relative path")
+    check(to_relative_workflow_path(root_file) == "root.json", "root file")
+
+    print()
+    if FAILURES:
+        print("%d check(s) failed" % len(FAILURES))
+        return 1
+    print("all workflow path checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        code = main()
+    finally:
+        shutil.rmtree(_TEMP_ROOT, ignore_errors=True)
+    sys.exit(code)

--- a/comfy-mobile-ui-api-extension/tests/test_workflow_paths.py
+++ b/comfy-mobile-ui-api-extension/tests/test_workflow_paths.py
@@ -58,6 +58,21 @@ to_relative_workflow_path = _handler.to_relative_workflow_path
 FAILURES = []
 
 
+def _walk_listing(workflows_dir):
+    """Relative paths list_workflows would return, using the same rules."""
+    found = []
+    for current_dir, dir_names, file_names in os.walk(workflows_dir):
+        dir_names[:] = [d for d in dir_names if not d.startswith('.')]
+        for name in file_names:
+            if not name.endswith('.json'):
+                continue
+            relative = to_relative_workflow_path(os.path.join(current_dir, name))
+            if resolve_workflow_path(relative) is None:
+                continue
+            found.append(relative)
+    return found
+
+
 def check(condition, label):
     if condition:
         print("  ok   %s" % label)
@@ -128,6 +143,21 @@ def main():
               "symlink escaping the root")
     else:
         print("  skip symlink escape (not permitted on this platform)")
+
+    # A symlinked file is enumerated by os.walk even though os.walk will not
+    # descend into symlinked directories, and os.stat would then report the
+    # outside target's metadata. The listing filters through the same resolver,
+    # so listed and readable stay the same set.
+    print("listing matches read policy:")
+    if symlinks_supported:
+        listed = _walk_listing(workflows_dir)
+        check("linked.json" not in listed, "symlinked file is not listed")
+        check("root.json" in listed, "regular root file is listed")
+        check("portraits/sdxl/hires.json" in listed, "nested file is listed")
+        check(all(resolve_workflow_path(rel) is not None for rel in listed),
+              "everything listed is readable")
+    else:
+        print("  skip (symlinks not permitted on this platform)")
 
     print("relative path mapping:")
     check(to_relative_workflow_path(nested_file) == "portraits/sdxl/hires.json",

--- a/src/components/workflow/WorkflowImport.tsx
+++ b/src/components/workflow/WorkflowImport.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ArrowLeft, Download, Server, AlertCircle, CheckCircle, Loader2, ExternalLink, Search, X } from 'lucide-react';
+import { ArrowLeft, Download, Server, AlertCircle, CheckCircle, Loader2, ExternalLink, Search, X, Folder, ChevronRight, CornerLeftUp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
@@ -16,7 +16,10 @@ interface ServerWorkflowInfo {
   description?: string;
   author?: string;
   createdAt?: Date;
+  /** Path relative to the server's workflows root, e.g. "portraits/sdxl/hires.json". */
   filename?: string;
+  /** Folder part of `filename`, '' for the root. */
+  folder: string;
   size?: number;
   modified?: Date;
 }
@@ -49,14 +52,54 @@ const WorkflowImport: React.FC = () => {
     errorMessage: ''
   });
   const [searchQuery, setSearchQuery] = useState<string>('');
+  // '' is the workflows root; otherwise a path like 'portraits/sdxl'.
+  const [currentFolder, setCurrentFolder] = useState<string>('');
 
-  // Filter workflows based on search query
-  const filteredWorkflows = serverWorkflows.filter(workflow => {
-    if (!searchQuery.trim()) return true;
+  const isSearching = searchQuery.trim().length > 0;
+
+  // While searching, look across every folder and show full paths - scoping the
+  // search to the open folder would hide the matches people are looking for.
+  const searchMatches = serverWorkflows.filter(workflow => {
+    if (!isSearching) return false;
     const query = searchQuery.toLowerCase();
-    const name = (workflow.filename || workflow.name || '').toLowerCase();
-    return name.includes(query);
+    return (workflow.filename || workflow.name || '').toLowerCase().includes(query);
   });
+
+  const folderPrefix = currentFolder ? `${currentFolder}/` : '';
+
+  // Files sitting directly in the open folder.
+  const workflowsInFolder = serverWorkflows.filter(w => w.folder === currentFolder);
+
+  // Immediate subfolders, each with the total number of workflows beneath it.
+  const subfolders = (() => {
+    const counts = new Map<string, number>();
+    for (const workflow of serverWorkflows) {
+      if (workflow.folder === currentFolder) continue;
+      if (currentFolder && !workflow.folder.startsWith(folderPrefix)) continue;
+
+      const remainder = workflow.folder.slice(folderPrefix.length);
+      const childName = remainder.split('/')[0];
+      if (!childName) continue;
+      counts.set(childName, (counts.get(childName) || 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  })();
+
+  const breadcrumbs = currentFolder ? currentFolder.split('/') : [];
+
+  // Drives the list body and the empty state alike.
+  const filteredWorkflows = isSearching ? searchMatches : workflowsInFolder;
+  const hasAnythingToShow = filteredWorkflows.length > 0 || (!isSearching && subfolders.length > 0);
+
+  const openFolder = (name: string) => {
+    setCurrentFolder(currentFolder ? `${currentFolder}/${name}` : name);
+  };
+
+  const goToBreadcrumb = (index: number) => {
+    setCurrentFolder(index < 0 ? '' : breadcrumbs.slice(0, index + 1).join('/'));
+  };
 
   // Load workflows when server requirements are met
   useEffect(() => {
@@ -83,13 +126,30 @@ const WorkflowImport: React.FC = () => {
 
       if (result.success && result.workflows) {
         // Map API response to ServerWorkflowInfo interface
-        const mappedWorkflows: ServerWorkflowInfo[] = result.workflows.map(workflow => ({
-          id: workflow.filename.replace('.json', ''),
-          name: workflow.filename.replace('.json', ''),
-          filename: workflow.filename,
-          size: workflow.size || 0,
-          modified: workflow.modified ? new Date(workflow.modified * 1000) : new Date()
-        }));
+        const mappedWorkflows: ServerWorkflowInfo[] = result.workflows.map(workflow => {
+          // `filename` is a path relative to the workflows root. Older
+          // extensions return a bare filename and no folder field, so derive
+          // both rather than depending on the server being up to date.
+          const relativePath: string = workflow.filename || '';
+          const separatorIndex = relativePath.lastIndexOf('/');
+          const folder = workflow.folder ?? (
+            separatorIndex >= 0 ? relativePath.slice(0, separatorIndex) : ''
+          );
+          const baseName = separatorIndex >= 0
+            ? relativePath.slice(separatorIndex + 1)
+            : relativePath;
+
+          return {
+            id: relativePath.replace(/\.json$/i, ''),
+            // Display and duplicate-detection use the bare name; the full path
+            // stays in `filename` because that is what the API addresses.
+            name: baseName.replace(/\.json$/i, ''),
+            filename: relativePath,
+            folder,
+            size: workflow.size || 0,
+            modified: workflow.modified ? new Date(workflow.modified * 1000) : new Date()
+          };
+        });
 
         setServerWorkflows(mappedWorkflows);
         setError(null);
@@ -157,7 +217,7 @@ const WorkflowImport: React.FC = () => {
       });
 
       // Generate unique name
-      const baseName = serverWorkflow.filename?.replace(/\.json$/i, '') || 'untitled';
+      const baseName = serverWorkflow.name || serverWorkflow.filename?.replace(/\.json$/i, '') || 'untitled';
       const uniqueName = generateUniqueFilename(baseName, existingNames);
 
       console.log('🔍 Import Debug - Name generation:', {
@@ -579,7 +639,7 @@ const WorkflowImport: React.FC = () => {
                 </div>
                 <div className="flex items-center gap-2 px-0.5">
                   <h2 className="font-mono text-[10px] font-semibold text-[#565d6b] tracking-[0.14em] uppercase whitespace-nowrap">
-                    {searchQuery ? t('workflow.import.foundCount', { count: filteredWorkflows.length }) : t('workflow.import.serverWorkflows', { count: serverWorkflows.length })}
+                    {isSearching ? t('workflow.import.foundCount', { count: filteredWorkflows.length }) : t('workflow.import.serverWorkflows', { count: serverWorkflows.length })}
                   </h2>
                   <div className="flex-1 h-px bg-white/[0.06]" />
                   <Button
@@ -596,7 +656,69 @@ const WorkflowImport: React.FC = () => {
                 </div>
               </div>
 
-              {filteredWorkflows.length === 0 ? (
+              {!isSearching && breadcrumbs.length > 0 && (
+                <div className="flex items-center gap-1 flex-wrap mb-2.5 px-0.5">
+                  <button
+                    type="button"
+                    onClick={() => goToBreadcrumb(-1)}
+                    className="text-[11.5px] font-medium text-[#7ba3f5]"
+                  >
+                    {t('workflow.import.rootFolder')}
+                  </button>
+                  {breadcrumbs.map((segment, index) => (
+                    <React.Fragment key={`${segment}-${index}`}>
+                      <ChevronRight className="h-3 w-3 text-[#31363f] flex-shrink-0" />
+                      <button
+                        type="button"
+                        onClick={() => goToBreadcrumb(index)}
+                        disabled={index === breadcrumbs.length - 1}
+                        className={`text-[11.5px] font-medium break-all ${index === breadcrumbs.length - 1
+                          ? 'text-[#e9ebef]'
+                          : 'text-[#7ba3f5]'
+                        }`}
+                      >
+                        {segment}
+                      </button>
+                    </React.Fragment>
+                  ))}
+                </div>
+              )}
+
+              {!isSearching && subfolders.length > 0 && (
+                <div className="grid grid-cols-[minmax(0,1fr)] gap-2 mb-2">
+                  {currentFolder && (
+                    <button
+                      type="button"
+                      onClick={() => goToBreadcrumb(breadcrumbs.length - 2)}
+                      className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl border border-white/5 bg-white/[0.02] text-left"
+                    >
+                      <CornerLeftUp className="h-4 w-4 text-[#66758a] flex-shrink-0" strokeWidth={1.9} />
+                      <span className="text-[13px] font-medium text-[#8a919e]">
+                        {t('workflow.import.parentFolder')}
+                      </span>
+                    </button>
+                  )}
+                  {subfolders.map(folder => (
+                    <button
+                      key={folder.name}
+                      type="button"
+                      onClick={() => openFolder(folder.name)}
+                      className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl border border-white/5 bg-white/[0.025] hover:bg-white/5 text-left transition-colors"
+                    >
+                      <Folder className="h-4 w-4 text-[#7ba3f5] flex-shrink-0" strokeWidth={1.9} />
+                      <span className="flex-1 min-w-0 text-[13px] font-semibold text-[#e9ebef] line-clamp-1 break-all">
+                        {folder.name}
+                      </span>
+                      <span className="font-mono text-[10px] text-[#565d6b] flex-shrink-0">
+                        {folder.count}
+                      </span>
+                      <ChevronRight className="h-3.5 w-3.5 text-[#31363f] flex-shrink-0" />
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {!hasAnythingToShow ? (
                 <Card className="bg-black/20 border-white/5">
                   <CardContent className="py-12 text-center">
                     <Server className="h-10 w-12 mx-auto mb-4 text-white/20" />
@@ -621,8 +743,16 @@ const WorkflowImport: React.FC = () => {
                           <div className="flex gap-3 items-center w-full">
                             <div className="flex-1 min-w-0">
                               <h3 className="text-[13px] font-semibold text-[#e9ebef] leading-[1.35] line-clamp-1 break-all">
-                                {workflow.filename?.replace(/\.json$/i, '') || t('workflow.newWorkflowName')}
+                                {workflow.name || t('workflow.newWorkflowName')}
                               </h3>
+                              {isSearching && workflow.folder && (
+                                <div className="flex items-center gap-1 mt-0.5 min-w-0">
+                                  <Folder className="h-2.5 w-2.5 text-[#565d6b] flex-shrink-0" strokeWidth={2} />
+                                  <span className="font-mono text-[10px] text-[#565d6b] line-clamp-1 break-all">
+                                    {workflow.folder}
+                                  </span>
+                                </div>
+                              )}
                               <div className="flex items-center gap-1.5 mt-1 font-mono text-[10px] text-[#565d6b] whitespace-nowrap">
                                 <span>{formatDate(workflow.modified?.getTime() || Date.now())}</span>
                                 <span className="text-[#31363f]">·</span>

--- a/src/infrastructure/api/ComfyFileService.ts
+++ b/src/infrastructure/api/ComfyFileService.ts
@@ -312,7 +312,14 @@ export class ComfyFileService {
 
       // Ensure .json extension
       const workflowFilename = filename.endsWith('.json') ? filename : `${filename}.json`;
-      const endpoint = `${this.serverUrl}/comfymobile/api/workflows/content/${encodeURIComponent(workflowFilename)}`;
+      // Workflows can sit in subfolders, so the separators must survive as real
+      // path separators. Encoding the whole string would turn them into %2F and
+      // leave the route match up to the server's decoding behaviour.
+      const encodedPath = workflowFilename
+        .split('/')
+        .map(segment => encodeURIComponent(segment))
+        .join('/');
+      const endpoint = `${this.serverUrl}/comfymobile/api/workflows/content/${encodedPath}`;
 
 
       const response = await axios.get(endpoint, {

--- a/src/locale/en/common.json
+++ b/src/locale/en/common.json
@@ -222,6 +222,8 @@
             "failedTitle": "Import Failed",
             "failedDesc": "Could not import workflow from server.",
             "serverWorkflows": "Server Workflows ({{count}})",
+            "rootFolder": "Workflows",
+            "parentFolder": "Parent folder",
             "foundCount": "Found {{count}} workflows",
             "noWorkflowsOnServer": "No workflows found on server",
             "noResultsQuery": "No workflows match your search",

--- a/src/locale/ja/common.json
+++ b/src/locale/ja/common.json
@@ -220,6 +220,8 @@
             "failedTitle": "インポート失敗",
             "failedDesc": "サーバーからワークフローをインポートできませんでした。",
             "serverWorkflows": "サーバーワークフロー ({{count}})",
+            "rootFolder": "ワークフロー",
+            "parentFolder": "親フォルダー",
             "foundCount": "{{count}} 件のワークフローが見つかりました",
             "noWorkflowsOnServer": "サーバー上にワークフローが見つかりません",
             "noResultsQuery": "検索条件に一致するワークフローはありません",

--- a/src/locale/ko/common.json
+++ b/src/locale/ko/common.json
@@ -222,6 +222,8 @@
             "failedTitle": "가져오기 실패",
             "failedDesc": "서버에서 워크플로우를 가져올 수 없습니다.",
             "serverWorkflows": "서버 워크플로우 ({{count}})",
+            "rootFolder": "워크플로",
+            "parentFolder": "상위 폴더",
             "foundCount": "{{count}}개의 워크플로우 발견",
             "noWorkflowsOnServer": "서버에서 워크플로우를 찾을 수 없습니다",
             "noResultsQuery": "검색과 일치하는 워크플로우가 없습니다",

--- a/src/locale/zh/common.json
+++ b/src/locale/zh/common.json
@@ -221,6 +221,8 @@
             "failedTitle": "导入失败",
             "failedDesc": "无法从服务器导入工作流。",
             "serverWorkflows": "服务器工作流 ({{count}})",
+            "rootFolder": "工作流",
+            "parentFolder": "上级文件夹",
             "foundCount": "找到 {{count}} 个工作流",
             "noWorkflowsOnServer": "服务器上未找到工作流",
             "noResultsQuery": "没有符合搜索条件的工作流",


### PR DESCRIPTION
Closes #59.

## Problem

`list_workflows` used `os.listdir`, so **Import from ComfyUI** only ever showed workflows sitting directly in the workflows root. As the reporter put it, they have enough workflows to organise them into subfolders — and that organisation made most of their work unreachable from the mobile UI.

## Server

**Listing walks the tree.** Each workflow is reported by its path relative to the workflows root, plus a split-out `name` and `folder` so clients can group without re-parsing:

```json
{ "filename": "portraits/sdxl/hires.json", "name": "hires.json", "folder": "portraits/sdxl", ... }
```

Symlinked directories are not followed (`os.walk` default) and dot-directories are skipped. Not following symlinks is deliberate: it keeps the listing consistent with what the content endpoint will actually read back, so nothing appears in the list that then fails to open.

**Path containment replaces the separator ban.** Reading a workflow now has to accept `/`, so `if '..' in filename or '/' in filename` could not survive. `resolve_workflow_path()` instead joins the path, resolves it fully — symlinks included — and requires the result to stay under the workflows root. Absolute paths, paths on another drive, and the root itself are rejected.

This is the risky part of the change, so it has direct tests (`comfy-mobile-ui-api-extension/tests/test_workflow_paths.py`, 15 checks): parent traversal, traversal through a real subfolder, absolute paths, a symlink inside the root pointing out of it, backslash separators, and `....//` — which defeats sanitisers that strip `../` textually but is harmless here because resolution treats `....` as an ordinary folder name.

**Route pattern.** `{filename}` does not match slashes, so a nested request would not have reached the handler at all. Both registration sites now use `{filename:.*}`. On the client, path segments are encoded individually so separators stay separators instead of becoming `%2F` and leaving the match up to server-side decoding.

**Write paths are untouched.** `upload_workflow` and `save_workflow` still refuse separators and target the root. Where an upload *should* land in a folder tree is a separate product decision that this issue does not settle, and widening a write path is not something to do as a side effect.

## Client

The import screen gains breadcrumb drill-down with folder tiles showing how many workflows sit beneath each, plus a parent-folder row. This matches the navigation `WorkflowList` already uses — the app has no tree component, and its existing folder UI is breadcrumb-based, so a tree here would have been the odd one out.

Search deliberately spans **every** folder rather than the open one, and shows the folder path on each hit; scoping search to the current folder would hide exactly the matches people open search to find.

Listings from an older extension still render: when the server sends no `folder` field, it is derived from the filename.

## Testing

`python comfy-mobile-ui-api-extension/tests/test_workflow_paths.py` — 15/15 pass. `tsc -b` passes.

Verified against a live ComfyUI (33 root workflows + 2 planted in `_subfolder_test/` and `_subfolder_test/nested/`):

| Request | Result |
|---|---|
| `workflows/list` | 35 entries, nested ones carrying correct `folder` |
| `content/_subfolder_test/nested/deeply-nested.json` | 200 |
| `content/_subfolder_test/in-subfolder.json` | 200 |
| `content/label.json` (root, unchanged behaviour) | 200 |
| `content/%2e%2e/%2e%2e/%2e%2e/%2e%2e/server.py` | **400** |
| `content/_subfolder_test/%2e%2e/%2e%2e/%2e%2e/server.py` | **400** |

The traversal cases use percent-encoded dots on purpose: a plain `../` is collapsed by the HTTP client before the request is sent, so it proves nothing about the handler. Encoded, it reaches the handler and is rejected there.

## Noted, not changed

`workflow_handler.py` defines `upload_workflow` twice (the second shadows the first). Pre-existing and unrelated, so left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 워크플로를 하위 폴더별로 탐색하고 폴더 이동, 경로 표시, 상위 폴더 이동을 지원합니다.
  - 폴더 내 항목 수와 현재 위치를 확인할 수 있으며, 검색 시 전체 폴더의 워크플로를 찾습니다.
  - 중첩 폴더에 저장된 워크플로를 가져오고 다운로드할 수 있습니다.

- **버그 수정**
  - 경로가 포함된 워크플로 파일을 안정적으로 불러오도록 개선했습니다.
  - 허용되지 않은 경로 접근을 차단해 파일 보안을 강화했습니다.

- **번역**
  - 폴더 탐색 관련 영어, 일본어, 한국어, 중국어 문구를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->